### PR TITLE
Fix login env vars and seed test user

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,23 @@ NEXT_PUBLIC_API_URL=http://localhost:3001
 NEXT_PUBLIC_WEB_URL=http://localhost:3000
 ```
 
+### Utilisateur de test
+
+Un compte de test est mis à disposition pour les démonstrations :
+
+- **Email** : `utilisateur@exemple.fr`
+- **Mot de passe** : `admin`
+
+Si ce compte n'existe pas dans votre base Supabase, vous pouvez le créer
+automatiquement avec la commande suivante&nbsp;:
+
+```bash
+npx ts-node scripts/ensureTestUser.ts
+```
+
+Cette commande nécessite la variable `SUPABASE_SERVICE_ROLE_KEY` dans votre
+`.env.local` afin d'utiliser l'API d'administration Supabase.
+
 ## Installation et démarrage
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "node --test --loader ts-node/esm"
+    "test": "node --test --loader ts-node/esm",
+    "seed:test-user": "ts-node scripts/ensureTestUser.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/ensureTestUser.ts
+++ b/scripts/ensureTestUser.ts
@@ -1,0 +1,54 @@
+import { createClient } from '@supabase/supabase-js';
+import 'dotenv/config';
+
+const supabaseUrl =
+  process.env.VITE_SUPABASE_URL ||
+  process.env.NEXT_PUBLIC_SUPABASE_URL ||
+  process.env.SUPABASE_URL ||
+  '';
+
+const serviceKey =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  process.env.VITE_SUPABASE_SERVICE_ROLE_KEY ||
+  '';
+
+if (!supabaseUrl || !serviceKey) {
+  console.error('Missing Supabase configuration.');
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, serviceKey, {
+  auth: { autoRefreshToken: false, persistSession: false }
+});
+
+async function ensureTestUser() {
+  const email = 'utilisateur@exemple.fr';
+  const password = 'admin';
+
+  const { data: existing, error: fetchError } = await supabase.auth.admin.getUserByEmail(email);
+  if (fetchError) {
+    console.error('Error fetching user:', fetchError.message);
+    return;
+  }
+
+  if (existing?.user) {
+    console.log('Test user already exists.');
+    return;
+  }
+
+  const { data, error } = await supabase.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+    user_metadata: { name: 'Utilisateur test', role: 'b2c' }
+  });
+
+  if (error) {
+    console.error('Error creating test user:', error.message);
+    return;
+  }
+
+  console.log('Test user created:', data.user?.id);
+}
+
+ensureTestUser().then(() => process.exit(0));

--- a/src/.env.example
+++ b/src/.env.example
@@ -9,8 +9,11 @@ NEXT_PUBLIC_OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxx
 NEXT_PUBLIC_HUME_API_KEY=hume_xxxxxxxxxxxxxxxxxxxxx
 
 # Configuration Supabase (si applicable)
-NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+# Utilisez de préférence les variables Vite suivantes
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key
+# Clé service (optionnelle, nécessaire pour le script de seed)
+SUPABASE_SERVICE_ROLE_KEY=
 
 # Autres configuration
 NEXT_PUBLIC_UPLOAD_MAX_SIZE=10485760 # 10MB

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,18 @@
 import { createClient } from '@supabase/supabase-js';
 
 // Configuration de Supabase
-const supabaseUrl = 'https://yaincoxihiqdksxgrsrk.supabase.co';
-const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlhaW5jb3hpaGlxZGtzeGdyc3JrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDI4MTE4MjcsImV4cCI6MjA1ODM4NzgyN30.HBfwymB2F9VBvb3uyeTtHBMZFZYXzL0wQmS5fqd65yU';
+// Les variables d'environnement sont privilégiées pour permettre la configuration
+// en local, staging ou production. Des valeurs par défaut sont utilisées pour
+// assurer la compatibilité avec les environnements de démonstration.
+const supabaseUrl =
+  import.meta.env.VITE_SUPABASE_URL ||
+  import.meta.env.NEXT_PUBLIC_SUPABASE_URL ||
+  'https://yaincoxihiqdksxgrsrk.supabase.co';
+
+const supabaseKey =
+  import.meta.env.VITE_SUPABASE_ANON_KEY ||
+  import.meta.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlhaW5jb3hpaGlxZGtzeGdyc3JrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDI4MTE4MjcsImV4cCI6MjA1ODM4NzgyN30.HBfwymB2F9VBvb3uyeTtHBMZFZYXzL0wQmS5fqd65yU';
 
 // Création du client Supabase avec les options d'authentification
 export const supabase = createClient(supabaseUrl, supabaseKey, {


### PR DESCRIPTION
## Summary
- load Supabase credentials from env variables with fallbacks
- document demo account and add seed command
- provide `.env.example` entries for Supabase including service key
- npm script and script to create demo account

## Testing
- `npm test` *(fails: cannot find package 'ts-node')*