### PR TITLE
Resolve env references

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ function App() {
               <MusicProvider>
                 <AppRouter />
                 <Toaster />
-                {process.env.NODE_ENV === 'development' && <RouteDebugger />}
+                {import.meta.env.DEV && <RouteDebugger />}
               </MusicProvider>
             </UserModeProvider>
           </UserPreferencesProvider>

--- a/src/components/DashboardAccessError.tsx
+++ b/src/components/DashboardAccessError.tsx
@@ -31,7 +31,7 @@ const DashboardAccessError: React.FC<DashboardAccessErrorProps> = ({
               <li>Authentifié: {isAuthenticated ? 'Oui' : 'Non'}</li>
               <li>Rôle: {user?.role || 'Non défini'}</li>
               <li>Chemin actuel: {window.location.pathname}</li>
-              <li>Mode: {process.env.NODE_ENV || 'production'}</li>
+              <li>Mode: {import.meta.env.MODE || 'production'}</li>
             </ul>
           </div>
         </CardContent>

--- a/src/components/ui/RouteDebugger.tsx
+++ b/src/components/ui/RouteDebugger.tsx
@@ -7,7 +7,7 @@ export const RouteDebugger: React.FC = () => {
   const location = useLocation();
   const { user, isAuthenticated, isLoading } = useAuth();
 
-  if (process.env.NODE_ENV !== 'development') {
+  if (!import.meta.env.DEV) {
     return null;
   }
 

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -9,36 +9,36 @@ import * as Sentry from '@sentry/react';
 
 export const env = {
   // URL API
-  NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL || 'https://api.example.com',
-  NEXT_PUBLIC_WEB_URL: process.env.NEXT_PUBLIC_WEB_URL || 'http://localhost:3000',
-  NEXT_PUBLIC_APP_ENV: process.env.NEXT_PUBLIC_APP_ENV || 'development',
+  NEXT_PUBLIC_API_URL: import.meta.env.NEXT_PUBLIC_API_URL || import.meta.env.VITE_PUBLIC_API_URL || 'https://api.example.com',
+  NEXT_PUBLIC_WEB_URL: import.meta.env.NEXT_PUBLIC_WEB_URL || import.meta.env.VITE_PUBLIC_WEB_URL || 'http://localhost:3000',
+  NEXT_PUBLIC_APP_ENV: import.meta.env.NEXT_PUBLIC_APP_ENV || import.meta.env.MODE || 'development',
 
   // Clés d'API
-  NEXT_PUBLIC_OPENAI_API_KEY: process.env.NEXT_PUBLIC_OPENAI_API_KEY || '',
-  NEXT_PUBLIC_HUME_API_KEY: process.env.NEXT_PUBLIC_HUME_API_KEY || '',
+  NEXT_PUBLIC_OPENAI_API_KEY: import.meta.env.NEXT_PUBLIC_OPENAI_API_KEY || import.meta.env.VITE_OPENAI_API_KEY || '',
+  NEXT_PUBLIC_HUME_API_KEY: import.meta.env.NEXT_PUBLIC_HUME_API_KEY || '',
   // DSN Sentry pour la surveillance des erreurs
-  NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN || '',
+  NEXT_PUBLIC_SENTRY_DSN: import.meta.env.NEXT_PUBLIC_SENTRY_DSN || '',
 
   // Configuration Supabase
   VITE_SUPABASE_URL:
-    process.env.VITE_SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || '',
+    import.meta.env.VITE_SUPABASE_URL || import.meta.env.NEXT_PUBLIC_SUPABASE_URL || '',
   VITE_SUPABASE_ANON_KEY:
-    process.env.VITE_SUPABASE_ANON_KEY ||
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '',
-  SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY || '',
+    import.meta.env.VITE_SUPABASE_ANON_KEY ||
+    import.meta.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '',
+  SUPABASE_SERVICE_ROLE_KEY: import.meta.env.SUPABASE_SERVICE_ROLE_KEY || '',
 
   // Configuration uploads
-  NEXT_PUBLIC_UPLOAD_MAX_SIZE: Number(process.env.NEXT_PUBLIC_UPLOAD_MAX_SIZE || '10485760'),
+  NEXT_PUBLIC_UPLOAD_MAX_SIZE: Number(import.meta.env.NEXT_PUBLIC_UPLOAD_MAX_SIZE || '10485760'),
   NEXT_PUBLIC_ALLOWED_IMAGE_TYPES:
-    process.env.NEXT_PUBLIC_ALLOWED_IMAGE_TYPES || 'image/jpeg,image/png,image/webp',
+    import.meta.env.NEXT_PUBLIC_ALLOWED_IMAGE_TYPES || 'image/jpeg,image/png,image/webp',
   NEXT_PUBLIC_ALLOWED_AUDIO_TYPES:
-    process.env.NEXT_PUBLIC_ALLOWED_AUDIO_TYPES || 'audio/mpeg,audio/wav,audio/ogg',
+    import.meta.env.NEXT_PUBLIC_ALLOWED_AUDIO_TYPES || 'audio/mpeg,audio/wav,audio/ogg',
 
   // Configuration du serveur
-  NODE_ENV: process.env.NODE_ENV || 'development',
+  NODE_ENV: import.meta.env.MODE || 'development',
   
   // Configuration d'authentification
-  SKIP_AUTH_CHECK: process.env.SKIP_AUTH_CHECK === 'true' || process.env.NODE_ENV === 'development'
+  SKIP_AUTH_CHECK: import.meta.env.SKIP_AUTH_CHECK === 'true' || import.meta.env.MODE === 'development'
 };
 
 // Validation simple en mode développement

--- a/src/lib/ai/openai-client.ts
+++ b/src/lib/ai/openai-client.ts
@@ -26,7 +26,7 @@ export async function callOpenAI<T>(
   cacheOptions?: { enabled: boolean, ttl: number }
 ): Promise<T> {
   // Utiliser la clé API de l'environnement ou du paramètre
-  const key = apiKey || process.env.OPENAI_API_KEY;
+  const key = apiKey || import.meta.env.VITE_OPENAI_API_KEY || import.meta.env.NEXT_PUBLIC_OPENAI_API_KEY;
   
   if (!key) {
     console.error("La clé API OpenAI est manquante");

--- a/src/services/dalle.ts
+++ b/src/services/dalle.ts
@@ -14,7 +14,7 @@ const generateImage = async (prompt: string, options: DALLEOptions = {}): Promis
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`, // This should be set in your environment
+        'Authorization': `Bearer ${import.meta.env.VITE_OPENAI_API_KEY || import.meta.env.NEXT_PUBLIC_OPENAI_API_KEY}`,
       },
       body: JSON.stringify({
         prompt,


### PR DESCRIPTION
## Summary
- use `import.meta.env` in OpenAI client
- use `import.meta.env` in frontend dashboard helpers
- replace all `process.env` in env configuration

## Testing
- `npm run type-check`
- `npm run build` *(fails: vite not found)*