### PR TITLE
Fix B2C registration parameter order

### DIFF
--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -34,7 +34,7 @@ const RegisterPage: React.FC = () => {
     setIsLoading(true);
     
     try {
-      await register(email, password, name);
+      await register(name, email, password);
       toast({
         title: "Inscription réussie",
         description: "Votre compte a été créé avec succès",

--- a/src/pages/b2c/Register.tsx
+++ b/src/pages/b2c/Register.tsx
@@ -35,7 +35,7 @@ const RegisterPage: React.FC = () => {
     setIsLoading(true);
     
     try {
-      await register(email, password, name);
+      await register(name, email, password);
       toast({
         title: "Inscription réussie",
         description: "Votre compte a été créé avec succès",

--- a/src/pages/common/Register.tsx
+++ b/src/pages/common/Register.tsx
@@ -53,7 +53,7 @@ const Register: React.FC<RegisterProps> = ({ role = 'b2c' }) => {
     setIsLoading(true);
     
     try {
-      await register(email, password, name);
+      await register(name, email, password);
       
       toast({
         title: "Inscription réussie",


### PR DESCRIPTION
## Summary
- fix register() call parameter order in Register pages

## Testing
- `npm test` *(fails: Cannot find package 'ts-node')*