### PR TITLE
Add evaluation dashboard

### DIFF
--- a/src/components/evaluation/EvaluationDashboard.tsx
+++ b/src/components/evaluation/EvaluationDashboard.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import FeedbackForm from '@/components/feedback/FeedbackForm';
+
+interface EvaluationDashboardProps {
+  module?: string;
+}
+
+const EvaluationDashboard: React.FC<EvaluationDashboardProps> = ({ module }) => {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Évaluation et feedback</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <FeedbackForm module={module} />
+      </CardContent>
+    </Card>
+  );
+};
+
+export default EvaluationDashboard;

--- a/src/components/feedback/FeedbackForm.tsx
+++ b/src/components/feedback/FeedbackForm.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { Star, Send } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { FeedbackService } from '@/lib/feedback-service';
+import { useAuth } from '@/contexts/AuthContext';
+import { toast } from '@/hooks/use-toast';
+
+interface FeedbackFormProps {
+  module?: string;
+}
+
+const FeedbackForm: React.FC<FeedbackFormProps> = ({ module = 'general' }) => {
+  const [rating, setRating] = useState(0);
+  const [comment, setComment] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const { user } = useAuth();
+
+  const handleSubmit = async () => {
+    if (rating === 0) {
+      toast({ title: 'Merci de sélectionner une note' });
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await FeedbackService.addFeedback({
+        module,
+        rating,
+        comment: comment.trim() || undefined,
+        userId: user?.id
+      });
+      setComment('');
+      setRating(0);
+      toast({ title: 'Feedback enregistré', description: "Merci pour votre retour" });
+    } catch (error) {
+      toast({ title: 'Erreur', description: 'Impossible denvoyer le feedback', variant: 'destructive' });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center space-x-1">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Star
+            key={i}
+            className={`h-5 w-5 cursor-pointer ${i < rating ? 'fill-yellow-500 text-yellow-500' : 'text-muted-foreground'}`}
+            onClick={() => setRating(i + 1)}
+          />
+        ))}
+      </div>
+      <Textarea
+        placeholder="Votre commentaire"
+        value={comment}
+        onChange={(e) => setComment(e.target.value)}
+      />
+      <Button onClick={handleSubmit} disabled={submitting} className="flex items-center gap-2">
+        <Send className="h-4 w-4" /> Envoyer
+      </Button>
+    </div>
+  );
+};
+
+export default FeedbackForm;

