### PR TITLE
Implement B2B login routes

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -5,6 +5,9 @@ import NotFoundPage from './pages/NotFoundPage';
 import LoginPage from './pages/common/Login';
 import RegisterPage from './pages/common/Register';
 import B2BSelectionPage from './pages/B2BSelectionPage';
+import B2BUserLogin from './pages/b2b/user/Login';
+import B2BAdminLogin from './pages/b2b/admin/Login';
+import B2BUserRegister from './pages/b2b/user/Register';
 import B2CLayout from './layouts/B2CLayout';
 import B2BUserLayout from './layouts/B2BUserLayout';
 import B2BAdminLayout from './layouts/B2BAdminLayout';
@@ -73,11 +76,15 @@ export const routes: RouteObject[] = [
   // B2B Auth Routes
   {
     path: 'b2b/user/login',
-    element: <LoginPage />
+    element: <B2BUserLogin />
+  },
+  {
+    path: 'b2b/user/register',
+    element: <B2BUserRegister />
   },
   {
     path: 'b2b/admin/login',
-    element: <LoginPage />
+    element: <B2BAdminLogin />
   },
   // B2C Protected Routes
   {

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -3,10 +3,15 @@ import { RouteObject, Navigate } from 'react-router-dom';
 import NotFoundPage from '@/pages/NotFoundPage';
 import LandingPage from '@/pages/LandingPage';
 import B2BSelectionPage from '@/pages/B2BSelectionPage';
+import B2BUserLogin from '@/pages/b2b/user/Login';
+import B2BAdminLogin from '@/pages/b2b/admin/Login';
+import B2BUserRegister from '@/pages/b2b/user/Register';
 import B2CLayout from '@/layouts/B2CLayout';
 import B2BUserLayout from '@/layouts/B2BUserLayout';
 import B2BAdminLayout from '@/layouts/B2BAdminLayout';
 import ProtectedRoute from '@/components/ProtectedRoute';
+import LoginPage from '@/pages/common/Login';
+import RegisterPage from '@/pages/common/Register';
 import B2CDashboardPage from '@/pages/b2c/DashboardPage';
 import B2BUserDashboardPage from '@/pages/b2b/user/Dashboard';
 import B2BAdminDashboardPage from '@/pages/b2b/admin/Dashboard';
@@ -72,11 +77,15 @@ export const routes: RouteObject[] = [
   // B2B Auth Routes
   {
     path: 'b2b/user/login',
-    element: <LoginPage />
+    element: <B2BUserLogin />
+  },
+  {
+    path: 'b2b/user/register',
+    element: <B2BUserRegister />
   },
   {
     path: 'b2b/admin/login',
-    element: <LoginPage />
+    element: <B2BAdminLogin />
   },
   // B2C Protected Routes
   {

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -36,6 +36,7 @@ export interface RouteConfig {
   b2bUser: {
     home: string;
     login: string;
+    register?: string;
     dashboard: string;
     journal?: string;
     scan?: string;
@@ -91,6 +92,7 @@ export const ROUTES: RouteConfig = {
   b2bUser: {
     home: '/b2b/user',
     login: '/b2b/user/login',
+    register: '/b2b/user/register',
     dashboard: '/b2b/user/dashboard',
     journal: '/b2b/user/journal',
     scan: '/b2b/user/scan',


### PR DESCRIPTION
## Summary
- wire dedicated login components for B2B user and admin in the router
- expose `/b2b/user/register` route
- extend navigation constants with register path

## Testing
- `npm test` *(fails: Cannot find package 'ts-node')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check`