### PR TITLE
Fix notification typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 # Changelog
 Toutes les modifications notables apportées à ce projet seront documentées dans ce fichier.
 
+## [1.1.8] - 2025-05-26
+
+### Corrigé
+- Typage `Notification` complété (`linkTo`, `content`, `date`, `isRead`)
+- Alignement des hooks et services sur ce type unifié
+- Nettoyage des déclarations locales dans `useNotifications`
+
 ## [1.1.5] - 2025-05-23
 
 ### Ajouté

--- a/src/hooks/useNotifications.tsx
+++ b/src/hooks/useNotifications.tsx
@@ -1,17 +1,9 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/hooks/use-toast';
+import { Notification } from '@/types/notifications';
 
-// Types for notifications
-export interface Notification {
-  id: string;
-  type: 'info' | 'warning' | 'success' | 'error' | 'system' | 'invitation' | 'reminder';
-  title: string;
-  message: string;
-  date: string;
-  isRead: boolean;
-  linkTo?: string;
-}
+// Local filter type used by this hook
 
 export type NotificationFilter = 'all' | 'unread' | 'invitation' | 'reminder' | 'system';
 

--- a/src/types/notification.d.ts
+++ b/src/types/notification.d.ts
@@ -63,14 +63,22 @@ export interface NotificationMessage {
 export interface Notification {
   id: string;
   title: string;
-  message: string;
+  /** Main text content of the notification */
+  message?: string;
+  /** Optional alternative content field */
+  content?: string;
   type: string;
   userId: string;
   read: boolean;
+  /** Some hooks also use the `isRead` property */
+  isRead?: boolean;
   createdAt: string;
   timestamp?: string;
+  /** Alternative date field for older components */
+  date?: string;
   action_text?: string;
   action_link?: string;
+  linkTo?: string;
   metadata?: Record<string, any>;
   image?: string;
   icon?: string;

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -44,18 +44,34 @@ export interface NotificationPreference {
 export interface Notification {
   id: string;
   title: string;
-  content: string;
+  /**
+   * Main text of the notification. `message` can also be used by some
+   * components so both are kept.
+   */
+  content?: string;
+  message?: string;
   read: boolean;
+  /**
+   * Some hooks use `isRead` instead of `read`.
+   */
+  isRead?: boolean;
   type: string;
   createdAt: string;
   created_at?: string;
-  userId?: string;
   timestamp?: string;
+  /**
+   * Alternative date field used in older components.
+   */
+  date?: string;
+  userId?: string;
   icon?: string;
   action?: string;
   actionUrl?: string;
+  /**
+   * Optional navigation target.
+   */
+  linkTo?: string;
   category?: string;
-  message?: string; // Ajout pour la compatibilité avec les hooks existants
 }
 
 export type NotificationFilter = string;

--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -27,8 +27,29 @@ export interface Notification {
   type: NotificationType;
   title: string;
   message: string;
+  /**
+   * Optional rich content field used by some hooks
+   */
+  content?: string;
+  /**
+   * Date of creation. Some parts of the code still reference `date`
+   * instead of `timestamp` or `createdAt`.
+   */
+  date?: string;
+  /**
+   * Creation timestamp. Accepts both string and Date for flexibility.
+   */
   timestamp: string | Date;
+  /**
+   * Indicates whether the notification has been read. `isRead` is kept for
+   * backward compatibility with some hooks.
+   */
   read: boolean;
+  isRead?: boolean;
+  /**
+   * Optional navigation link associated with the notification.
+   */
+  linkTo?: string;
   action?: {
     label: string;
     url: string;


### PR DESCRIPTION
## Summary
- align `Notification` type with hooks/services
- remove local interface in `useNotifications` hook
- document notification typing fix in changelog

## Testing
- `npm run type-check`