### PR TITLE
Fix mock music playlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ Toutes les modifications notables apportées à ce projet seront documentées da
 ### Modifié
 - Mise à jour de `README.md` pour référencer ces nouveaux documents
 
+## [1.1.8] - 2025-05-26
+
+### Corrigé
+- Données mock musicales mises en conformité (`src/data/musicPlaylists.ts`).
+- Ajout des propriétés manquantes `url`, `title` et `creator`.
+
 ## [1.1.4] - 2025-05-22
 
 ### Corrigé

--- a/src/data/musicPlaylists.ts
+++ b/src/data/musicPlaylists.ts
@@ -7,6 +7,7 @@ export const sampleTracks: MusicTrack[] = [
     id: '1',
     title: 'Calm Waters',
     artist: 'Nature Sounds',
+    url: '/sounds/ambient-calm.mp3',
     duration: 180,
     src: '/sounds/ambient-calm.mp3',
     audioUrl: '/sounds/ambient-calm.mp3',
@@ -17,6 +18,7 @@ export const sampleTracks: MusicTrack[] = [
     id: '2',
     title: 'Peaceful Mind',
     artist: 'Meditation Masters',
+    url: '/sounds/welcome.mp3',
     duration: 240,
     src: '/sounds/welcome.mp3',
     audioUrl: '/sounds/welcome.mp3',
@@ -30,9 +32,11 @@ export const defaultPlaylists: MusicPlaylist[] = [
   {
     id: 'calm-playlist',
     name: 'Calming Sounds',
+    title: 'Calming Sounds',
     tracks: sampleTracks,
     description: 'Relaxing sounds to calm your mind',
-    tags: ['calm', 'relax', 'meditation']
+    tags: ['calm', 'relax', 'meditation'],
+    creator: 'EmotionsCare'
   }
 ];
 


### PR DESCRIPTION
## Summary
- add missing `url` and `creator` fields to `sampleTracks` and `defaultPlaylists`
- document mock data fix in changelog

## Testing
- `npm run type-check`