### PR TITLE
Fix chat naming

### DIFF
--- a/src/components/coach/ConversationList.tsx
+++ b/src/components/coach/ConversationList.tsx
@@ -85,12 +85,12 @@ const ConversationList: React.FC<ConversationListProps> = ({
                   <div className="flex-grow pr-4">
                     <h3 className="font-medium truncate">{conversation.title}</h3>
                     <p className="text-sm text-muted-foreground truncate mt-1">
-                      {truncateText(conversation.last_message)}
+                      {truncateText(conversation.lastMessage)}
                     </p>
                   </div>
                   <div className="flex flex-col items-end">
                     <span className="text-xs text-muted-foreground">
-                      {formatDate(conversation.updated_at || conversation.created_at)}
+                      {formatDate(conversation.updatedAt || conversation.createdAt)}
                     </span>
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>

--- a/src/hooks/chat/useChatHistory.ts
+++ b/src/hooks/chat/useChatHistory.ts
@@ -13,17 +13,17 @@ const ConversationsService = {
       {
         id: 'conv1',
         title: 'First Conversation',
-        updated_at: '2023-01-15T14:22:00Z',
-        created_at: '2023-01-15T14:00:00Z',
-        last_message: 'Hello there!',
+        updatedAt: '2023-01-15T14:22:00Z',
+        createdAt: '2023-01-15T14:00:00Z',
+        lastMessage: 'Hello there!',
         user_id: userId || 'user1',
       },
       {
         id: 'conv2',
         title: 'Support Request',
-        updated_at: '2023-01-10T09:15:00Z',
-        created_at: '2023-01-10T09:00:00Z',
-        last_message: 'Thank you for your help.',
+        updatedAt: '2023-01-10T09:15:00Z',
+        createdAt: '2023-01-10T09:00:00Z',
+        lastMessage: 'Thank you for your help.',
         user_id: userId || 'user1',
       }
     ] as ChatConversation[];

--- a/src/hooks/chat/useConversationLoader.tsx
+++ b/src/hooks/chat/useConversationLoader.tsx
@@ -19,10 +19,10 @@ const extendedChatHistoryService = {
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         lastMessage: "Dernier message de test",
-        user_id: userId,
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-        last_message: "Dernier message de test"
+        user_id: userId, // legacy field
+        created_at: new Date().toISOString(), // legacy field
+        updated_at: new Date().toISOString(), // legacy field
+        last_message: "Dernier message de test" // legacy field
       },
       {
         id: "conv-2",
@@ -30,10 +30,10 @@ const extendedChatHistoryService = {
         createdAt: new Date(Date.now() - 86400000).toISOString(),
         updatedAt: new Date(Date.now() - 3600000).toISOString(),
         lastMessage: "Un autre message de test",
-        user_id: userId,
-        created_at: new Date(Date.now() - 86400000).toISOString(),
-        updated_at: new Date(Date.now() - 3600000).toISOString(),
-        last_message: "Un autre message de test"
+        user_id: userId, // legacy field
+        created_at: new Date(Date.now() - 86400000).toISOString(), // legacy field
+        updated_at: new Date(Date.now() - 3600000).toISOString(), // legacy field
+        last_message: "Un autre message de test" // legacy field
       }
     ];
   }

--- a/src/hooks/chat/useConversationManagement.tsx
+++ b/src/hooks/chat/useConversationManagement.tsx
@@ -38,10 +38,10 @@ export const useConversationManagement = () => {
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         lastMessage: "",
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-        last_message: "",
-        user_id: "user-123" // Normalement, l'ID utilisateur serait dynamique
+        created_at: new Date().toISOString(), // legacy field
+        updated_at: new Date().toISOString(), // legacy field
+        last_message: "", // legacy field
+        user_id: "user-123" // Normally dynamic according to logged user
       };
       
       // Dans une vraie application, sauvegarder dans la base de données

--- a/src/hooks/chat/useConversationState.tsx
+++ b/src/hooks/chat/useConversationState.tsx
@@ -17,7 +17,7 @@ export const useConversationState = () => {
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
       lastMessage: "",
-      user_id: "user-123", // Normalement dynamique selon l'utilisateur connecté
+      user_id: "user-123", // legacy field
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
       last_message: ""
@@ -35,7 +35,7 @@ export const useConversationState = () => {
     setConversations(prev => 
       prev.map(conv => 
         conv.id === id 
-          ? { ...conv, title, updatedAt: new Date().toISOString(), updated_at: new Date().toISOString() } 
+          ? { ...conv, title, updatedAt: new Date().toISOString(), updated_at: new Date().toISOString() }
           : conv
       )
     );

--- a/src/hooks/chat/useConversations.tsx
+++ b/src/hooks/chat/useConversations.tsx
@@ -11,11 +11,11 @@ const mockConversations: ChatConversation[] = [
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
     lastMessage: "Bonjour, comment puis-je vous aider ?",
-    user_id: "user-123", // Pour compatibilité
-    created_at: new Date().toISOString(), // Pour compatibilité
-    updated_at: new Date().toISOString(), // Pour compatibilité
-    last_message: "Bonjour, comment puis-je vous aider ?", // Pour compatibilité
-    messages: [] // Pour compatibilité
+    user_id: "user-123", // legacy field
+    created_at: new Date().toISOString(), // legacy field
+    updated_at: new Date().toISOString(), // legacy field
+    last_message: "Bonjour, comment puis-je vous aider ?", // legacy field
+    messages: [] // legacy field
   },
   {
     id: uuidv4(),
@@ -23,11 +23,11 @@ const mockConversations: ChatConversation[] = [
     createdAt: new Date(Date.now() - 86400000).toISOString(), // 1 day ago
     updatedAt: new Date(Date.now() - 86400000).toISOString(),
     lastMessage: "Merci pour votre aide !",
-    user_id: "user-123", // Pour compatibilité
-    created_at: new Date(Date.now() - 86400000).toISOString(), // Pour compatibilité
-    updated_at: new Date(Date.now() - 86400000).toISOString(), // Pour compatibilité
-    last_message: "Merci pour votre aide !", // Pour compatibilité
-    messages: [] // Pour compatibilité
+    user_id: "user-123", // legacy field
+    created_at: new Date(Date.now() - 86400000).toISOString(), // legacy field
+    updated_at: new Date(Date.now() - 86400000).toISOString(), // legacy field
+    last_message: "Merci pour votre aide !", // legacy field
+    messages: [] // legacy field
   }
 ];
 
@@ -92,11 +92,11 @@ export const useConversations = () => {
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
       lastMessage: "",
-      user_id: "user-123", // Pour compatibilité
-      created_at: new Date().toISOString(), // Pour compatibilité
-      updated_at: new Date().toISOString(), // Pour compatibilité
-      last_message: "", // Pour compatibilité
-      messages: [] // Pour compatibilité
+      user_id: "user-123", // legacy field
+      created_at: new Date().toISOString(), // legacy field
+      updated_at: new Date().toISOString(), // legacy field
+      last_message: "", // legacy field
+      messages: [] // legacy field
     };
     
     mockConversations.unshift(newConversation);

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -32,6 +32,13 @@ export interface Conversation {
   title: string;
   createdAt: string;
   updatedAt: string;
+  /** Latest message content */
+  lastMessage?: string;
+  /** Legacy snake_case fields for backward compatibility */
+  created_at?: string;
+  updated_at?: string;
+  last_message?: string;
+  user_id?: string;
   messages: ChatMessage[];
   summary?: string;
   participants?: string[];


### PR DESCRIPTION
## Summary
- add `lastMessage` and legacy fields to chat `Conversation`
- use camelCase conversation fields in chat hooks and component

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: cannot find package 'ts-node')*