### PR TITLE
Fix emotion module types

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,20 @@ Un tableau de bord dédié permet aux administrateurs de suivre les incidents et
 Il est accessible via la route `/b2b/admin/security`.
 Tous les utilisateurs disposent d'un widget « Sécurité » dans leurs paramètres pour consulter les dernières alertes.
 
+## Types d'émotion unifiés
+
+Les interfaces `EmotionResult` et `EmotionRecommendation` se trouvent dans `src/types/emotion.ts`.
+Elles sont utilisées par tous les modules de scan et de recommandations. Les champs
+suivants sont disponibles :
+
+- `EmotionResult` : informations détaillées sur l'émotion détectée (confidence,
+  intensity, recommandations, etc.).
+- `EmotionRecommendation` : objet décrivant une action ou une ressource associée
+  à l'émotion (type, titre, description, lien, etc.).
+
+Les mocks du dossier `src/mocks` respectent désormais strictement ces
+définitions pour éviter les erreurs de typage lors du build.
+
 ## Documentation technique
 
 Vous trouverez dans le dossier `src/docs` plusieurs guides détaillés :

--- a/src/components/scan/EmojiEmotionScanner.tsx
+++ b/src/components/scan/EmojiEmotionScanner.tsx
@@ -48,21 +48,21 @@ const EmojiEmotionScanner: React.FC<EmojiEmotionScannerProps> = ({
         text: `Sélection emoji: ${emoji}`,
         recommendations: [
           {
+            id: 'music-recommendation',
             type: 'music',
             title: 'Écoutez de la musique apaisante',
-            description: 'Nous vous recommandons d\'écouter une playlist adaptée à votre émotion.',
+            description: "Nous vous recommandons d'écouter une playlist adaptée à votre émotion.",
             icon: 'music',
-            id: 'music-recommendation',
-            emotion: emotion
-          } as unknown as string,
+            emotion: emotion,
+          },
           {
+            id: 'activity-recommendation',
             type: 'activity',
             title: 'Activité recommandée',
             description: 'Une activité pour vous aider à maintenir ou améliorer votre état émotionnel.',
             icon: 'activity',
-            id: 'activity-recommendation',
-            emotion: emotion
-          } as unknown as string,
+            emotion: emotion,
+          },
         ],
       };
       

--- a/src/components/scan/FacialEmotionScanner.tsx
+++ b/src/components/scan/FacialEmotionScanner.tsx
@@ -97,17 +97,21 @@ const FacialEmotionScanner: React.FC<FacialEmotionScannerProps> = ({
         source: 'facial',
         recommendations: [
           {
+            id: 'facial-music',
             type: 'music',
             title: 'Playlist joyeuse',
             description: 'Des morceaux pour maintenir votre bonne humeur',
-            icon: 'music'
-          } as unknown as string,
+            icon: 'music',
+            emotion: 'happy',
+          },
           {
+            id: 'facial-activity',
             type: 'activity',
             title: 'Activité créative',
             description: 'Profitez de cette énergie positive pour créer quelque chose',
-            icon: 'activity'
-          } as unknown as string
+            icon: 'activity',
+            emotion: 'happy',
+          },
         ]
       };
       

--- a/src/components/scan/LiveVoiceScanner.tsx
+++ b/src/components/scan/LiveVoiceScanner.tsx
@@ -151,17 +151,21 @@ const LiveVoiceScanner: React.FC<LiveVoiceScannerProps> = ({
         duration: scanDuration - timeRemaining,
         recommendations: [
           {
+            id: 'live-music',
             type: 'music',
             title: 'Playlist méditative',
             description: 'Des sons pour maintenir votre état de calme',
-            icon: 'music'
-          } as unknown as string,
+            icon: 'music',
+            emotion: emotion,
+          },
           {
+            id: 'live-activity',
             type: 'activity',
             title: 'Exercice de respiration',
             description: 'Prenez 5 minutes pour approfondir votre état de calme',
-            icon: 'activity'
-          } as unknown as string
+            icon: 'activity',
+            emotion: emotion,
+          },
         ]
       };
       

--- a/src/components/scan/TextEmotionScanner.tsx
+++ b/src/components/scan/TextEmotionScanner.tsx
@@ -44,21 +44,21 @@ const TextEmotionScanner: React.FC<TextEmotionScannerProps> = ({
         text: text,
         recommendations: [
           {
+            id: 'music-recommendation',
             type: 'music',
             title: 'Playlist de réflexion',
             description: 'Une sélection musicale pour accompagner votre réflexion.',
             icon: 'music',
-            id: 'music-recommendation',
-            emotion: 'thoughtful'
-          } as unknown as string,
+            emotion: 'thoughtful',
+          },
           {
+            id: 'activity-recommendation',
             type: 'activity',
             title: 'Journal de pensées',
             description: 'Prenez le temps de noter vos réflexions dans un journal.',
             icon: 'book',
-            id: 'activity-recommendation',
-            emotion: 'thoughtful'
-          } as unknown as string,
+            emotion: 'thoughtful',
+          },
         ],
       };
 

