### PR TITLE
Add scalability audit and module registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ Toutes les modifications notables apportées à ce projet seront documentées da
 ### Modifié
 - `README.md` référence désormais ce nouveau document dans la section documentation technique.
 
+## [1.1.7] - 2025-05-25
+
+### Ajouté
+- Rapport `docs/scalability-innovation-audit.md` sur l'évolutivité et l'innovation continue
+- Fichier `docs/module-registry.md` listant les modules et la roadmap technique
+
+### Modifié
+- Mise à jour de `README.md` pour référencer ces nouveaux documents
+
 ## [1.1.4] - 2025-05-22
 
 ### Corrigé

--- a/README.md
+++ b/README.md
@@ -316,6 +316,9 @@ Vous trouverez dans le dossier `src/docs` plusieurs guides détaillés :
 - `RoutingFlow.md` : schéma du flux d'accès (accueil → login → dashboard)
 - `unified-access-adaptive-audit.md` : logique d'accès centralisée et expérience adaptative
 
+Des audits complémentaires sont disponibles dans le dossier `docs` :
+- `scalability-innovation-audit.md` : évolutivité et innovation continue
+- `module-registry.md` : registre des modules et roadmap
 
 ## Équipe et contribution
 

--- a/docs/module-registry.md
+++ b/docs/module-registry.md
@@ -1,0 +1,52 @@
+# Module Registry et Roadmap technique
+
+Ce fichier recense les modules officiels d'EmotionsCare ainsi que les extensions en cours de conception. Il sert de référence pour savoir comment déclarer un nouveau module et suivre la feuille de route technique.
+
+## Modules existants
+
+- **auth** : contexte d'authentification et pages de connexion/inscription
+- **scan** : analyse émotionnelle (texte, voix, expression faciale)
+- **music** : thérapie musicale et lecteur intégré
+- **journal** : journal émotionnel et visualisations
+- **predictive** : tableau de bord d'intelligence prédictive
+- **social** : cocoon communautaire et messagerie
+
+## Modules planifiés ou expérimentaux
+
+- **vr** : sessions de réalité virtuelle
+- **analytics** : tableau de bord RH et suivi des KPIs
+- **coach** : agent conversationnel IA
+- **extensions IA** : intégrations OpenAI/HumeAI avancées
+
+Les modules en phase d'exploration peuvent être placés dans `src/experimental` ou `src/services/experimental`.
+
+## Déclaration d'un nouveau module
+
+1. Créer un dossier `src/components/<module>` pour les composants React.
+2. Ajouter les contextes associés sous `src/contexts/<module>`.
+3. Définir les types dans `types/<module>.ts` et les réexporter via `src/types.ts`.
+4. Documenter la fonctionnalité dans `docs/<module>-module.md` ou une note dans ce fichier.
+5. Enregistrer le module dans ce tableau.
+
+| Module | Statut | Description |
+| ------ | ------ | ----------- |
+| auth | stable | Gestion des utilisateurs |
+| scan | stable | Détection d'émotions |
+| music | stable | Thérapie musicale |
+| journal | stable | Journal émotionnel |
+| predictive | stable | Analytics prédictifs |
+| social | bêta | Cocoon communautaire |
+| vr | planifié | Relaxation VR |
+| analytics | planifié | Dashboard RH complet |
+| coach | expérimental | Coach IA et chat |
+| extensions IA | expérimental | Intégrations rapides d'APIs |
+
+## Roadmap
+
+Une roadmap simplifiée peut être tenue ici ou dans un outil externe. Chaque version majeure doit mentionner :
+
+- Les modules ajoutés ou mis à jour
+- Les APIs intégrées ou dépréciées
+- Les migrations de schéma éventuelles
+
+Ce registre permet d'assurer la traçabilité des évolutions et de vérifier la compatibilité des modules entre eux.

--- a/docs/scalability-innovation-audit.md
+++ b/docs/scalability-innovation-audit.md
@@ -1,0 +1,52 @@
+# Audit "Évolutivité et innovation continue"
+
+Ce document examine la capacité de la plateforme **EmotionsCare** à évoluer rapidement tout en intégrant de nouvelles fonctionnalités ou APIs. Il se base sur la structure actuelle du dépôt.
+
+## 1. Architecture modulaire
+
+- Les composants et contextes sont regroupés par domaine (`src/components`, `src/contexts`, `src/hooks`).
+- `AppProviders` centralise l'injection des providers globaux (`ThemeProvider`, `AuthProvider`, `UserModeProvider`...).
+- Les routes et rôles sont décrits dans `src/types/navigation.ts` et utilisés par `ProtectedRoute`.
+- Les variables de configuration sont rassemblées dans `src/constants` et `src/types`.
+
+**Observation** : cette organisation facilite l'ajout de modules mais la documentation d'extension peut être améliorée.
+
+## 2. Processus CI/CD et automatisation
+
+- Scripts disponibles : `npm run build`, `npm run type-check`, `npm run lint`, `npm run test`.
+- Les tests unitaires couvrent certaines fonctionnalités clés (authentification, coach...).
+- Les workflows CI (non fournis dans ce dépôt) sont prévus pour être intégrés sur GitHub Actions ou Vercel.
+
+**Recommandation** : compléter la configuration CI pour lancer lint, type-check et tests sur chaque PR.
+
+## 3. Support multi‑API et extensions
+
+- Les intégrations OpenAI, Hume AI, MusicGen et Supabase sont prêtes dans `src/services`.
+- Les clés API sont lues depuis `.env.local`.
+- La structure des services permet d'ajouter de nouvelles APIs sans modifier les modules existants.
+
+**Recommandation** : prévoir un dossier `src/services/experimental` pour tester rapidement de nouvelles APIs.
+
+## 4. Roadmap technique et Module Registry
+
+- Il n'existe pas encore de fichier de roadmap centralisée ni de registre de modules.
+- La création d'un fichier `docs/module-registry.md` (voir ci‑joint) permettra de lister les modules officiels et les extensions en préparation.
+
+## 5. Tests et qualité
+
+- `npm run type-check` passe sans erreur.
+- `npm run lint` échoue actuellement dans cet environnement car certaines dépendances manquent (`@eslint/js`).
+
+**Recommandation** : vérifier la configuration ESLint et inclure son exécution dans la CI.
+
+## 6. Facilité d'ajout de modules
+
+- Les modules peuvent être ajoutés sous `src/components/<module>` et `src/contexts/<module>`.
+- Les types associés sont centralisés dans `types/<module>.ts`.
+- La documentation propose déjà un guide d'architecture (`src/docs/ARCHITECTURE.md`).
+
+**Recommandation** : ajouter un template de module dans `docs/module-registry.md` pour un enregistrement rapide.
+
+## Conclusion
+
+La base actuelle permet une bonne évolutivité grâce à la séparation claire des contextes et à l'utilisation de TypeScript. L'ajout d'un **Module Registry**, d'une roadmap technique et d'une CI plus complète renforcera la capacité d'innovation continue de la plateforme.


### PR DESCRIPTION
## Summary
- document scalability & innovation practices
- introduce a module registry
- link new docs in README
- log everything in CHANGELOG

## Testing
- `npm run type-check`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*