### PR TITLE
Refactor interfaces

### DIFF
--- a/src/hooks/usePreferences.tsx
+++ b/src/hooks/usePreferences.tsx
@@ -1,21 +1,7 @@
 
 import { useState } from 'react';
 import { useToast } from './use-toast';
-
-export interface UserPreferences {
-  notifications_enabled?: boolean;
-  email_notifications?: boolean;
-  push_notifications?: boolean;
-  theme?: 'light' | 'dark' | 'system';
-  fontSize?: 'small' | 'medium' | 'large';
-  emotionalCamouflage?: boolean;
-  aiSuggestions?: boolean;
-  fullAnonymity?: boolean;
-  language?: string;
-  autoPlay?: boolean;
-  journalReminders?: boolean;
-  audioQuality?: 'low' | 'medium' | 'high';
-}
+import type { UserPreferences } from '@/types/preferences';
 
 export function usePreferences() {
   // Dans une app réelle, ceci viendrait de l'API ou du stockage local

--- a/src/hooks/useScanDetailPage.tsx
+++ b/src/hooks/useScanDetailPage.tsx
@@ -1,14 +1,6 @@
 
 import { useState, useEffect } from 'react';
-
-// Définition du type User manquant
-export interface User {
-  id: string;
-  name: string;
-  email: string;
-  role: string;
-  created_at: string;
-}
+import type { User } from '@/types/user';
 
 export interface ScanDetail {
   id: string;

--- a/src/types/auth-extended.ts
+++ b/src/types/auth-extended.ts
@@ -1,11 +1,10 @@
 
-import { UserPreferences as AuthUserPreferences } from './auth';
-import { UserPreferences as AppUserPreferences } from './preferences';
+import type { UserPreferences } from './preferences';
 
 /**
  * Adapter pour convertir entre les types de préférences utilisateur
  */
-export function adaptAuthPreferences(authPrefs: AuthUserPreferences): AppUserPreferences {
+export function adaptAuthPreferences(authPrefs: UserPreferences): UserPreferences {
   return {
     theme: authPrefs.theme || 'system',
     fontSize: authPrefs.fontSize,

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,4 +1,6 @@
 
+import type { UserPreferences } from './preferences';
+
 export interface AuthContextType {
   user: {
     id: string;
@@ -17,43 +19,4 @@ export interface AuthContextType {
   updatePreferences?: (preferences: Partial<UserPreferences>) => Promise<void>;
   updateUser?: (user: any) => Promise<void>;
   clearError?: () => void;
-}
-
-export interface UserPreferences {
-  theme: "system" | "dark" | "light" | "pastel";
-  fontSize?: string;
-  fontFamily?: string;
-  reduceMotion?: boolean;
-  colorBlindMode?: boolean;
-  autoplayMedia?: boolean;
-  soundEnabled?: boolean;
-  emotionalCamouflage?: boolean;
-  aiSuggestions?: boolean;
-  language?: string;
-  dashboardLayout?: Record<string, any> | string;
-  onboardingCompleted?: boolean;
-  privacy?: {
-    shareData: boolean;
-    anonymizeReports: boolean;
-    profileVisibility: string;
-  };
-  notifications?: {
-    enabled: boolean;
-    emailEnabled: boolean;
-    pushEnabled: boolean;
-    inAppEnabled: boolean;
-    types: {
-      system: boolean;
-      emotion: boolean;
-      coach: boolean;
-      journal: boolean;
-      community: boolean;
-      achievement: boolean;
-    };
-    frequency: string;
-    email: boolean;
-    push: boolean;
-    sms: boolean;
-  };
-  [key: string]: any;
 }

--- a/src/types/user-context.ts
+++ b/src/types/user-context.ts
@@ -6,18 +6,12 @@ export interface UserHistory {
   preferredActivities?: string[];
 }
 
-export interface UserPreferences {
-  dailyReminders?: boolean;
-  notificationsEnabled?: boolean;
-  preferredTheme?: string;
-  emotionTrackingFrequency?: 'daily' | 'weekly' | 'onDemand';
-  notificationTone?: 'friendly' | 'neutral' | 'formal' | 'casual' | 'direct' | 'professional' | 'motivational';
-}
+import type { UserPreferences } from './preferences';
 
 export interface UserContext {
   id?: string;
   name?: string;
-  preferences?: UserPreferences;
+  preferences?: Partial<UserPreferences> & Record<string, any>;
   recentEmotions?: string[];
   recentActivities?: string[];
   userHistory?: UserHistory;


### PR DESCRIPTION
## Summary
- centralize `UserPreferences` in hooks and contexts
- reference unified `User` in scan detail hook
- simplify auth types

## Testing
- `npm run type-check`
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*