### PR TITLE
Fix DEFAULT_PREFERENCES export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 Toutes les modifications notables apportées à ce projet seront documentées dans ce fichier.
 
+## [1.1.1] - 2025-05-19
+
+### Corrigé
+- Export manquant `DEFAULT_PREFERENCES` rétabli dans `src/types/preferences.ts`.
+
 ## [1.1.0] - 2025-05-18
 
 ### Ajouté

--- a/README.md
+++ b/README.md
@@ -169,6 +169,53 @@ EmotionsCare utilise un système de design basé sur Tailwind CSS et Shadcn UI, 
 - **LayoutContext** - Mise en page et navigation
 - **MusicContext** - Lecture et gestion de la musique (source unique via `useMusic`)
 
+## Préférences utilisateur par défaut
+
+La constante `DEFAULT_PREFERENCES` centralise les valeurs initiales utilisées
+dans les contextes de préférences utilisateur. Elle est définie dans
+`src/constants/defaults.ts` et réexportée par `src/types/preferences.ts`.
+Sa structure est la suivante :
+
+```ts
+{
+  theme: 'system',
+  fontSize: 'medium',
+  fontFamily: 'system',
+  reduceMotion: false,
+  colorBlindMode: false,
+  autoplayMedia: true,
+  soundEnabled: true,
+  emotionalCamouflage: false,
+  aiSuggestions: true,
+  notifications_enabled: true,
+  language: 'fr',
+  privacy: {
+    shareData: false,
+    allowAnalytics: true,
+    showProfile: true,
+    shareActivity: true,
+    allowMessages: true,
+    allowNotifications: true
+  },
+  notifications: {
+    email: true,
+    push: true,
+    sms: false,
+    frequency: 'daily',
+    enabled: true,
+    emailEnabled: true,
+    pushEnabled: true,
+    inAppEnabled: true
+  }
+}
+```
+
+Les composants peuvent l'importer via :
+
+```ts
+import { DEFAULT_PREFERENCES } from '@/types/preferences';
+```
+
 ## Gestion du responsive
 
 L'application est entièrement responsive et optimisée pour les appareils mobiles, tablettes et desktop. Nous utilisons:

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -89,3 +89,6 @@ export function normalizePreferences(prefs: any): UserPreferences {
       prefs.notifications || { enabled: true, emailEnabled: true, pushEnabled: false }
   };
 }
+
+// Re-export des préférences par défaut pour un accès centralisé
+export { DEFAULT_PREFERENCES } from '@/constants/defaults';


### PR DESCRIPTION
## Summary
- re-export `DEFAULT_PREFERENCES` from `src/types/preferences.ts`
- document default user preferences in README
- note the fix in CHANGELOG

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check`
- `npm test` *(fails: Cannot find package 'ts-node')*
- `npm run build` *(fails: vite not found)*