### PR TITLE
Refactor user preferences types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 Toutes les modifications notables apportées à ce projet seront documentées dans ce fichier.
 
+## [1.1.2] - 2025-05-19
+
+### Modifié
+- Centralisation du typage des préférences utilisateur.
+- Ajout d'`AccessibilityPreferences` et uniformisation des imports.
+- Ajout d'une documentation d'audit du module de préférences utilisateur.
+
 ## [1.1.1] - 2025-05-19
 
 ### Corrigé

--- a/docs/user-preferences-audit.md
+++ b/docs/user-preferences-audit.md
@@ -1,0 +1,27 @@
+# Audit du module de préférences utilisateur
+
+## Structure actuelle
+
+- `src/contexts/UserPreferencesContext.tsx` expose les préférences mais un ancien `PreferencesContext` demeure.
+- Les types `UserPreferences` et associés existaient à la fois dans `src/types/user.ts` et `src/types/preferences.ts`.
+- Le contexte gère l'état en mémoire sans persistance automatique.
+
+## Problèmes identifiés
+
+1. **Duplication de types** entraînant des imports incohérents.
+2. **Risque de contextes multiples** (`PreferencesContext` vs `UserPreferencesContext`).
+3. **Couverture de test limitée** sur la logique de normalisation.
+4. **Persistance minimale** des préférences côté client.
+
+## Correctifs appliqués
+
+- Centralisation des interfaces dans `src/types/preferences.ts`.
+- Ajout d'`AccessibilityPreferences` et de la propriété `accessibility` dans `UserPreferences`.
+- Mise à jour des imports et suppression des doublons dans `src/types/user.ts`.
+- Création de tests unitaires basiques pour `normalizePreferences`.
+
+## Recommandations
+
+- Supprimer définitivement `PreferencesContext` pour éviter la divergence d'état.
+- Ajouter une couche de persistance (localStorage ou Supabase) tout en respectant la RGPD.
+- Étendre la couverture de test sur `updatePreferences` et la suppression des préférences.

--- a/docs/user-preferences-context.md
+++ b/docs/user-preferences-context.md
@@ -1,0 +1,40 @@
+# UserPreferencesContext
+
+Ce contexte global centralise l'ensemble des préférences utilisateur.
+Il est déclaré dans `src/contexts/UserPreferencesContext.tsx`.
+
+## API du contexte
+
+```ts
+export interface UserPreferencesContextType {
+  preferences: UserPreferences;
+  theme: string;
+  fontSize: string;
+  language: string;
+  notifications: NotificationsPreferences;
+  privacy: string | PrivacyPreferences;
+  updatePreferences: (preferences: Partial<UserPreferences>) => Promise<void>;
+  resetPreferences?: () => void;
+  isLoading?: boolean;
+  error?: Error | null;
+}
+```
+
+## Flow des données
+
+```mermaid
+flowchart TD
+    C[Composants] -->|useUserPreferences| P(UserPreferencesContext)
+    P --> S((State interne))
+    S -->|updatePreferences| A[API Supabase]
+    A --> S
+```
+
+## Persistance
+
+À ce jour, le provider conserve les préférences en mémoire.
+Pour une meilleure expérience et une conformité RGPD, on recommande d'ajouter :
+
+- Synchronisation avec Supabase pour sauvegarder les modifications.
+- Optionnellement un stockage local (localStorage) pour précharger les préférences.
+- Une méthode de suppression complète des préférences à la demande de l'utilisateur.

