### PR TITLE
Add data ethics portal

### DIFF
--- a/src/components/navigation/B2BAdminNavBar.tsx
+++ b/src/components/navigation/B2BAdminNavBar.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { LayoutDashboard, Users, FileBarChart, Calendar, Settings, BookOpen, Scan, Music } from 'lucide-react';
+import { LayoutDashboard, Users, FileBarChart, Calendar, Settings, BookOpen, Scan, Music, ShieldCheck } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/contexts/AuthContext';
 import ConfirmationModal from '@/components/ui/confirmation-modal';
@@ -32,6 +32,7 @@ const B2BAdminNavBar: React.FC = () => {
       <NavItem to={ROUTES.b2bAdmin.reports} isActive={isActive(ROUTES.b2bAdmin.reports)} icon={<FileBarChart className="h-5 w-5" />} label="Rapports" />
       <NavItem to={ROUTES.b2bAdmin.events} isActive={isActive(ROUTES.b2bAdmin.events)} icon={<Calendar className="h-5 w-5" />} label="Événements" />
       <NavItem to={ROUTES.b2bAdmin.settings} isActive={isActive(ROUTES.b2bAdmin.settings)} icon={<Settings className="h-5 w-5" />} label="Paramètres" />
+      <NavItem to={ROUTES.common.ethics} isActive={isActive(ROUTES.common.ethics)} icon={<ShieldCheck className="h-5 w-5" />} label="Éthique" />
       
       <button 
         onClick={() => setShowConfirm(true)}

--- a/src/components/navigation/B2BUserNavBar.tsx
+++ b/src/components/navigation/B2BUserNavBar.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { Home, BookOpen, Music, Scan, MessageSquare, Glasses, Trophy, Settings, HeartHandshake } from 'lucide-react';
+import { Home, BookOpen, Music, Scan, MessageSquare, Glasses, Trophy, Settings, HeartHandshake, ShieldCheck } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/contexts/AuthContext';
 import ConfirmationModal from '@/components/ui/confirmation-modal';
@@ -33,6 +33,7 @@ const B2BUserNavBar: React.FC = () => {
       <NavItem to={ROUTES.b2bUser.gamification} isActive={isActive(ROUTES.b2bUser.gamification)} icon={<Trophy className="h-5 w-5" />} label="Défis" />
       <NavItem to={ROUTES.b2bUser.cocon} isActive={isActive(ROUTES.b2bUser.cocon)} icon={<HeartHandshake className="h-5 w-5" />} label="Cocon" />
       <NavItem to={ROUTES.b2bUser.preferences} isActive={isActive(ROUTES.b2bUser.preferences)} icon={<Settings className="h-5 w-5" />} label="Paramètres" />
+      <NavItem to={ROUTES.common.ethics} isActive={isActive(ROUTES.common.ethics)} icon={<ShieldCheck className="h-5 w-5" />} label="Éthique" />
       
       <button 
         onClick={() => setShowConfirm(true)}

--- a/src/layouts/B2CLayout.tsx
+++ b/src/layouts/B2CLayout.tsx
@@ -16,8 +16,9 @@ const B2CLayout: React.FC = () => {
       </main>
       
       <footer className="border-t py-4">
-        <div className="container mx-auto text-center text-muted-foreground">
-          &copy; 2025 B2C Application
+        <div className="container mx-auto text-center text-muted-foreground space-y-1">
+          <div>&copy; 2025 B2C Application</div>
+          <a href="/ethique" className="underline">Portail RGPD &amp; éthique</a>
         </div>
       </footer>
     </div>

--- a/src/pages/DataEthicsPage.tsx
+++ b/src/pages/DataEthicsPage.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import DashboardLayout from '@/components/DashboardLayout';
+import PageHeader from '@/components/layout/PageHeader';
+import PrivacySettings from '@/components/settings/PrivacySettings';
+import PersonalActivityLogs from '@/components/account/PersonalActivityLogs';
+import { ShieldCheck } from 'lucide-react';
+
+const DataEthicsPage: React.FC = () => {
+  return (
+    <DashboardLayout>
+      <div className="space-y-6 p-4">
+        <PageHeader
+          title="Données & éthique"
+          description="Contrôlez vos informations et découvrez nos engagements."
+          icon={<ShieldCheck className="h-5 w-5" />}
+        />
+        <PrivacySettings />
+        <PersonalActivityLogs />
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default DataEthicsPage;

--- a/src/pages/b2b/user/Settings.tsx
+++ b/src/pages/b2b/user/Settings.tsx
@@ -9,6 +9,8 @@ import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useToast } from '@/hooks/use-toast';
+import PrivacySettings from '@/components/settings/PrivacySettings';
+import PersonalActivityLogs from '@/components/account/PersonalActivityLogs';
 
 const B2BUserSettings = () => {
   const { theme, setTheme } = useTheme();
@@ -31,10 +33,11 @@ const B2BUserSettings = () => {
       </div>
       
       <Tabs defaultValue="appearance">
-        <TabsList className="grid grid-cols-3 mb-8">
+        <TabsList className="grid grid-cols-4 mb-8">
           <TabsTrigger value="appearance">Apparence</TabsTrigger>
           <TabsTrigger value="notifications">Notifications</TabsTrigger>
           <TabsTrigger value="privacy">Confidentialité</TabsTrigger>
+          <TabsTrigger value="ethics">Données &amp; éthique</TabsTrigger>
         </TabsList>
         
         <TabsContent value="appearance" className="space-y-6">
@@ -198,6 +201,11 @@ const B2BUserSettings = () => {
               </div>
             </CardContent>
           </Card>
+        </TabsContent>
+
+        <TabsContent value="ethics" className="space-y-6">
+          <PrivacySettings />
+          <PersonalActivityLogs />
         </TabsContent>
       </Tabs>
     </div>

--- a/src/pages/b2c/Settings.tsx
+++ b/src/pages/b2c/Settings.tsx
@@ -10,6 +10,8 @@ import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useToast } from '@/hooks/use-toast';
+import PrivacySettings from '@/components/settings/PrivacySettings';
+import PersonalActivityLogs from '@/components/account/PersonalActivityLogs';
 
 const Settings = () => {
   const { theme, setTheme } = useTheme();
@@ -61,11 +63,12 @@ const Settings = () => {
       </div>
       
       <Tabs defaultValue="appearance" value={activeTab} onValueChange={setActiveTab}>
-        <TabsList className="grid grid-cols-4 mb-8">
+        <TabsList className="grid grid-cols-5 mb-8">
           <TabsTrigger value="appearance">Apparence</TabsTrigger>
           <TabsTrigger value="notifications">Notifications</TabsTrigger>
           <TabsTrigger value="security">Sécurité</TabsTrigger>
           <TabsTrigger value="accessibility">Accessibilité</TabsTrigger>
+          <TabsTrigger value="ethics">Données &amp; éthique</TabsTrigger>
         </TabsList>
         
         <TabsContent value="appearance" className="space-y-6">
@@ -280,6 +283,11 @@ const Settings = () => {
               </div>
             </CardContent>
           </Card>
+        </TabsContent>
+
+        <TabsContent value="ethics" className="space-y-6">
+          <PrivacySettings />
+          <PersonalActivityLogs />
         </TabsContent>
       </Tabs>
     </div>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -49,6 +49,7 @@ import SanctuaryPage from './pages/SanctuaryPage';
 import ImmersiveHome from './pages/ImmersiveHome';
 import Home from './pages/Home';
 import UnifiedSettingsPage from './pages/UnifiedSettingsPage';
+import DataEthicsPage from './pages/DataEthicsPage';
 
 // Define the application routes without creating a router instance
 export const routes: RouteObject[] = [
@@ -59,6 +60,10 @@ export const routes: RouteObject[] = [
   {
     path: '/home',
     element: <Home />
+  },
+  {
+    path: 'ethique',
+    element: <DataEthicsPage />
   },
   {
     path: 'settings',

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -70,6 +70,7 @@ export interface RouteConfig {
     b2bSelection: string;
     unauthorized: string;
     notFound: string;
+    ethics: string;
   };
 }
 
@@ -123,6 +124,7 @@ export const ROUTES: RouteConfig = {
     home: '/',
     b2bSelection: '/b2b/selection',
     unauthorized: '/unauthorized',
-    notFound: '/not-found'
+    notFound: '/not-found',
+    ethics: '/ethique'
   }
 };


### PR DESCRIPTION
## Summary
- create `DataEthicsPage` with privacy settings and activity logs
- add new `/ethique` route
- expose route in navigation constants
- link to the new portal from user and admin navigation and B2C footer
- surface "Données & éthique" tab in B2C and B2B user settings

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check`
- `npm test` *(fails: ERR_MODULE_NOT_FOUND for ts-node)*