### PR TITLE
Fix CI environment and add conflict check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,14 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20
+
+      - name: Pre-check merge conflicts
+        run: |
+          if grep -r "<<<<<<<" -n .; then
+            echo "Unresolved merge conflict markers detected";
+            exit 1;
+          fi
       - name: Install deps
         run: |
           npm install

--- a/README.md
+++ b/README.md
@@ -184,6 +184,16 @@ L'application est entièrement responsive et optimisée pour les appareils mobil
 - Tests unitaires (placeholder) (`npm run test`)
 - Nettoyage du build (`npm run clean`)
 
+## Notifications CI
+
+Par défaut, GitHub envoie un email à chaque échec du workflow CI. Pour 
+éviter d'être submergé par ces messages :
+
+1. Ouvrez **Settings > Notifications** sur GitHub et désactivez
+   l'option *Actions*.
+2. Vous pouvez toujours réactiver les alertes en cas d'incident majeur
+   depuis cette même page.
+
 ## Monitoring & Alerting
 
 L'application intègre **Sentry** pour la surveillance des erreurs et des incidents.


### PR DESCRIPTION
## Summary
- update Node version in CI workflow to 20 (ts-node compatible)
- add pre-check to detect merge conflict markers before running tests
- document how to disable CI email notifications in README

## Testing
- `npm test` *(fails: Cannot find package 'ts-node')*