--- a/src/components/preferences/DataPrivacySettings.tsx
+++ b/src/components/preferences/DataPrivacySettings.tsx
@@ -3,7 +3,7 @@ import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Control, Controller } from 'react-hook-form'; // Import for form control
-import { UserPreferences } from '@/types/user'; // Assuming this type exists for preferences
+import { UserPreferences } from '@/types/preferences';
 
 export interface DataPrivacyProps {
   className?: string;

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/contexts/AuthContext';
 import { useUserMode } from '@/contexts/UserModeContext';
-import { UserPreferences } from '@/types';
+import { UserPreferences } from '@/types/preferences';
 import { Theme, FontSize, FontFamily } from '@/contexts/ThemeContext';
 
 const OnboardingPage: React.FC = () => {

--- a/src/pages/UserPreferences.tsx
+++ b/src/pages/UserPreferences.tsx
@@ -7,7 +7,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
-import { UserPreferences as UserPreferencesType } from '@/types';
+import { UserPreferences as UserPreferencesType } from '@/types/preferences';
 import { usePreferences } from '@/hooks/usePreferences';
 
 const UserPreferences: React.FC = () => {

--- a/src/tests/preferences.test.ts
+++ b/src/tests/preferences.test.ts
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { normalizePreferences, DEFAULT_PREFERENCES } from '@/types/preferences';
+
+test('normalizePreferences returns defaults when input is null', () => {
+  const prefs = normalizePreferences(null);
+  assert.deepEqual(prefs, {
+    theme: 'system',
+    fontSize: 'medium',
+    language: 'fr',
+    privacy: 'private',
+    notifications: { enabled: true, emailEnabled: true, pushEnabled: false }
+  });
+});
+
+test('normalizePreferences merges provided values', () => {
+  const prefs = normalizePreferences({ theme: 'dark', language: 'en' });
+  assert.equal(prefs.theme, 'dark');
+  assert.equal(prefs.language, 'en');
+  assert.equal(prefs.fontSize, 'medium');
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,13 @@
 
 export type {
   User,
-  UserPreferences,
   UserRole,
   UserWithStatus
 } from './types/user';
+
+export type {
+  UserPreferences,
+} from './types/preferences';
 
 export type {
   UserPreferencesContextType,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,6 +20,7 @@ export * from './vr';
 
 // Export user types
 export * from './user';
+export * from './preferences';
 
 // Export gamification types
 export * from './gamification';

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -55,6 +55,14 @@ export interface PrivacyPreferences {
   profileVisibility?: string;
 }
 
+export interface AccessibilityPreferences {
+  reduceMotion?: boolean;
+  highContrast?: boolean;
+  largeText?: boolean;
+  screenReader?: boolean;
+  [key: string]: boolean | undefined;
+}
+
 export interface UserPreferences {
   theme?: 'light' | 'dark' | 'pastel' | 'system';
   fontSize?: 'small' | 'medium' | 'large' | 'xlarge';
@@ -68,6 +76,7 @@ export interface UserPreferences {
   autoplayMedia?: boolean;
   soundEnabled?: boolean;
   dashboardLayout?: string | object;
+  accessibility?: AccessibilityPreferences;
   onboardingCompleted?: boolean;
   shareData?: boolean;
   anonymizedData?: boolean;
@@ -131,5 +140,6 @@ export const DEFAULT_PREFERENCES: UserPreferences = {
   },
   soundEnabled: false,
   autoplayMedia: true,
-  dashboardLayout: 'default'
+  dashboardLayout: 'default',
+  accessibility: {}
 };

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -1,5 +1,5 @@
 
-import { UserPreferences } from './user';
+import { UserPreferences } from './preferences';
 
 export type FontFamily = 'inter' | 'roboto' | 'system' | 'open-sans' | 'poppins' | 'sans' | 'serif' | 'mono' | 'rounded' | 'monospace' | 'sans-serif' | string;
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,5 +1,6 @@
 
-export type { User, UserPreferences, UserRole } from './user';
+export type { User, UserRole } from './user';
+export type { UserPreferences } from './preferences';
 export type { Badge, Challenge } from './badge';
 export type { ChatMessage, ChatConversation, ChatResponse } from './chat';
 export type { MoodData } from './other';

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,44 +1,11 @@
 
 export type UserRole = 'b2c' | 'b2b_user' | 'b2b_admin' | 'admin' | string;
 
-export interface UserPreferences {
-  theme?: string;
-  fontSize?: string;
-  fontFamily?: string;
-  colorAccent?: string;
-  language?: string;
-  notificationsEnabled?: boolean;
-  emailNotifications?: boolean;
-  soundEffects?: boolean;
-  privacySettings?: PrivacyPreferences;
-  accessibilitySettings?: AccessibilitySettings;
-  dashboardLayout?: Record<string, any>;
-  onboardingCompleted?: boolean;
-  notifications?: {
-    email?: boolean;
-    push?: boolean;
-    sms?: boolean;
-    weekly?: boolean;
-    insights?: boolean;
-  };
-  [key: string]: any;
-}
-
-export interface PrivacyPreferences {
-  shareData?: boolean;
-  anonymizedData?: boolean;
-  analytics?: boolean;
-  marketing?: boolean;
-  [key: string]: boolean | undefined;
-}
-
-export interface AccessibilitySettings {
-  reduceMotion?: boolean;
-  highContrast?: boolean;
-  largeText?: boolean;
-  screenReader?: boolean;
-  [key: string]: boolean | undefined;
-}
+import type {
+  UserPreferences,
+  PrivacyPreferences,
+  AccessibilityPreferences,
+} from './preferences';
 
 export interface User {
   id: string;


### PR DESCRIPTION
## Summary
- centralize all user preference types in `preferences.ts`
- expose accessibility preferences
- update imports and exports for user preference types
- document user preference context and audit findings
- add unit test for `normalizePreferences`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find package 'ts-node')*