### PR TITLE
Add SocialCocon routes

### DIFF
--- a/src/pages/b2b/admin/SocialCocon.tsx
+++ b/src/pages/b2b/admin/SocialCocon.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import SocialCocoonTab from '@/components/dashboard/admin/tabs/SocialCocoonTab';
+
+const B2BAdminSocialCocon: React.FC = () => {
+  const mockData = {
+    totalPosts: 128,
+    moderationRate: 5,
+    topHashtags: [
+      { tag: '#bienetre', count: 42 },
+      { tag: '#entraide', count: 36 },
+      { tag: '#motivation', count: 31 }
+    ]
+  };
+
+  return (
+    <div className="container mx-auto py-6">
+      <h1 className="text-3xl font-bold mb-6">Modération SocialCocon</h1>
+      <SocialCocoonTab socialCocoonData={mockData} />
+    </div>
+  );
+};
+
+export default B2BAdminSocialCocon;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -41,6 +41,7 @@ import B2BAdminTeamsPage from '@/pages/b2b/admin/Teams';
 import B2BAdminReportsPage from '@/pages/b2b/admin/Reports';
 import B2BAdminEventsPage from '@/pages/b2b/admin/Events';
 import B2BAdminSettingsPage from '@/pages/b2b/admin/Settings';
+import B2BAdminSocialCoconPage from '@/pages/b2b/admin/SocialCocon';
 import ImmersiveHome from '@/pages/ImmersiveHome';
 import Home from '@/pages/Home';
 import LoginPage from '@/pages/common/Login';
@@ -145,6 +146,10 @@ export const routes: RouteObject[] = [
         element: <B2CCoconPage />
       },
       {
+        path: 'social-cocon',
+        element: <B2CCoconPage />
+      },
+      {
         path: 'gamification',
         element: <B2CGamificationPage />
       }
@@ -200,6 +205,10 @@ export const routes: RouteObject[] = [
         element: <B2BUserCoconPage />
       },
       {
+        path: 'social-cocon',
+        element: <B2BUserCoconPage />
+      },
+      {
         path: 'gamification',
         element: <B2BUserGamificationPage />
       }
@@ -245,6 +254,10 @@ export const routes: RouteObject[] = [
       {
         path: 'events',
         element: <B2BAdminEventsPage />
+      },
+      {
+        path: 'social-cocon',
+        element: <B2BAdminSocialCoconPage />
       },
       {
         path: 'settings',


### PR DESCRIPTION
## Summary
- add SocialCocon admin page
- map new `social-cocon` routes for B2C, B2B user and B2B admin

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find package 'ts-node')*
- `npm run build` *(fails: vite not found)*