--- a/src/types/emotion.d.ts
+++ b/src/types/emotion.d.ts
@@ -11,13 +11,20 @@ export interface EmotionData {
 
 export interface EmotionResult {
   emotion: string;
-  intensity: number;
   confidence: number;
-  data?: EmotionData[];
+  intensity?: number;
+  secondaryEmotions?: string[];
   timestamp?: string;
-  source?: string;
-  language?: string;
+  source?: 'text' | 'voice' | 'facial' | 'emoji' | 'system' | 'ai';
   text?: string;
+  duration?: number;
+  userId?: string;
+  sessionId?: string;
+  language?: string;
+  data?: EmotionData[];
+  id?: string;
+  primaryEmotion?: string;
+  score?: number;
   feedback?: string;
   recommendations?: EmotionRecommendation[];
   triggers?: string[];
@@ -25,6 +32,11 @@ export interface EmotionResult {
   model?: string;
   raw?: any;
   ai_feedback?: string;
+  emojis?: string[];
+  emotions?: Record<string, number>;
+  date?: string;
+  audioUrl?: string;
+  transcript?: string;
 }
 
 export interface EmotionRecommendation {
@@ -32,9 +44,15 @@ export interface EmotionRecommendation {
   type: string;
   title: string;
   description: string;
-  emotion: string;
-  content: string;
-  category: string;
+  emotion?: string;
+  content?: string;
+  category?: string;
+  action?: string;
+  link?: string;
+  icon?: string;
+  duration?: number;
+  intensity?: 'low' | 'medium' | 'high';
+  tags?: string[];
 }
 
 export interface EmotionTrigger {

--- a/src/types/emotion.ts
+++ b/src/types/emotion.ts
@@ -1,24 +1,60 @@
 
+export interface EmotionData {
+  emotion: string;
+  confidence: number;
+  intensity?: number;
+  valence?: number;
+  arousal?: number;
+  dominance?: number;
+  timestamp?: string;
+}
+
+export interface EmotionRecommendation {
+  id: string;
+  type: string;
+  title: string;
+  description: string;
+  emotion?: string;
+  content?: string;
+  category?: string;
+  action?: string;
+  link?: string;
+  icon?: string;
+  duration?: number;
+  intensity?: 'low' | 'medium' | 'high';
+  tags?: string[];
+}
+
 export interface EmotionResult {
   emotion: string;
   confidence: number;
+  intensity?: number;
   secondaryEmotions?: string[];
-  timestamp: string;
-  source: 'text' | 'voice' | 'facial' | 'emoji' | 'system' | 'ai';
+  timestamp?: string;
+  source?: EmotionSource;
   text?: string;
   duration?: number;
   userId?: string;
   sessionId?: string;
-  
+  language?: string;
+  data?: EmotionData[];
+
   // Extended fields for compatibility
   id?: string;
   primaryEmotion?: string;
   score?: number;
-  intensity?: number;
   feedback?: string;
-  recommendations?: string[];
+  recommendations?: EmotionRecommendation[];
+  triggers?: string[];
+  context?: object;
+  model?: string;
+  raw?: any;
+  ai_feedback?: string;
   emojis?: string[];
+  emotions?: Record<string, number>;
   date?: string; // Date for display
+  audioUrl?: string;
+  transcript?: string;
 }
 
 export type EmotionSource = 'text' | 'voice' | 'facial' | 'emoji' | 'system' | 'ai';
@@ -46,20 +82,6 @@ export interface EmotionalState {
   baseline: string;
   trends: EmotionTrend[];
   recentHistory: EmotionHistoryItem[];
-}
-
-// Extended types for compatibility
-export interface EmotionRecommendation {
-  type: string;
-  title: string;
-  description: string;
-  action?: string;
-  link?: string;
-  icon?: string;
-  id?: string; // Added for compatibility
-  emotion?: string; // Added to fix build errors
-  content?: string; // Added to fix build errors
-  category?: string; // Added to fix build errors
 }
 
 export interface Emotion {


### PR DESCRIPTION
## Summary
- unify EmotionResult and EmotionRecommendation
- update mocks and scanners to use new types
- document new emotion types in README

## Testing
- `npm run type-check`
- `npm test` *(fails: Cannot find package 'ts-node')*