### PR TITLE
Improve shell layout structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ Toutes les modifications notables apportées à ce projet seront documentées da
 ### Modifié
 - Normalisation du `CoachContext` pour utiliser les nouveaux types.
 
+## [1.1.3] - 2025-05-21
+
+### Ajouté
+- Composant `AppProviders` regroupant les providers globaux.
+- Types de layout centralisés dans `src/types/layout.ts`.
+- Documentation `docs/layout-shell-audit.md` sur la structure du Shell.
+
+### Modifié
+- `App.tsx` utilise désormais `AppProviders` pour simplifier l'arbre React.
+- `Shell` et `LayoutContext` importent les nouveaux types.
+
 ## [1.1.0] - 2025-05-18
 
 ### Ajouté

--- a/docs/layout-shell-audit.md
+++ b/docs/layout-shell-audit.md
@@ -1,0 +1,33 @@
+# Audit du Shell et du layout global
+
+Ce rapport résume l'analyse du composant `Shell`, de la navigation et de la gestion du contexte global.
+
+## Points observés
+- Deux implémentations de `Shell` existaient (`src/Shell.tsx` et `src/components/Shell.tsx`). La première est utilisée par les pages via l'alias `@/Shell`.
+- `App.tsx` imbriquait plus de huit providers, rendant la lecture difficile.
+- Le `LayoutContext` définissait son type directement dans le fichier.
+
+## Actions réalisées
+- Création d'un composant `AppProviders` (`src/providers/AppProviders.tsx`) qui regroupe les providers globaux dans un seul arbre.
+- Centralisation des types de layout dans `src/types/layout.ts` et utilisation dans `Shell` et `LayoutContext`.
+- Mise à jour de `App.tsx` pour utiliser `AppProviders`, simplifiant la structure du composant racine.
+- Export des nouveaux types via `src/types/index.ts`.
+
+## Hiérarchie des providers
+```
+<AppProviders>
+  ThemeProvider
+    AuthProvider
+      UserPreferencesProvider
+        UserModeProvider
+          MusicProvider
+            OptimizationProvider
+              ExtensionsProvider
+                OrchestrationProvider
+                  {children}
+```
+
+## Recommandations
+- Supprimer l'ancienne implémentation `src/components/Shell.tsx` si elle n'est plus utilisée.
+- Ajouter des tests pour vérifier la disponibilité des contextes dans `Shell`.
+- Documenter les routes principales à l'aide des types présents dans `src/types/navigation.ts`.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,39 +1,18 @@
 
 import { BrowserRouter as Router } from 'react-router-dom';
 import { Toaster } from '@/components/ui/toaster';
-import { AuthProvider } from '@/contexts/AuthContext';
-import { UserModeProvider } from '@/contexts/UserModeContext';
-import { MusicProvider } from '@/contexts/music';
-import { ThemeProvider } from '@/contexts/ThemeContext';
-import { UserPreferencesProvider } from '@/contexts/UserPreferencesContext';
 import AppRouter from '@/AppRouter';
 import RouteDebugger from '@/components/ui/RouteDebugger';
-import { OrchestrationProvider } from '@/contexts/OrchestrationContext';
-import { OptimizationProvider } from '@/providers/OptimizationProvider';
-import { ExtensionsProvider } from '@/providers/ExtensionsProvider';
+import AppProviders from '@/providers/AppProviders';
 
 function App() {
   return (
     <Router>
-      <ThemeProvider>
-        <AuthProvider>
-          <UserPreferencesProvider>
-            <UserModeProvider>
-              <MusicProvider>
-                <OptimizationProvider>
-                  <ExtensionsProvider>
-                    <OrchestrationProvider>
-                      <AppRouter />
-                      <Toaster />
-                      {import.meta.env.DEV && <RouteDebugger />}
-                    </OrchestrationProvider>
-                  </ExtensionsProvider>
-                </OptimizationProvider>
-              </MusicProvider>
-            </UserModeProvider>
-          </UserPreferencesProvider>
-        </AuthProvider>
-      </ThemeProvider>
+      <AppProviders>
+        <AppRouter />
+        <Toaster />
+        {import.meta.env.DEV && <RouteDebugger />}
+      </AppProviders>
     </Router>
   );
 }

--- a/src/Shell.tsx
+++ b/src/Shell.tsx
@@ -9,14 +9,7 @@ import MusicDrawer from './components/music/player/MusicDrawer';
 import { useMusic } from './contexts/music';
 import { useTheme } from './contexts/ThemeContext';
 import ScrollProgress from './components/ui/ScrollProgress';
