### PR TITLE
Add B2B audit doc and centralize types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Toutes les modifications notables apportées à ce projet seront documentées da
 
 ### Modifié
 - Normalisation du `CoachContext` pour utiliser les nouveaux types.
+## [1.1.3] - 2025-05-21
+
+### Ajouté
+- Documentation d'audit du module B2B (`docs/b2b-module-audit.md`).
+- Réexport des types utilisateurs et dashboard dans `types/`.
+
 
 ## [1.1.0] - 2025-05-18
 

--- a/docs/b2b-module-audit.md
+++ b/docs/b2b-module-audit.md
@@ -1,0 +1,38 @@
+# Audit du module B2B
+
+Ce document synthétise l'audit et les ajustements réalisés sur la partie B2B de l'application (connexion, inscription et dashboards utilisateur/administrateur).
+
+## Gestion des rôles et contextes
+
+- Le `AuthContext` centralise l'authentification et expose l'objet `user` contenant la propriété `role`.
+- Le `UserModeContext` conserve le mode sélectionné (B2C, B2B utilisateur, B2B admin) dans `localStorage` pour restaurer l'expérience.
+- Le routage sécurisé s'appuie sur `ProtectedRoute` qui vérifie `user.role` et redirige vers le dashboard adapté.
+
+## ProtectedRoute
+
+- La route protégée s'assure qu'un utilisateur non authentifié est redirigé vers la page de connexion correspondante.
+- En cas de rôle incorrect, l'utilisateur est redirigé vers son propre dashboard.
+
+## Typage centralisé
+
+- Les types liés aux utilisateurs et aux dashboards sont désormais exportés dans `types/user.ts` et `types/dashboard.ts` afin d'être utilisés partout dans le projet.
+- Les définitions initiales restent dans `src/types` mais sont réexportées pour une meilleure visibilité.
+
+## Flux d'inscription et de connexion
+
+- Les pages `src/pages/b2b/user/Login.tsx` et `src/pages/b2b/admin/Login.tsx` utilisent le `AuthContext` pour authentifier puis vérifient le rôle avant de rediriger sur `/b2b/user/dashboard` ou `/b2b/admin/dashboard`.
+- L'inscription côté collaborateur (`Register.tsx`) reste limitée à une demande d'accès et redirige vers la connexion après soumission.
+
+## Sécurité et persistance
+
+- Les sessions sont gérées via Supabase avec écoute d'état dans `AuthContext`.
+- `UserModeContext` garantit la persistance du mode utilisateur sans exposer d'informations sensibles.
+
+## Tests et couverture
+
+- Très peu de tests sont présents. Il est recommandé d'ajouter des tests unitaires sur `AuthContext`, `ProtectedRoute` et les pages de connexion.
+- Des tests end‑to‑end devraient couvrir le parcours complet sélection → connexion → dashboard.
+
+## Documentation complémentaire
+
+- Ce fichier décrit le schéma global du module B2B. Pour plus de détails sur les rôles et routes, consulter `src/router.tsx` et `src/utils/userModeHelpers.ts`.

--- a/types/dashboard.ts
+++ b/types/dashboard.ts
@@ -1,0 +1,1 @@
+export * from '../src/types/dashboard';

--- a/types/user.ts
+++ b/types/user.ts
@@ -1,0 +1,1 @@
+export * from '../src/types/user';


### PR DESCRIPTION
## Summary
- document B2B module audit
- reexport user and dashboard types from root `types/`
- update changelog

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check`
- `npm test` *(fails: Cannot find package 'ts-node')*