### PR TITLE
Add innovation dashboard skeleton

### DIFF
--- a/src/pages/b2b/admin/Innovation.tsx
+++ b/src/pages/b2b/admin/Innovation.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+import { innovationService } from '@/services/innovationService';
+import { Experiment } from '@/types/innovation';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+const B2BAdminInnovationPage: React.FC = () => {
+  const [experiments, setExperiments] = useState<Experiment[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    innovationService
+      .fetchExperiments()
+      .then(data => setExperiments(data))
+      .catch(err => {
+        console.error('Innovation fetch error', err);
+        setError('Erreur lors du chargement');
+      })
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  if (isLoading) {
+    return <div className="p-8 text-center">Chargement...</div>;
+  }
+
+  return (
+    <div className="container mx-auto py-6 space-y-6">
+      <h1 className="text-3xl font-bold">Innovation Lab</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      {experiments.length === 0 ? (
+        <p className="text-muted-foreground">Aucune expérimentation en cours.</p>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {experiments.map(exp => (
+            <Card key={exp.id} className="animate-fade-in">
+              <CardHeader>
+                <CardTitle>{exp.name}</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <p className="text-muted-foreground">{exp.description}</p>
+                <span className="text-sm">Statut : {exp.status}</span>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default B2BAdminInnovationPage;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -43,6 +43,7 @@ import B2BAdminTeamsPage from './pages/b2b/admin/Teams';
 import B2BAdminReportsPage from './pages/b2b/admin/Reports';
 import B2BAdminEventsPage from './pages/b2b/admin/Events';
 import B2BAdminSettingsPage from './pages/b2b/admin/Settings';
+import B2BAdminInnovationPage from './pages/b2b/admin/Innovation';
 import TimelinePage from './pages/TimelinePage';
 import WorldPage from './pages/WorldPage';
 import SanctuaryPage from './pages/SanctuaryPage';
@@ -278,6 +279,10 @@ export const routes: RouteObject[] = [
       {
         path: 'events',
         element: <B2BAdminEventsPage />
+      },
+      {
+        path: 'innovation',
+        element: <B2BAdminInnovationPage />
       },
       {
         path: 'settings',

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -12,6 +12,7 @@ import musicGenService from './musicgen';
 import whisperService from './whisper';
 import humeAIService from './humeai';
 import dalleService from './dalle';
+import innovationService from './innovationService';
 import { env } from '@/env.mjs';
 
 // Type pour le statut des API
@@ -31,6 +32,7 @@ class APIServices {
   public whisper = whisperService;
   public humeAI = humeAIService;
   public dalle = dalleService;
+  public innovation = innovationService;
   
   constructor() {
     // Initialisation des statuts d'API
@@ -149,3 +151,4 @@ export const musicGen = musicGenService;
 export const whisper = whisperService;
 export const humeAI = humeAIService;
 export const dalle = dalleService;
+export const innovation = innovationService;

--- a/src/services/innovationService.ts
+++ b/src/services/innovationService.ts
@@ -1,0 +1,44 @@
+import { supabase } from '@/integrations/supabase/client';
+import { Experiment } from '@/types/innovation';
+
+/**
+ * Service for managing innovation experiments
+ */
+export const innovationService = {
+  async fetchExperiments(): Promise<Experiment[]> {
+    const { data, error } = await supabase
+      .from('experiments')
+      .select('*')
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      console.error('Error fetching experiments:', error);
+      throw error;
+    }
+
+    return (data || []) as Experiment[];
+  },
+
+  async createExperiment(
+    exp: Omit<Experiment, 'id' | 'createdAt'>
+  ): Promise<Experiment> {
+    const { data, error } = await supabase
+      .from('experiments')
+      .insert({
+        name: exp.name,
+        description: exp.description,
+        status: exp.status
+      })
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Error creating experiment:', error);
+      throw error;
+    }
+
+    return data as Experiment;
+  }
+};
+
+export default innovationService;

--- a/src/types/innovation.ts
+++ b/src/types/innovation.ts
@@ -1,0 +1,10 @@
+// Types for innovation experiments
+
+export interface Experiment {
+  id: string;
+  name: string;
+  description?: string;
+  status: 'draft' | 'active' | 'completed';
+  createdAt?: string;
+  [key: string]: any;
+}


### PR DESCRIPTION
## Summary
- add Experiment type
- add innovation service to fetch experiments from Supabase
- export innovation service and register it in API services
- add B2B Admin Innovation page
- add `/b2b/admin/innovation` route

## Testing
- `npm test` *(fails: Cannot find package 'ts-node')*