### PR TITLE
Restore B2C auth routes

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -4,6 +4,8 @@ import LandingPage from './pages/LandingPage';
 import NotFoundPage from './pages/NotFoundPage';
 import LoginPage from './pages/common/Login';
 import RegisterPage from './pages/common/Register';
+import B2CLogin from './pages/b2c/Login';
+import B2CRegister from './pages/b2c/Register';
 import B2BSelectionPage from './pages/B2BSelectionPage';
 import B2CLayout from './layouts/B2CLayout';
 import B2BUserLayout from './layouts/B2BUserLayout';
@@ -54,11 +56,11 @@ export const routes: RouteObject[] = [
   // B2C Auth Routes
   {
     path: 'b2c/login',
-    element: <LoginPage />
+    element: <B2CLogin />
   },
   {
     path: 'b2c/register',
-    element: <RegisterPage />
+    element: <B2CRegister />
   },
   // B2B Selection Route
   {

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -38,6 +38,10 @@ import B2BAdminEventsPage from '@/pages/b2b/admin/Events';
 import B2BAdminSettingsPage from '@/pages/b2b/admin/Settings';
 import ImmersiveHome from '@/pages/ImmersiveHome';
 import Home from '@/pages/Home';
+import LoginPage from '@/pages/common/Login';
+import RegisterPage from '@/pages/common/Register';
+import B2CLogin from '@/pages/b2c/Login';
+import B2CRegister from '@/pages/b2c/Register';
 
 
 // Define the application routes without creating a router instance
@@ -53,11 +57,11 @@ export const routes: RouteObject[] = [
   // B2C Auth Routes
   {
     path: 'b2c/login',
-    element: <LoginPage />
+    element: <B2CLogin />
   },
   {
     path: 'b2c/register',
-    element: <RegisterPage />
+    element: <B2CRegister />
   },
   // B2B Selection Route
   {


### PR DESCRIPTION
## Summary
- add dedicated imports for the B2C login and register pages
- route `/b2c/login` and `/b2c/register` to their premium B2C pages

## Testing
- `npm run type-check`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find package 'ts-node')*