### PR TITLE
Improve coach context typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Toutes les modifications notables apportées à ce projet seront documentées da
 ### Corrigé
 - Export manquant `DEFAULT_PREFERENCES` rétabli dans `src/types/preferences.ts`.
 
+## [1.1.2] - 2025-05-20
+
+### Ajouté
+- Centralisation des types du coach et du chat (`src/types/coach.ts`, `src/types/chat.ts`).
+- Documentation `COACH_CHAT_MODULE.md` décrivant le contexte et le flux principal.
+- Test unitaire minimal pour les exports du `CoachContext`.
+
+### Modifié
+- Normalisation du `CoachContext` pour utiliser les nouveaux types.
+
 ## [1.1.0] - 2025-05-18
 
 ### Ajouté

--- a/docs/coach-chat-audit.md
+++ b/docs/coach-chat-audit.md
@@ -1,0 +1,18 @@
+# Audit Coach IA & Chat
+
+Ce rapport fait suite à l'analyse du contexte `Coach` et du module de chat. Les objectifs étaient de vérifier la centralisation de l'état, la cohérence des types et la préparation à l'extension.
+
+## Points clés
+- Plusieurs implémentations du contexte existaient (`contexts/coach.tsx`, `contexts/coach/index.tsx`, `contexts/coach/CoachContext.tsx`).
+- Les types `ChatMessage` et `Conversation` étaient dupliqués à plusieurs endroits.
+- Le service `openai` gère correctement les appels mais sans mécanisme de retry.
+
+## Actions réalisées
+- Consolidation des définitions dans `src/types/coach.ts` et `src/types/chat.ts`.
+- Mise à jour du `CoachContext` pour utiliser ces types.
+- Ajout d'un test unitaire simple et d'une documentation dédiée.
+
+## Recommandations futures
+- Mettre en place des tests plus poussés sur `sendMessage` et le service OpenAI.
+- Supprimer les anciennes implémentations du contexte après validation.
+- Ajouter une stratégie de backoff pour les appels réseau.

--- a/src/contexts/coach/CoachContext.tsx
+++ b/src/contexts/coach/CoachContext.tsx
@@ -2,22 +2,7 @@
 import React, { createContext, useState, useEffect, useCallback } from 'react';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { useCoachHandlers } from './useCoachHandlers';
