### PR TITLE
Fix theme context typing and toast action

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ npm start
 
 EmotionsCare utilise un système de design basé sur Tailwind CSS et Shadcn UI, avec prise en charge des thèmes clairs et sombres. Le thème est configurable par l'utilisateur et peut s'adapter automatiquement aux préférences système.
 
+Le `ThemeContext` expose également des préférences d'accessibilité comme `soundEnabled` et `reduceMotion` ainsi que leurs setters correspondants. Ces valeurs sont définies dans `src/types/theme.ts` et stockées via `useLocalStorage`.
+
 ## Contextes globaux
 
 - **ThemeContext** - Gestion du thème (clair/sombre)

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -42,16 +42,24 @@ const Toast = React.forwardRef<
 });
 Toast.displayName = "Toast";
 
-const ToastAction = React.forwardRef<
-  HTMLButtonElement,
-  React.ButtonHTMLAttributes<HTMLButtonElement>
->(({ className, ...props }, ref) => (
-  <button
-    ref={ref}
-    className={cn("inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary focus:outline-none focus:ring-1 focus:ring-ring disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive", className)}
-    {...props}
-  />
-));
+interface ToastActionProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  altText: string;
+}
+
+const ToastAction = React.forwardRef<HTMLButtonElement, ToastActionProps>(
+  ({ className, altText, ...props }, ref) => (
+    <button
+      ref={ref}
+      aria-label={altText}
+      className={cn(
+        "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary focus:outline-none focus:ring-1 focus:ring-ring disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+);
 ToastAction.displayName = "ToastAction";
 
 const ToastClose = React.forwardRef<

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -4,19 +4,24 @@ import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { Theme, FontFamily, FontSize, ThemeContextType } from '@/types/theme';
 
 // Default values
-const defaultContext: ThemeContextType = { 
+const defaultContext: ThemeContextType = {
   theme: "system",
   setTheme: () => {},
-  toggleTheme: () => {}, 
-  isDark: false, 
+  toggleTheme: () => {},
+  isDark: false,
   isDarkMode: false,
-  fontSize: "medium", 
+  fontSize: "medium",
   setFontSize: () => {},
-  fontFamily: "system", 
+  fontFamily: "system",
   setFontFamily: () => {},
   systemTheme: "light",
+  soundEnabled: false,
+  setSoundEnabled: () => {},
+  reduceMotion: false,
+  setReduceMotion: () => {},
   preferences: {},
-  updatePreferences: () => {}
+  updatePreferences: () => {},
+  getContrastText: () => "#000"
 };
 
 // Create context with default values


### PR DESCRIPTION
## Summary
- complete ThemeContext default values for reduceMotion & sound options
- add altText prop handling to ToastAction
- document theme accessibility prefs in README

## Testing
- `npm run type-check`
- `npm test` *(fails: Cannot find package 'ts-node')*