### PR TITLE
Add basic reporting pages

### DIFF
--- a/src/pages/ReportingPage.tsx
+++ b/src/pages/ReportingPage.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import Shell from '@/Shell';
+import EmotionPieChart from '@/components/dashboard/charts/EmotionPieChart';
+import WeeklyActivityChart from '@/components/dashboard/charts/WeeklyActivityChart';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { weeklyActivityData } from '@/data/line-chart-data';
+import mockEmotions from '@/data/mockEmotions';
+
+const emotionColors: Record<string, string> = {
+  happy: '#FBBF24',
+  calm: '#34D399',
+  focused: '#60A5FA',
+  anxious: '#F87171',
+  sad: '#A78BFA'
+};
+
+const ReportingPage: React.FC = () => {
+  const counts = mockEmotions.reduce<Record<string, number>>((acc, cur) => {
+    acc[cur.emotion] = (acc[cur.emotion] || 0) + 1;
+    return acc;
+  }, {});
+
+  const pieData = Object.entries(counts).map(([name, value]) => ({
+    name,
+    value,
+    color: emotionColors[name] || '#8884d8'
+  }));
+
+  return (
+    <Shell>
+      <div className="container py-6 max-w-6xl space-y-6">
+        <h1 className="text-3xl font-bold">Mon reporting</h1>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Répartition des émotions</CardTitle>
+            </CardHeader>
+            <CardContent className="h-64">
+              <EmotionPieChart data={pieData} />
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Activité hebdomadaire</CardTitle>
+            </CardHeader>
+            <CardContent className="h-64">
+              <WeeklyActivityChart data={weeklyActivityData.map(d => ({
+                day: d.day,
+                journal: d.journalEntries,
+                scan: d.emotionScans,
+                music: d.musicSessions
+              }))} />
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </Shell>
+  );
+};
+
+export default ReportingPage;

--- a/src/pages/admin/AdminReportingPage.tsx
+++ b/src/pages/admin/AdminReportingPage.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import Shell from '@/Shell';
+import ReportsDashboard from '@/components/admin/reports/ReportsDashboard';
+import { useAuth } from '@/contexts/AuthContext';
+import { Navigate } from 'react-router-dom';
+import { isAdminRole } from '@/utils/roleUtils';
+import { useToast } from '@/hooks/use-toast';
+
+const AdminReportingPage: React.FC = () => {
+  const { user, isLoading } = useAuth();
+  const { toast } = useToast();
+
+  if (!isLoading && (!user || !isAdminRole(user?.role))) {
+    toast({
+      title: 'Accès non autorisé',
+      description: "Vous n'avez pas les permissions nécessaires pour accéder à cette page.",
+      variant: 'destructive'
+    });
+    return <Navigate to="/" replace />;
+  }
+
+  if (isLoading) {
+    return (
+      <Shell>
+        <div className="flex items-center justify-center h-96">
+          <div className="flex flex-col items-center space-y-4">
+            <div className="h-8 w-8 border-4 border-t-primary border-primary/30 rounded-full animate-spin" />
+            <div className="text-muted-foreground">Chargement...</div>
+          </div>
+        </div>
+      </Shell>
+    );
+  }
+
+  return (
+    <Shell>
+      <div className="container mx-auto py-8 px-4">
+        <ReportsDashboard />
+      </div>
+    </Shell>
+  );
+};
+
+export default AdminReportingPage;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -51,6 +51,8 @@ import ImmersiveHome from './pages/ImmersiveHome';
 import Home from './pages/Home';
 import UnifiedSettingsPage from './pages/UnifiedSettingsPage';
 import SupportPage from './pages/Support';
+import ReportingPage from './pages/ReportingPage';
+import AdminReportingPage from './pages/admin/AdminReportingPage';
 
 // Define the application routes without creating a router instance
 export const routes: RouteObject[] = [
@@ -71,6 +73,22 @@ export const routes: RouteObject[] = [
     element: (
       <ProtectedRoute>
         <UnifiedSettingsPage />
+      </ProtectedRoute>
+    )
+  },
+  {
+    path: 'reporting',
+    element: (
+      <ProtectedRoute>
+        <ReportingPage />
+      </ProtectedRoute>
+    )
+  },
+  {
+    path: 'admin/reporting',
+    element: (
+      <ProtectedRoute requiredRole="b2b_admin">
+        <AdminReportingPage />
       </ProtectedRoute>
     )
   },


### PR DESCRIPTION
## Summary
- create `ReportingPage` with charts for users
- add `AdminReportingPage` using existing dashboard component
- expose `/reporting` and `/admin/reporting` routes

## Testing
- `npm test` *(fails: Cannot find package 'ts-node')*