### PR TITLE
Implement unified settings route

### DIFF
--- a/src/pages/UnifiedSettingsPage.tsx
+++ b/src/pages/UnifiedSettingsPage.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { normalizeUserMode } from '@/utils/userModeHelpers';
+import B2CSettingsPage from '@/pages/b2c/Settings';
+import B2BUserSettingsPage from '@/pages/b2b/user/Settings';
+import B2BAdminSettingsPage from '@/pages/b2b/admin/Settings';
+
+const UnifiedSettingsPage: React.FC = () => {
+  const { user } = useAuth();
+
+  const role = normalizeUserMode(user?.role || 'b2c');
+
+  if (role === 'b2b_admin') {
+    return <B2BAdminSettingsPage />;
+  }
+
+  if (role === 'b2b_user') {
+    return <B2BUserSettingsPage />;
+  }
+
+  return <B2CSettingsPage />;
+};
+
+export default UnifiedSettingsPage;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -42,6 +42,7 @@ import B2BAdminEventsPage from './pages/b2b/admin/Events';
 import B2BAdminSettingsPage from './pages/b2b/admin/Settings';
 import ImmersiveHome from './pages/ImmersiveHome';
 import Home from './pages/Home';
+import UnifiedSettingsPage from './pages/UnifiedSettingsPage';
 
 // Define the application routes without creating a router instance
 export const routes: RouteObject[] = [
@@ -52,6 +53,14 @@ export const routes: RouteObject[] = [
   {
     path: '/home',
     element: <Home />
+  },
+  {
+    path: 'settings',
+    element: (
+      <ProtectedRoute>
+        <UnifiedSettingsPage />
+      </ProtectedRoute>
+    )
   },
   // B2C Auth Routes
   {

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -42,6 +42,7 @@ import LoginPage from '@/pages/common/Login';
 import RegisterPage from '@/pages/common/Register';
 import B2CLogin from '@/pages/b2c/Login';
 import B2CRegister from '@/pages/b2c/Register';
+import UnifiedSettingsPage from '@/pages/UnifiedSettingsPage';
 
 
 // Define the application routes without creating a router instance
@@ -53,6 +54,14 @@ export const routes: RouteObject[] = [
   {
     path: '/home',
     element: <Home />
+  },
+  {
+    path: 'settings',
+    element: (
+      <ProtectedRoute>
+        <UnifiedSettingsPage />
+      </ProtectedRoute>
+    )
   },
   // B2C Auth Routes
   {


### PR DESCRIPTION
## Summary
- add a new `UnifiedSettingsPage` that renders the correct settings page based on user role
- expose the new `/settings` path protected by `ProtectedRoute`

## Testing
- `npm test` *(fails: Cannot find package 'ts-node')*