### PR TITLE
Add admin branding placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ src/
 - `/music` - Thérapie musicale
 - `/vr` - Sessions de réalité virtuelle
 - `/admin/dashboard` - Tableau de bord administrateur
+- `/b2b/admin/branding` - Gestion du branding et des communications
 
 ## Configuration d'environnement
 

--- a/src/components/navigation/B2BAdminNavBar.tsx
+++ b/src/components/navigation/B2BAdminNavBar.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { LayoutDashboard, Users, FileBarChart, Calendar, Settings, BookOpen, Scan, Music } from 'lucide-react';
+import { LayoutDashboard, Users, FileBarChart, Calendar, Settings, BookOpen, Scan, Music, Megaphone } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/contexts/AuthContext';
 import ConfirmationModal from '@/components/ui/confirmation-modal';
@@ -31,6 +31,7 @@ const B2BAdminNavBar: React.FC = () => {
       <NavItem to={ROUTES.b2bAdmin.teams} isActive={isActive(ROUTES.b2bAdmin.teams)} icon={<Users className="h-5 w-5" />} label="Équipes" />
       <NavItem to={ROUTES.b2bAdmin.reports} isActive={isActive(ROUTES.b2bAdmin.reports)} icon={<FileBarChart className="h-5 w-5" />} label="Rapports" />
       <NavItem to={ROUTES.b2bAdmin.events} isActive={isActive(ROUTES.b2bAdmin.events)} icon={<Calendar className="h-5 w-5" />} label="Événements" />
+      <NavItem to={ROUTES.b2bAdmin.branding} isActive={isActive(ROUTES.b2bAdmin.branding)} icon={<Megaphone className="h-5 w-5" />} label="Branding" />
       <NavItem to={ROUTES.b2bAdmin.settings} isActive={isActive(ROUTES.b2bAdmin.settings)} icon={<Settings className="h-5 w-5" />} label="Paramètres" />
       
       <button 

--- a/src/pages/b2b/admin/Branding.tsx
+++ b/src/pages/b2b/admin/Branding.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import BrandingManager from '@/components/branding/BrandingManager';
+
+const B2BAdminBranding: React.FC = () => {
+  return (
+    <div className="container mx-auto py-6 space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold mb-2">Branding & Communication</h1>
+        <p className="text-muted-foreground">
+          Gérez l'apparence de la marque et les communications immersives.
+        </p>
+      </div>
+      <BrandingManager />
+      {/* TODO: ajouter l'analytics d'impact et les notifications IA */}
+    </div>
+  );
+};
+
+export default B2BAdminBranding;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -43,6 +43,7 @@ import B2BAdminTeamsPage from './pages/b2b/admin/Teams';
 import B2BAdminReportsPage from './pages/b2b/admin/Reports';
 import B2BAdminEventsPage from './pages/b2b/admin/Events';
 import B2BAdminSettingsPage from './pages/b2b/admin/Settings';
+import B2BAdminBrandingPage from './pages/b2b/admin/Branding';
 import TimelinePage from './pages/TimelinePage';
 import WorldPage from './pages/WorldPage';
 import SanctuaryPage from './pages/SanctuaryPage';
@@ -278,6 +279,10 @@ export const routes: RouteObject[] = [
       {
         path: 'events',
         element: <B2BAdminEventsPage />
+      },
+      {
+        path: 'branding',
+        element: <B2BAdminBrandingPage />
       },
       {
         path: 'settings',

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -63,6 +63,7 @@ export interface RouteConfig {
     teams?: string;
     reports?: string;
     events?: string;
+    branding?: string;
     settings?: string;
   };
   common: {
@@ -117,6 +118,7 @@ export const ROUTES: RouteConfig = {
     teams: '/b2b/admin/teams',
     reports: '/b2b/admin/reports',
     events: '/b2b/admin/events',
+    branding: '/b2b/admin/branding',
     settings: '/b2b/admin/settings'
   },
   common: {


### PR DESCRIPTION
## Summary
- create B2B admin branding page
- add branding route and navigation entry
- document admin branding route in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find package 'ts-node')*
- `npm run type-check`