--- a/src/components/navigation/B2BAdminNavBar.tsx
+++ b/src/components/navigation/B2BAdminNavBar.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { LayoutDashboard, Users, FileBarChart, Calendar, Settings, BookOpen, Scan, Music } from 'lucide-react';
+import { LayoutDashboard, Users, FileBarChart, Calendar, Settings, BookOpen, Scan, Music, BarChart2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/contexts/AuthContext';
 import ConfirmationModal from '@/components/ui/confirmation-modal';
@@ -30,6 +30,7 @@ const B2BAdminNavBar: React.FC = () => {
       <NavItem to={ROUTES.b2bAdmin.music} isActive={isActive(ROUTES.b2bAdmin.music)} icon={<Music className="h-5 w-5" />} label="Musique" />
       <NavItem to={ROUTES.b2bAdmin.teams} isActive={isActive(ROUTES.b2bAdmin.teams)} icon={<Users className="h-5 w-5" />} label="Équipes" />
       <NavItem to={ROUTES.b2bAdmin.reports} isActive={isActive(ROUTES.b2bAdmin.reports)} icon={<FileBarChart className="h-5 w-5" />} label="Rapports" />
+      <NavItem to={ROUTES.b2bAdmin.evaluation} isActive={isActive(ROUTES.b2bAdmin.evaluation)} icon={<BarChart2 className="h-5 w-5" />} label="Évaluation" />
       <NavItem to={ROUTES.b2bAdmin.events} isActive={isActive(ROUTES.b2bAdmin.events)} icon={<Calendar className="h-5 w-5" />} label="Événements" />
       <NavItem to={ROUTES.b2bAdmin.settings} isActive={isActive(ROUTES.b2bAdmin.settings)} icon={<Settings className="h-5 w-5" />} label="Paramètres" />
       

--- a/src/components/navigation/B2BUserNavBar.tsx
+++ b/src/components/navigation/B2BUserNavBar.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { Home, BookOpen, Music, Scan, MessageSquare, Glasses, Trophy, Settings, HeartHandshake } from 'lucide-react';
+import { Home, BookOpen, Music, Scan, MessageSquare, Glasses, Trophy, Settings, HeartHandshake, BarChart2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/contexts/AuthContext';
 import ConfirmationModal from '@/components/ui/confirmation-modal';
@@ -31,6 +31,7 @@ const B2BUserNavBar: React.FC = () => {
       <NavItem to={ROUTES.b2bUser.coach} isActive={isActive(ROUTES.b2bUser.coach)} icon={<MessageSquare className="h-5 w-5" />} label="Coach" />
       <NavItem to={ROUTES.b2bUser.vr} isActive={isActive(ROUTES.b2bUser.vr)} icon={<Glasses className="h-5 w-5" />} label="VR" />
       <NavItem to={ROUTES.b2bUser.gamification} isActive={isActive(ROUTES.b2bUser.gamification)} icon={<Trophy className="h-5 w-5" />} label="Défis" />
+      <NavItem to={ROUTES.b2bUser.evaluation} isActive={isActive(ROUTES.b2bUser.evaluation)} icon={<BarChart2 className="h-5 w-5" />} label="Évaluation" />
       <NavItem to={ROUTES.b2bUser.cocon} isActive={isActive(ROUTES.b2bUser.cocon)} icon={<HeartHandshake className="h-5 w-5" />} label="Cocon" />
       <NavItem to={ROUTES.b2bUser.preferences} isActive={isActive(ROUTES.b2bUser.preferences)} icon={<Settings className="h-5 w-5" />} label="Paramètres" />
       

--- a/src/components/navigation/B2CNavBar.tsx
+++ b/src/components/navigation/B2CNavBar.tsx
@@ -14,7 +14,8 @@ import {
   MessageSquare, 
   Glasses,
   Trophy,
-  HeartHandshake
+  HeartHandshake,
+  BarChart2
 } from "lucide-react";
 import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from "@/hooks/use-toast";
@@ -124,6 +125,16 @@ const B2CNavBar: React.FC = () => {
           >
             <Trophy className="mr-2 h-4 w-4" />
             Défis
+          </Button>
+        </Link>
+
+        <Link to={ROUTES.b2c.evaluation}>
+          <Button
+            variant={location.pathname === ROUTES.b2c.evaluation ? "default" : "ghost"}
+            className="w-full justify-start"
+          >
+            <BarChart2 className="mr-2 h-4 w-4" />
+            Évaluation
           </Button>
         </Link>
 

--- a/src/components/navigation/navConfig.ts
+++ b/src/components/navigation/navConfig.ts
@@ -76,6 +76,11 @@ export const b2cNavItems: NavItemType[] = [
     icon: Trophy,
   },
   {
+    title: "Évaluation",
+    href: "/b2c/evaluation",
+    icon: BarChart2,
+  },
+  {
     title: "Paramètres",
     href: "/b2c/preferences",
     icon: Settings,
@@ -130,6 +135,11 @@ export const b2bUserNavItems: NavItemType[] = [
     icon: Trophy,
   },
   {
+    title: "Évaluation",
+    href: "/b2b/user/evaluation",
+    icon: BarChart2,
+  },
+  {
     title: "Paramètres",
     href: "/b2b/user/preferences",
     icon: Settings,
@@ -166,6 +176,11 @@ export const b2bAdminNavItems: NavItemType[] = [
   {
     title: "Rapports",
     href: "/b2b/admin/reports",
+    icon: BarChart2,
+  },
+  {
+    title: "Évaluation",
+    href: "/b2b/admin/evaluation",
     icon: BarChart2,
   },
   {

--- a/src/lib/feedback-service.ts
+++ b/src/lib/feedback-service.ts
@@ -1,0 +1,53 @@
+import { supabase } from '@/integrations/supabase/client';
+
+export interface Feedback {
+  id: string;
+  module: string;
+  rating: number;
+  comment?: string;
+  userId?: string;
+  created_at: string;
+}
+
+export class FeedbackService {
+  static async addFeedback(feedback: Omit<Feedback, 'id' | 'created_at'>): Promise<string> {
+    try {
+      const { data, error } = await supabase.functions.invoke('add-feedback', {
+        body: feedback
+      });
+      if (error) throw error;
+      return data.id as string;
+    } catch (error) {
+      console.error('Error adding feedback:', error);
+      throw error;
+    }
+  }
+
+  static async getFeedbacks(filters?: { module?: string; userId?: string }): Promise<Feedback[]> {
+    try {
+      const { data, error } = await supabase.functions.invoke('get-feedbacks', {
+        body: filters || {}
+      });
+      if (error) throw error;
+      return (data as Feedback[]) || [];
+    } catch (error) {
+      console.error('Error getting feedbacks:', error);
+      return [];
+    }
+  }
+
+  static async getSummary(filters?: { module?: string }): Promise<string> {
+    try {
+      const { data, error } = await supabase.functions.invoke('get-feedback-summary', {
+        body: filters || {}
+      });
+      if (error) throw error;
+      return (data as { summary: string })?.summary || '';
+    } catch (error) {
+      console.error('Error getting feedback summary:', error);
+      return '';
+    }
+  }
+}
+
+export default FeedbackService;

--- a/src/pages/b2b/admin/Evaluation.tsx
+++ b/src/pages/b2b/admin/Evaluation.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import EvaluationDashboard from '@/components/evaluation/EvaluationDashboard';
+
+const B2BAdminEvaluationPage: React.FC = () => {
+  return (
+    <div className="container mx-auto py-6">
+      <EvaluationDashboard module="b2b_admin" />
+    </div>
+  );
+};
+
+export default B2BAdminEvaluationPage;

--- a/src/pages/b2b/user/Evaluation.tsx
+++ b/src/pages/b2b/user/Evaluation.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import EvaluationDashboard from '@/components/evaluation/EvaluationDashboard';
+
+const B2BUserEvaluationPage: React.FC = () => {
+  return (
+    <div className="container mx-auto py-6">
+      <EvaluationDashboard module="b2b_user" />
+    </div>
+  );
+};
+
+export default B2BUserEvaluationPage;

--- a/src/pages/b2c/Evaluation.tsx
+++ b/src/pages/b2c/Evaluation.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import EvaluationDashboard from '@/components/evaluation/EvaluationDashboard';
+
+const B2CEvaluationPage: React.FC = () => {
+  return (
+    <div className="container mx-auto py-6">
+      <EvaluationDashboard module="b2c" />
+    </div>
+  );
+};
+
+export default B2CEvaluationPage;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -18,7 +18,9 @@ import B2CDashboardPage from './pages/b2c/DashboardPage';
 import B2BUserDashboardPage from './pages/b2b/user/Dashboard';
 import B2BAdminDashboardPage from './pages/b2b/admin/Dashboard';
 import B2CGamificationPage from './pages/b2c/Gamification';
+import B2CEvaluationPage from './pages/b2c/Evaluation';
 import B2BUserGamificationPage from './pages/b2b/user/Gamification';
+import B2BUserEvaluationPage from './pages/b2b/user/Evaluation';
 import B2CJournalPage from './pages/b2c/Journal';
 import B2CScanPage from './pages/b2c/Scan';
 import B2CMusicPage from './pages/b2c/Music';
@@ -41,6 +43,7 @@ import B2BAdminScanPage from './pages/b2b/admin/Scan';
 import B2BAdminMusicPage from './pages/b2b/admin/Music';
 import B2BAdminTeamsPage from './pages/b2b/admin/Teams';
 import B2BAdminReportsPage from './pages/b2b/admin/Reports';
+import B2BAdminEvaluationPage from './pages/b2b/admin/Evaluation';
 import B2BAdminEventsPage from './pages/b2b/admin/Events';
 import B2BAdminSettingsPage from './pages/b2b/admin/Settings';
 import TimelinePage from './pages/TimelinePage';
@@ -173,6 +176,10 @@ export const routes: RouteObject[] = [
       {
         path: 'gamification',
         element: <B2CGamificationPage />
+      },
+      {
+        path: 'evaluation',
+        element: <B2CEvaluationPage />
       }
     ]
   },
@@ -240,6 +247,10 @@ export const routes: RouteObject[] = [
       {
         path: 'gamification',
         element: <B2BUserGamificationPage />
+      },
+      {
+        path: 'evaluation',
+        element: <B2BUserEvaluationPage />
       }
     ]
   },
@@ -279,6 +290,10 @@ export const routes: RouteObject[] = [
       {
         path: 'reports',
         element: <B2BAdminReportsPage />
+      },
+      {
+        path: 'evaluation',
+        element: <B2BAdminEvaluationPage />
       },
       {
         path: 'events',

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -32,6 +32,7 @@ export interface RouteConfig {
     gamification?: string;
     cocon?: string;
     preferences?: string;
+    evaluation?: string;
   };
   b2bUser: {
     home: string;
@@ -50,6 +51,7 @@ export interface RouteConfig {
     gamification?: string;
     cocon?: string;
     preferences?: string;
+    evaluation?: string;
   };
   b2bAdmin: {
     home: string;
@@ -64,6 +66,7 @@ export interface RouteConfig {
     reports?: string;
     events?: string;
     settings?: string;
+    evaluation?: string;
   };
   common: {
     home: string;
@@ -87,7 +90,8 @@ export const ROUTES: RouteConfig = {
     settings: '/b2c/settings',
     gamification: '/b2c/gamification',
     cocon: '/b2c/cocon',
-    preferences: '/b2c/preferences'
+    preferences: '/b2c/preferences',
+    evaluation: '/b2c/evaluation'
   },
   b2bUser: {
     home: '/b2b/user',
@@ -103,7 +107,8 @@ export const ROUTES: RouteConfig = {
     settings: '/b2b/user/settings',
     gamification: '/b2b/user/gamification',
     cocon: '/b2b/user/cocon',
-    preferences: '/b2b/user/preferences'
+    preferences: '/b2b/user/preferences',
+    evaluation: '/b2b/user/evaluation'
   },
   b2bAdmin: {
     home: '/b2b/admin',
@@ -117,7 +122,8 @@ export const ROUTES: RouteConfig = {
     teams: '/b2b/admin/teams',
     reports: '/b2b/admin/reports',
     events: '/b2b/admin/events',
-    settings: '/b2b/admin/settings'
+    settings: '/b2b/admin/settings',
+    evaluation: '/b2b/admin/evaluation'
   },
   common: {
     home: '/',


### PR DESCRIPTION
## Summary
- add feedback service for supabase functions
- create feedback form and evaluation dashboard
- add evaluation pages for B2C, B2B user, B2B admin
- link evaluation routes in navigation and router

## Testing
- `npm test` *(fails: Cannot find package 'ts-node')*