-
-interface ShellProps {
-  children?: React.ReactNode;
-  hideNav?: boolean;
-  hideFooter?: boolean;
-  immersive?: boolean;
-  className?: string;
-}
+import { ShellProps } from '@/types/layout';
 
 const Shell: React.FC<ShellProps> = ({ 
   children, 

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -8,14 +8,7 @@ import AudioControls from './audio/AudioControls';
 import MusicMiniPlayer from './music/MusicMiniPlayer';
 import { default as MusicDrawer } from './music/player/MusicDrawer';
 import { useMusic } from '@/contexts/music';
-
-interface ShellProps {
-  children?: React.ReactNode;
-  hideNav?: boolean;
-  hideFooter?: boolean;
-  className?: string;
-  immersive?: boolean;
-}
+import { ShellProps } from '@/types/layout';
 
 const Shell: React.FC<ShellProps> = ({ 
   children, 

--- a/src/contexts/LayoutContext.tsx
+++ b/src/contexts/LayoutContext.tsx
@@ -1,12 +1,6 @@
 
 import React, { createContext, useState, useContext } from 'react';
-
-export type LayoutContextType = {
-  sidebarCollapsed: boolean;
-  toggleSidebar: () => void;
-  setSidebarCollapsed: (collapsed: boolean) => void;
-  sidebarOpen?: boolean; // Added for compatibility
-};
+import { LayoutContextType, LayoutProviderProps } from '@/types/layout';
 
 export const LayoutContext = createContext<LayoutContextType>({
   sidebarCollapsed: false,
@@ -15,7 +9,7 @@ export const LayoutContext = createContext<LayoutContextType>({
   sidebarOpen: true,
 });
 
-export const LayoutProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+export const LayoutProvider: React.FC<LayoutProviderProps> = ({ children }) => {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
   const toggleSidebar = () => {

--- a/src/providers/AppProviders.tsx
+++ b/src/providers/AppProviders.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { ThemeProvider } from '@/contexts/ThemeContext';
+import { AuthProvider } from '@/contexts/AuthContext';
+import { UserPreferencesProvider } from '@/contexts/UserPreferencesContext';
+import { UserModeProvider } from '@/contexts/UserModeContext';
+import { MusicProvider } from '@/contexts/music';
+import { OptimizationProvider } from '@/providers/OptimizationProvider';
+import { ExtensionsProvider } from '@/providers/ExtensionsProvider';
+import { OrchestrationProvider } from '@/contexts/OrchestrationContext';
+import { LayoutProviderProps } from '@/types/layout';
+
+/**
+ * Aggregates all global providers used by the application.
+ * This helps keeping App.tsx concise and documents the provider order.
+ */
+const AppProviders: React.FC<LayoutProviderProps> = ({ children }) => (
+  <ThemeProvider>
+    <AuthProvider>
+      <UserPreferencesProvider>
+        <UserModeProvider>
+          <MusicProvider>
+            <OptimizationProvider>
+              <ExtensionsProvider>
+                <OrchestrationProvider>
+                  {children}
+                </OrchestrationProvider>
+              </ExtensionsProvider>
+            </OptimizationProvider>
+          </MusicProvider>
+        </UserModeProvider>
+      </UserPreferencesProvider>
+    </AuthProvider>
+  </ThemeProvider>
+);
+
+export default AppProviders;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,3 +26,7 @@ export * from './user';
 
 // Export gamification types
 export * from './gamification';
+
+// Export navigation and layout types
+export * from './navigation';
+export * from './layout';

--- a/src/types/layout.ts
+++ b/src/types/layout.ts
@@ -1,0 +1,29 @@
+/**
+ * Layout and Shell related types
+ * --------------------------------------
+ * Centralised definitions for layout components and context.
+ */
+import React from 'react';
+
+/** Props for the main Shell layout */
+export interface ShellProps {
+  children?: React.ReactNode;
+  hideNav?: boolean;
+  hideFooter?: boolean;
+  immersive?: boolean;
+  className?: string;
+}
+
+/** Context provided by LayoutProvider */
+export interface LayoutContextType {
+  sidebarCollapsed: boolean;
+  toggleSidebar: () => void;
+  setSidebarCollapsed: (collapsed: boolean) => void;
+  /** True when the sidebar is visible (not collapsed) */
+  sidebarOpen?: boolean;
+}
+
+/** Generic props for layout providers */
+export interface LayoutProviderProps {
+  children: React.ReactNode;
+}


### PR DESCRIPTION
## Summary
- create AppProviders to hold global providers
- centralize ShellProps and LayoutContext types
- update Shell and LayoutContext to use new types
- simplify App.tsx by using AppProviders
- document shell layout audit
- export layout and navigation types from index

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check`
- `npm test`
