### PR TITLE
Add retention dashboard feature

### DIFF
--- a/src/hooks/useRetentionStats.ts
+++ b/src/hooks/useRetentionStats.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+import { RetentionStats, retentionService } from '@/services/retentionService';
+import { useAuth } from '@/contexts/AuthContext';
+
+export const useRetentionStats = () => {
+  const { user } = useAuth();
+  const [stats, setStats] = useState<RetentionStats | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!user?.id) return;
+    setLoading(true);
+    retentionService
+      .fetchStats(user.id)
+      .then(data => setStats(data))
+      .finally(() => setLoading(false));
+  }, [user?.id]);
+
+  return { stats, loading };
+};
+
+export default useRetentionStats;

--- a/src/pages/RetentionDashboardPage.tsx
+++ b/src/pages/RetentionDashboardPage.tsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useRetentionStats } from '@/hooks/useRetentionStats';
+import { retentionService, ReengagementCampaign } from '@/services/retentionService';
+import { useAuth } from '@/contexts/AuthContext';
+
+const RetentionDashboardPage: React.FC = () => {
+  const { user } = useAuth();
+  const { stats, loading } = useRetentionStats();
+  const [campaigns, setCampaigns] = useState<ReengagementCampaign[]>([]);
+
+  useEffect(() => {
+    if (user?.role === 'b2b_admin' || user?.role === 'admin') {
+      retentionService.fetchCampaigns().then(data => setCampaigns(data));
+    }
+  }, [user?.role]);
+
+  if (loading) {
+    return <div className="p-8 text-center">Chargement...</div>;
+  }
+
+  return (
+    <div className="container mx-auto py-6 space-y-6">
+      <h1 className="text-3xl font-bold">Tableau de fidélité</h1>
+
+      {stats && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>Votre progression</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <p>Jours actifs : {stats.daysActive}</p>
+              <p>Série actuelle : {stats.streak} jours</p>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Badges</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ul className="list-disc list-inside space-y-1">
+                {stats.badges.map(b => (
+                  <li key={b}>{b}</li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Récompenses</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ul className="list-disc list-inside space-y-1">
+                {stats.rewards.map(r => (
+                  <li key={r}>{r}</li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Rituels à relancer</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ul className="list-disc list-inside space-y-1">
+                {stats.rituals.map(r => (
+                  <li key={r}>{r}</li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {(user?.role === 'b2b_admin' || user?.role === 'admin') && (
+        <div>
+          <h2 className="text-2xl font-semibold mb-4">Campagnes de réengagement</h2>
+          {campaigns.length === 0 ? (
+            <p className="text-muted-foreground">Aucune campagne pour le moment.</p>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {campaigns.map(c => (
+                <Card key={c.id} className="animate-fade-in">
+                  <CardHeader>
+                    <CardTitle>{c.name}</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-1 text-sm">
+                    <p>Cible : {c.target}</p>
+                    <p>Statut : {c.status}</p>
+                    <p>Envoyées : {c.sent}</p>
+                    <p>Ouvertures : {c.opened}</p>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RetentionDashboardPage;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -19,6 +19,7 @@ import B2BUserDashboardPage from './pages/b2b/user/Dashboard';
 import B2BAdminDashboardPage from './pages/b2b/admin/Dashboard';
 import B2CGamificationPage from './pages/b2c/Gamification';
 import B2BUserGamificationPage from './pages/b2b/user/Gamification';
+import RetentionDashboardPage from './pages/RetentionDashboardPage';
 import B2CJournalPage from './pages/b2c/Journal';
 import B2CScanPage from './pages/b2c/Scan';
 import B2CMusicPage from './pages/b2c/Music';
@@ -172,6 +173,10 @@ export const routes: RouteObject[] = [
         element: <SanctuaryPage />
       },
       {
+        path: 'retention',
+        element: <RetentionDashboardPage />
+      },
+      {
         path: 'gamification',
         element: <B2CGamificationPage />
       }
@@ -239,6 +244,10 @@ export const routes: RouteObject[] = [
         element: <SanctuaryPage />
       },
       {
+        path: 'retention',
+        element: <RetentionDashboardPage />
+      },
+      {
         path: 'gamification',
         element: <B2BUserGamificationPage />
       }
@@ -288,6 +297,10 @@ export const routes: RouteObject[] = [
       {
         path: 'innovation',
         element: <B2BAdminInnovationPage />
+      },
+      {
+        path: 'retention',
+        element: <RetentionDashboardPage />
       },
       {
         path: 'settings',

--- a/src/services/retentionService.ts
+++ b/src/services/retentionService.ts
@@ -1,0 +1,58 @@
+export interface RetentionStats {
+  daysActive: number;
+  streak: number;
+  badges: string[];
+  rewards: string[];
+  rituals: string[];
+}
+
+export interface ReengagementCampaign {
+  id: string;
+  name: string;
+  target: string;
+  status: 'scheduled' | 'running' | 'completed';
+  sent: number;
+  opened: number;
+}
+
+export const retentionService = {
+  async fetchStats(userId: string): Promise<RetentionStats> {
+    // In a real app this would query Supabase
+    await new Promise(resolve => setTimeout(resolve, 300));
+    return {
+      daysActive: 42,
+      streak: 5,
+      badges: ['Welcome Back', 'Loyal User'],
+      rewards: ['Playlist spéciale', 'Badge fidélité'],
+      rituals: [
+        "Rituels matinaux", 
+        "Pause musicale", 
+        "Journal quotidien"
+      ]
+    };
+  },
+
+  async fetchCampaigns(): Promise<ReengagementCampaign[]> {
+    await new Promise(resolve => setTimeout(resolve, 300));
+    return [
+      {
+        id: 'camp-1',
+        name: 'Relance utilisateurs inactifs',
+        target: 'B2C',
+        status: 'running',
+        sent: 150,
+        opened: 80
+      },
+      {
+        id: 'camp-2',
+        name: 'Défi bien-être',
+        target: 'B2B',
+        status: 'scheduled',
+        sent: 0,
+        opened: 0
+      }
+    ];
+  }
+};
+
+export default retentionService;

--- a/src/tests/retentionService.test.ts
+++ b/src/tests/retentionService.test.ts
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { retentionService } from '@/services/retentionService';
+
+test('retentionService.fetchStats returns stats object', async () => {
+  const stats = await retentionService.fetchStats('demo');
+  assert.equal(typeof stats.daysActive, 'number');
+  assert.ok(Array.isArray(stats.badges));
+});
+
+test('retentionService.fetchCampaigns returns campaigns array', async () => {
+  const campaigns = await retentionService.fetchCampaigns();
+  assert.ok(Array.isArray(campaigns));
+});


### PR DESCRIPTION
## Summary
- add retention service with mock stats and campaign data
- create React hook to load retention statistics
- implement `RetentionDashboardPage` for loyalty view and admin campaigns
- expose new `/retention` route for B2C, B2B user and admin dashboards
- test retention service API

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find package 'ts-node')*