### PR TITLE
Add predictive dashboard route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 Toutes les modifications notables apportées à ce projet seront documentées dans ce fichier.
 
+## [1.1.0] - 2025-05-18
+
+### Ajouté
+- Module d'intelligence prédictive avec page dédiée `/predictive`
+- Lien de navigation "Prédictif" accessible à tous les rôles
+
 ## [1.0.0] - 2025-05-17
 
 ### Ajouté

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ EmotionsCare est une plateforme SaaS innovante dédiée au bien-être émotionne
 - **Coaching personnalisé** : Recommandations adaptées à l'état émotionnel
 - **Thérapie musicale** : Générations de musiques adaptées aux émotions détectées
 - **Journal émotionnel** : Suivi de l'évolution émotionnelle au fil du temps
+- **Personnalisation prédictive** : Interface et suggestions IA qui s'adaptent automatiquement à vos besoins
 - **Gamification** : Défis, badges et récompenses pour encourager l'engagement
 - **Réalité Virtuelle** : Sessions de relaxation immersives en VR
 - **Cocoon social** : Communauté bienveillante pour partager et progresser ensemble

--- a/src/components/navigation/MainNavigation.tsx
+++ b/src/components/navigation/MainNavigation.tsx
@@ -14,7 +14,7 @@ import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom';
 import { useBranding } from '@/hooks/useBranding';
 import { cn } from '@/lib/utils';
 import { useNotificationBadge } from '@/hooks/useNotificationBadge';
-import { Bell, Home, Settings, User, Users, GraduationCap, BookOpenCheck, BarChart, LogOut } from 'lucide-react';
+import { Bell, Home, Settings, User, Users, GraduationCap, BookOpenCheck, BarChart, LogOut, Sparkles } from 'lucide-react';
 
 export function MainNavigation() {
   const { user, logout } = useAuth();
@@ -50,6 +50,7 @@ export function MainNavigation() {
     { label: 'Profil', href: '/profile', icon: <User className="mr-2 h-4 w-4" /> },
     { label: 'Paramètres', href: '/settings', icon: <Settings className="mr-2 h-4 w-4" /> },
     { label: 'Dashboard', href: '/dashboard', icon: <BarChart className="mr-2 h-4 w-4" /> },
+    { label: 'Prédictif', href: '/predictive', icon: <Sparkles className="mr-2 h-4 w-4" /> },
     { label: 'Équipe', href: '/team', icon: <Users className="mr-2 h-4 w-4" /> },
     { label: 'Formations', href: '/training', icon: <GraduationCap className="mr-2 h-4 w-4" /> },
     { label: 'Ressources', href: '/resources', icon: <BookOpenCheck className="mr-2 h-4 w-4" /> },

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -51,6 +51,7 @@ import ImmersiveHome from './pages/ImmersiveHome';
 import Home from './pages/Home';
 import UnifiedSettingsPage from './pages/UnifiedSettingsPage';
 import SupportPage from './pages/Support';
+import PredictiveDashboardPage from './pages/PredictiveDashboardPage';
 
 // Define the application routes without creating a router instance
 export const routes: RouteObject[] = [
@@ -174,6 +175,10 @@ export const routes: RouteObject[] = [
       {
         path: 'gamification',
         element: <B2CGamificationPage />
+      },
+      {
+        path: 'predictive',
+        element: <PredictiveDashboardPage />
       }
     ]
   },
@@ -241,6 +246,10 @@ export const routes: RouteObject[] = [
       {
         path: 'gamification',
         element: <B2BUserGamificationPage />
+      },
+      {
+        path: 'predictive',
+        element: <PredictiveDashboardPage />
       }
     ]
   },
@@ -292,6 +301,10 @@ export const routes: RouteObject[] = [
       {
         path: 'settings',
         element: <B2BAdminSettingsPage />
+      },
+      {
+        path: 'predictive',
+        element: <PredictiveDashboardPage />
       }
     ]
   },


### PR DESCRIPTION
## Summary
- expose predictive personalization in the UI
- route `/predictive` available for all user roles
- link to the new page in main navigation
- document predictive personalization

## Testing
- `npm test` *(fails: Cannot find package 'ts-node')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*