-
-export interface Message {
-  id: string;
-  content: string;
-  sender: 'user' | 'coach';
-  timestamp: Date;
-  isLoading?: boolean;
-}
-
-export interface Conversation {
-  id: string;
-  title: string;
-  messages: Message[];
-  createdAt: Date;
-  lastUpdated: Date;
-}
+import type { Conversation, ChatMessage, CoachSession, Suggestion } from '@/types/coach';
 
 export interface CoachContextType {
   conversations: Conversation[];
@@ -115,7 +100,7 @@ export const CoachProvider: React.FC<{children: React.ReactNode}> = ({ children 
 
     // Add welcome message from coach
     setTimeout(() => {
-      const welcomeMessage: Message = {
+      const welcomeMessage: ChatMessage = {
         id: `msg-${Date.now()}`,
         content: `Bonjour ! Je suis ${coachCharacter.name}, votre coach personnel. Comment puis-je vous aider aujourd'hui ?`,
         sender: 'coach',
@@ -141,7 +126,7 @@ export const CoachProvider: React.FC<{children: React.ReactNode}> = ({ children 
     if (!content.trim() || !currentConversationId) return;
 
     // Add user message
-    const userMessage: Message = {
+    const userMessage: ChatMessage = {
       id: `msg-u-${Date.now()}`,
       content,
       sender: 'user',
@@ -149,7 +134,7 @@ export const CoachProvider: React.FC<{children: React.ReactNode}> = ({ children 
     };
 
     // Create temporary loading message
-    const tempMessage: Message = {
+    const tempMessage: ChatMessage = {
       id: `msg-c-${Date.now()}`,
       content: '...',
       sender: 'coach',

--- a/src/contexts/coach/useCoachHandlers.ts
+++ b/src/contexts/coach/useCoachHandlers.ts
@@ -10,17 +10,17 @@ export const useCoachHandlers = () => {
   const [messages, setMessages] = useState<ChatMessage[]>([
     {
       id: uuidv4(),
-      text: "Bonjour, je suis votre coach virtuel. Comment puis-je vous aider aujourd'hui ?",
+      content: "Bonjour, je suis votre coach virtuel. Comment puis-je vous aider aujourd'hui ?",
       sender: "assistant",
       timestamp: createTimestamp(),
     },
   ]);
 
   // Function to add a new message
-  const addMessage = useCallback((text: string, sender: 'user' | 'assistant', options: any = {}) => {
+  const addMessage = useCallback((content: string, sender: 'user' | 'assistant', options: any = {}) => {
     const newMessage: ChatMessage = {
       id: options.id || uuidv4(),
-      text,
+      content,
       sender,
       timestamp: options.timestamp || createTimestamp(),
       ...options,
@@ -35,7 +35,7 @@ export const useCoachHandlers = () => {
     // Ensure all messages have required properties
     const validMessages: ChatMessage[] = initialMessages.map(msg => ({
       id: msg.id || uuidv4(),
-      text: msg.text || msg.content || '',
+      content: msg.content || msg.text || '',
       sender: msg.sender || 'user',
       timestamp: msg.timestamp || createTimestamp(),
       conversationId: msg.conversationId || msg.conversation_id,

--- a/src/docs/COACH_CHAT_MODULE.md
+++ b/src/docs/COACH_CHAT_MODULE.md
@@ -1,0 +1,44 @@
+# Audit du module Coach IA & Chat
+
+Ce document résume la structure actuelle du contexte `Coach` et les recommandations principales pour assurer sa robustesse et son extensibilité.
+
+## Contexte global
+- **CoachContext** centralise les conversations, le personnage du coach et l'état de saisie.
+- Les appels à l'IA sont délégués à `useCoachHandlers` puis au service `openai`.
+- Les conversations sont persistées via `useLocalStorage`.
+
+## API du contexte
+```ts
+interface CoachContextType {
+  conversations: Conversation[];
+  currentConversation: Conversation | null;
+  isTyping: boolean;
+  loadingMessage: string | null;
+  coachCharacter: {
+    name: string;
+    avatar: string;
+    personality: string;
+    expertise: string[];
+  };
+  sendMessage(content: string): Promise<void>;
+  startNewConversation(): void;
+  selectConversation(id: string): void;
+  renameConversation(id: string, title: string): void;
+  deleteConversation(id: string): void;
+  setCoachCharacter(character: CoachContextType['coachCharacter']): void;
+  getRecommendations(category: string): string[];
+  analyzeEmotion(text: string): Promise<{ emotion: string; score: number }>;
+}
+```
+
+## Flux principal
+1. L'utilisateur envoie un texte via `sendMessage`.
+2. `useCoachHandlers` orchestre l'appel à l'API OpenAI (`chatCompletion` et `analyzeEmotion`).
+3. La réponse est injectée dans la conversation et l'état `isTyping` est mis à jour.
+
+## Recommandations
+- Supprimer les doublons de contexte (`contexts/coach.tsx`, `index.tsx`), ne conserver qu'une version.
+- Regrouper les types dans `src/types/coach.ts` et `src/types/chat.ts` (fait dans cette PR).
+- Ajouter des tests unitaires sur `sendMessage` et le service OpenAI.
+- Prévoir un mécanisme de retry côté service en cas d'échec réseau.
+

--- a/src/tests/coachContext.test.ts
+++ b/src/tests/coachContext.test.ts
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { CoachContext, CoachProvider } from '@/contexts/coach';
+
+// Basic export tests for CoachContext module
+
+test('CoachContext exports are available', () => {
+  assert.ok(CoachContext, 'CoachContext should be defined');
+  assert.equal(typeof CoachProvider, 'function');
+});

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,9 +1,14 @@
 
+/**
+ * Message utilisé dans les conversations du module de chat.
+ */
 export interface ChatMessage {
   id: string;
-  text: string;
-  content?: string; // Adding this field to fix type errors
+  /** Contenu textuel du message */
+  content: string;
+  /** Expéditeur du message */
   sender: 'user' | 'assistant' | string;
+  /** Date d'envoi */
   timestamp: string | Date;
   emotion?: string;
   feedback?: string;
@@ -17,8 +22,8 @@ export interface ChatMessage {
 export interface ChatConversation {
   id: string;
   title: string;
-  createdAt: string;
-  updatedAt: string;
+  createdAt: Date | string;
+  updatedAt: Date | string;
   lastMessage: string;
   user_id?: string;
   created_at?: string;
@@ -35,3 +40,4 @@ export type ChatResponse = {
 };
 
 export type Conversation = ChatConversation; // Alias for backward compatibility
+

--- a/src/types/coach.ts
+++ b/src/types/coach.ts
@@ -1,15 +1,21 @@
 
 import { ReactNode } from 'react';
 
+/**
+ * Message échangé entre l'utilisateur et le coach IA.
+ */
 export interface ChatMessage {
   id: string;
-  text?: string;
-  content?: string;
-  sender: string;
-  sender_type?: string;
-  timestamp?: string;
-  conversation_id?: string;
-  role?: string;
+  /** Contenu textuel du message */
+  content: string;
+  /** Expéditeur du message */
+  sender: 'user' | 'coach' | 'system' | string;
+  /** Date d'envoi */
+  timestamp: string | Date;
+  /** Indique si le message est en cours de génération */
+  isLoading?: boolean;
+  /** Métadonnées libres */
+  metadata?: Record<string, any>;
 }
 
 export interface CoachCharacterProps {
@@ -32,3 +38,36 @@ export interface CoachChatProps {
   showInput?: boolean;
   embedded?: boolean;
 }
+
+/**
+ * Conversation complète regroupant une liste de messages.
+ */
+export interface Conversation {
+  id: string;
+  title: string;
+  messages: ChatMessage[];
+  createdAt: Date | string;
+  lastUpdated: Date | string;
+}
+
+/**
+ * Session de coaching contenant plusieurs conversations d'un utilisateur.
+ */
+export interface CoachSession {
+  id: string;
+  userId: string;
+  conversations: Conversation[];
+  startedAt: Date | string;
+  endedAt?: Date | string;
+}
+
+/**
+ * Suggestion de ressource ou d'action proposée par le coach.
+ */
+export interface Suggestion {
+  id: string;
+  content: string;
+  category: string;
+  createdAt: Date | string;
+}
+

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,9 @@ export * from './emotional-data';
 // Export chat types
 export * from './chat';
 
+// Export coach types
+export * from './coach';
+
 // Export VR types
 export * from './vr';
 


### PR DESCRIPTION
## Summary
- centralize coach & chat types
- export coach types from index
- document Coach module architecture
- add minimal Coach context test
- update CHANGELOG

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check`
- `npm test` *(fails: Cannot find package 'ts-node')*