### PR TITLE
Add basic extensions system

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import AppRouter from '@/AppRouter';
 import RouteDebugger from '@/components/ui/RouteDebugger';
 import { OrchestrationProvider } from '@/contexts/OrchestrationContext';
 import { OptimizationProvider } from '@/providers/OptimizationProvider';
+import { ExtensionsProvider } from '@/providers/ExtensionsProvider';
 
 function App() {
   return (
@@ -20,11 +21,13 @@ function App() {
             <UserModeProvider>
               <MusicProvider>
                 <OptimizationProvider>
-                  <OrchestrationProvider>
-                    <AppRouter />
-                    <Toaster />
-                    {import.meta.env.DEV && <RouteDebugger />}
-                  </OrchestrationProvider>
+                  <ExtensionsProvider>
+                    <OrchestrationProvider>
+                      <AppRouter />
+                      <Toaster />
+                      {import.meta.env.DEV && <RouteDebugger />}
+                    </OrchestrationProvider>
+                  </ExtensionsProvider>
                 </OptimizationProvider>
               </MusicProvider>
             </UserModeProvider>

--- a/src/components/navigation/B2BAdminNavBar.tsx
+++ b/src/components/navigation/B2BAdminNavBar.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { LayoutDashboard, Users, FileBarChart, Calendar, Settings, BookOpen, Scan, Music } from 'lucide-react';
+import { LayoutDashboard, Users, FileBarChart, Calendar, Settings, BookOpen, Scan, Music, Box } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/contexts/AuthContext';
 import ConfirmationModal from '@/components/ui/confirmation-modal';
@@ -31,6 +31,7 @@ const B2BAdminNavBar: React.FC = () => {
       <NavItem to={ROUTES.b2bAdmin.teams} isActive={isActive(ROUTES.b2bAdmin.teams)} icon={<Users className="h-5 w-5" />} label="Équipes" />
       <NavItem to={ROUTES.b2bAdmin.reports} isActive={isActive(ROUTES.b2bAdmin.reports)} icon={<FileBarChart className="h-5 w-5" />} label="Rapports" />
       <NavItem to={ROUTES.b2bAdmin.events} isActive={isActive(ROUTES.b2bAdmin.events)} icon={<Calendar className="h-5 w-5" />} label="Événements" />
+      <NavItem to="/extensions" isActive={isActive('/extensions')} icon={<Box className="h-5 w-5" />} label="Extensions" />
       <NavItem to={ROUTES.b2bAdmin.optimisation} isActive={isActive(ROUTES.b2bAdmin.optimisation)} icon={<FileBarChart className="h-5 w-5" />} label="Optimisation" />
       <NavItem to={ROUTES.b2bAdmin.settings} isActive={isActive(ROUTES.b2bAdmin.settings)} icon={<Settings className="h-5 w-5" />} label="Paramètres" />
       

--- a/src/components/navigation/B2BUserNavBar.tsx
+++ b/src/components/navigation/B2BUserNavBar.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { Home, BookOpen, Music, Scan, MessageSquare, Glasses, Trophy, Settings, HeartHandshake } from 'lucide-react';
+import { Home, BookOpen, Music, Scan, MessageSquare, Glasses, Trophy, Settings, HeartHandshake, Box } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/contexts/AuthContext';
 import ConfirmationModal from '@/components/ui/confirmation-modal';
@@ -32,6 +32,7 @@ const B2BUserNavBar: React.FC = () => {
       <NavItem to={ROUTES.b2bUser.vr} isActive={isActive(ROUTES.b2bUser.vr)} icon={<Glasses className="h-5 w-5" />} label="VR" />
       <NavItem to={ROUTES.b2bUser.gamification} isActive={isActive(ROUTES.b2bUser.gamification)} icon={<Trophy className="h-5 w-5" />} label="Défis" />
       <NavItem to={ROUTES.b2bUser.cocon} isActive={isActive(ROUTES.b2bUser.cocon)} icon={<HeartHandshake className="h-5 w-5" />} label="Cocon" />
+      <NavItem to="/extensions" isActive={isActive('/extensions')} icon={<Box className="h-5 w-5" />} label="Extensions" />
       <NavItem to={ROUTES.b2bUser.preferences} isActive={isActive(ROUTES.b2bUser.preferences)} icon={<Settings className="h-5 w-5" />} label="Paramètres" />
       
       <button 

--- a/src/components/navigation/B2CNavBar.tsx
+++ b/src/components/navigation/B2CNavBar.tsx
@@ -14,7 +14,8 @@ import {
   MessageSquare, 
   Glasses,
   Trophy,
-  HeartHandshake
+  HeartHandshake,
+  Box
 } from "lucide-react";
 import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from "@/hooks/use-toast";
@@ -134,6 +135,16 @@ const B2CNavBar: React.FC = () => {
           >
             <HeartHandshake className="mr-2 h-4 w-4" />
             Cocon
+          </Button>
+        </Link>
+
+        <Link to="/extensions">
+          <Button
+            variant={location.pathname === '/extensions' ? 'default' : 'ghost'}
+            className="w-full justify-start"
+          >
+            <Box className="mr-2 h-4 w-4" />
+            Extensions
           </Button>
         </Link>
       </nav>

--- a/src/components/navigation/navConfig.ts
+++ b/src/components/navigation/navConfig.ts
@@ -71,6 +71,11 @@ export const b2cNavItems: NavItemType[] = [
     icon: HeartHandshake,
   },
   {
+    title: "Extensions",
+    href: "/extensions",
+    icon: Box,
+  },
+  {
     title: "Défis",
     href: "/b2c/gamification",
     icon: Trophy,
@@ -125,6 +130,11 @@ export const b2bUserNavItems: NavItemType[] = [
     icon: HeartHandshake,
   },
   {
+    title: "Extensions",
+    href: "/extensions",
+    icon: Box,
+  },
+  {
     title: "Défis",
     href: "/b2b/user/gamification",
     icon: Trophy,
@@ -172,6 +182,11 @@ export const b2bAdminNavItems: NavItemType[] = [
     title: "Événements",
     href: "/b2b/admin/events",
     icon: Activity,
+  },
+  {
+    title: "Extensions",
+    href: "/extensions",
+    icon: Box,
   },
   {
     title: "Optimisation",

--- a/src/contexts/ExtensionsContext.tsx
+++ b/src/contexts/ExtensionsContext.tsx
@@ -1,0 +1,49 @@
+import React, { createContext, useContext } from 'react';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+import { ExtensionMeta } from '@/types/extensions';
+
+interface ExtensionsContextType {
+  available: ExtensionMeta[];
+  installed: string[];
+  toggleExtension: (id: string) => void;
+}
+
+const defaultExtensions: ExtensionMeta[] = [
+  {
+    id: 'mood-widget',
+    name: 'Widget Humeur',
+    description: "Suivi rapide de votre humeur du jour"
+  },
+  {
+    id: 'team-dashboard',
+    name: 'Dashboard Équipe',
+    description: "Vue consolidée pour les managers"
+  }
+];
+
+const ExtensionsContext = createContext<ExtensionsContextType | undefined>(undefined);
+
+export const ExtensionsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [installed, setInstalled] = useLocalStorage<string[]>('installedExtensions', []);
+
+  const toggleExtension = (id: string) => {
+    setInstalled((current) => {
+      if (current.includes(id)) {
+        return current.filter((ext) => ext !== id);
+      }
+      return [...current, id];
+    });
+  };
+
+  return (
+    <ExtensionsContext.Provider value={{ available: defaultExtensions, installed, toggleExtension }}>
+      {children}
+    </ExtensionsContext.Provider>
+  );
+};
+
+export const useExtensions = () => {
+  const ctx = useContext(ExtensionsContext);
+  if (!ctx) throw new Error('useExtensions must be used within an ExtensionsProvider');
+  return ctx;
+};

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -15,6 +15,7 @@ export { useAudioPlayer } from './useAudioPlayer';
 export { useMusic } from './useMusic';
 export { useMusicControls } from './useMusicControls';
 export { useMusicGen } from './api/useMusicGen';
+export { useExtensions } from '@/providers/ExtensionsProvider';
 
 // User mode hooks
 export { default as useUserModeHelpers } from './useUserModeHelpers';

--- a/src/pages/ExtensionsPage.tsx
+++ b/src/pages/ExtensionsPage.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { useExtensions } from '@/providers/ExtensionsProvider';
+
+const ExtensionsPage: React.FC = () => {
+  const { available, installed, toggleExtension } = useExtensions();
+
+  return (
+    <div className="container mx-auto py-6">
+      <h1 className="text-3xl font-bold mb-6">Marketplace d'extensions</h1>
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {available.map((ext) => (
+          <div key={ext.id} className="border p-4 rounded-lg space-y-2">
+            <h2 className="font-semibold text-lg">{ext.name}</h2>
+            <p className="text-sm text-muted-foreground">{ext.description}</p>
+            <Button
+              onClick={() => toggleExtension(ext.id)}
+              variant={installed.includes(ext.id) ? 'secondary' : 'default'}
+            >
+              {installed.includes(ext.id) ? 'Désinstaller' : 'Installer'}
+            </Button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ExtensionsPage;

--- a/src/providers/ExtensionsProvider.tsx
+++ b/src/providers/ExtensionsProvider.tsx
@@ -1,0 +1,1 @@
+export { ExtensionsProvider, useExtensions } from '@/contexts/ExtensionsContext';

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -44,6 +44,7 @@ import B2BAdminSettingsPage from '@/pages/b2b/admin/Settings';
 import B2BAdminSocialCoconPage from '@/pages/b2b/admin/SocialCocon';
 import B2BAdminOptimisationPage from '@/pages/b2b/admin/Optimisation';
 import OptimizationPage from '@/pages/OptimizationPage';
+import ExtensionsPage from '@/pages/ExtensionsPage';
 import ImmersiveHome from '@/pages/ImmersiveHome';
 import Home from '@/pages/Home';
 import LoginPage from '@/pages/common/Login';
@@ -76,6 +77,14 @@ export const routes: RouteObject[] = [
     element: (
       <ProtectedRoute>
         <OptimizationPage />
+      </ProtectedRoute>
+    )
+  },
+  {
+    path: 'extensions',
+    element: (
+      <ProtectedRoute>
+        <ExtensionsPage />
       </ProtectedRoute>
     )
   },

--- a/src/types/extensions.ts
+++ b/src/types/extensions.ts
@@ -1,0 +1,6 @@
+export interface ExtensionMeta {
+  id: string;
+  name: string;
+  description: string;
+  category?: string;
+}

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -87,7 +87,8 @@ export const ROUTES: RouteConfig = {
     settings: '/b2c/settings',
     gamification: '/b2c/gamification',
     cocon: '/b2c/cocon',
-    preferences: '/b2c/preferences'
+    preferences: '/b2c/preferences',
+    extensions: '/extensions'
   },
   b2bUser: {
     home: '/b2b/user',
@@ -103,7 +104,8 @@ export const ROUTES: RouteConfig = {
     settings: '/b2b/user/settings',
     gamification: '/b2b/user/gamification',
     cocon: '/b2b/user/cocon',
-    preferences: '/b2b/user/preferences'
+    preferences: '/b2b/user/preferences',
+    extensions: '/extensions'
   },
   b2bAdmin: {
     home: '/b2b/admin',
@@ -118,7 +120,8 @@ export const ROUTES: RouteConfig = {
     reports: '/b2b/admin/reports',
     events: '/b2b/admin/events',
     settings: '/b2b/admin/settings',
-    optimisation: '/b2b/admin/optimisation'
+    optimisation: '/b2b/admin/optimisation',
+    extensions: '/extensions'
   },
   common: {
     home: '/',


### PR DESCRIPTION
## Summary
- introduce `ExtensionsProvider` and `useExtensions`
- add simple Extension marketplace page
- expose extensions route in router and navigation
- link new marketplace from sidebars
- wrap app with provider

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check`
- `npm test`