### PR TITLE
Fix music context types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ Toutes les modifications notables apportées à ce projet seront documentées da
 - Données mock musicales mises en conformité (`src/data/musicPlaylists.ts`).
 - Ajout des propriétés manquantes `url`, `title` et `creator`.
 
+## [1.1.9] - 2025-05-27
+
+### Modifié
+- Ajout de la fonction `convertToPlaylist` dans `musicCompatibility` et nettoyage des imports.
+- Contexte musical enrichi : gestion de l'historique et de la queue (fonctions `addToQueue`, `removeFromQueue`, `clearQueue`).
+- Type `MusicContextType` complété (`setMuted`).
+
 ## [1.1.4] - 2025-05-22
 
 ### Corrigé

--- a/docs/music-module-fix.md
+++ b/docs/music-module-fix.md
@@ -1,0 +1,11 @@
+# Mise à jour du module musique (mai 2025)
+
+Ce bref document résume les corrections effectuées sur la gestion de la musique.
+
+## Correctifs principaux
+
+- Ajout d'une fonction `convertToPlaylist` pour normaliser divers formats de playlists.
+- Le `MusicContext` gère désormais un historique de lecture et expose des fonctions de gestion de la queue (`addToQueue`, `removeFromQueue`, `clearQueue`).
+- Les types ont été alignés avec ces nouvelles fonctionnalités (`setMuted` dans `MusicContextType`).
+
+Ces ajustements améliorent la cohérence du module et préparent l'intégration de nouvelles sources audio.

--- a/src/components/EmotionMusicRecommendations.tsx
+++ b/src/components/EmotionMusicRecommendations.tsx
@@ -6,7 +6,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Music, Play } from 'lucide-react';
 import { MusicPlaylist, EmotionMusicParams } from '@/types/music';
 import { useMusic } from '@/hooks/useMusic';
-import { ensurePlaylist, convertToPlaylist } from '@/utils/musicCompatibility';
+import { ensurePlaylist } from '@/utils/musicCompatibility';
 
 interface EmotionMusicRecommendationsProps {
   emotion: string;

--- a/src/contexts/MusicContext.tsx
+++ b/src/contexts/MusicContext.tsx
@@ -1,6 +1,6 @@
 
 import React, { createContext, useContext, useState, useCallback, useEffect } from 'react';
-import { MusicContextType, MusicTrack, MusicPlaylist, EmotionMusicParams } from '@/types/music';
+import { MusicContextType, MusicTrack, MusicPlaylist, MusicQueueItem, EmotionMusicParams } from '@/types/music';
 import { getPlaylistByEmotion } from '@/data/emotionPlaylists';
 import { mapAudioUrlToUrl } from '@/utils/musicCompatibility';
 
@@ -10,6 +10,7 @@ const defaultMusicState: MusicContextType = {
   currentPlaylist: null,
   playlist: null,
   queue: [],
+  history: [],
   isPlaying: false,
   volume: 0.75,
   muted: false,
@@ -27,6 +28,9 @@ const defaultMusicState: MusicContextType = {
   resumeTrack: () => {},
   previousTrack: () => {},
   nextTrack: () => {},
+  addToQueue: () => {},
+  removeFromQueue: () => {},
+  clearQueue: () => {},
 };
 
 // Create context
@@ -37,7 +41,8 @@ export const MusicProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   // State
   const [currentTrack, setCurrentTrack] = useState<MusicTrack | null>(null);
   const [currentPlaylist, setCurrentPlaylist] = useState<MusicPlaylist | null>(null);
-  const [queue, setQueue] = useState<MusicTrack[]>([]);
+  const [queue, setQueue] = useState<MusicQueueItem[]>([]);
+  const [history, setHistory] = useState<MusicQueueItem[]>([]);
   const [isPlaying, setIsPlaying] = useState(false);
   const [volume, setVolume] = useState(0.75);
   const [muted, setMuted] = useState(false);
@@ -52,11 +57,17 @@ export const MusicProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
   // Functions to control playback
   const playTrack = useCallback((track: MusicTrack) => {
-    // Ensure the track has a url property
     const processedTrack = mapAudioUrlToUrl(track);
     setCurrentTrack(processedTrack);
     setIsPlaying(true);
-  }, []);
+    setHistory(h => [
+      ...h,
+      {
+        ...processedTrack,
+        playlistId: currentPlaylist ? currentPlaylist.id : undefined,
+      },
+    ]);
+  }, [currentPlaylist]);
 
   const pauseTrack = useCallback(() => {
     setIsPlaying(false);
@@ -161,12 +172,31 @@ export const MusicProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     setCurrentTime(time);
   }, []);
 
+  const addToQueue = useCallback(
+    (track: MusicTrack) => {
+      setQueue(q => [
+        ...q,
+        { ...track, playlistId: currentPlaylist ? currentPlaylist.id : undefined }
+      ]);
+    },
+    [currentPlaylist]
+  );
+
+  const removeFromQueue = useCallback((index: number) => {
+    setQueue(q => q.filter((_, i) => i !== index));
+  }, []);
+
+  const clearQueue = useCallback(() => {
+    setQueue([]);
+  }, []);
+
   // Value object to be passed to consumers
   const value: MusicContextType = {
     currentTrack,
     currentPlaylist,
     playlist: currentPlaylist,
     queue,
+    history,
     isPlaying,
     volume,
     muted,
@@ -189,6 +219,9 @@ export const MusicProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     setVolume,
     setMuted,
     seekTo,
+    addToQueue,
+    removeFromQueue,
+    clearQueue,
     setRepeat,
     toggleShuffle,
     toggleRepeat,

--- a/src/types/music.ts
+++ b/src/types/music.ts
@@ -73,6 +73,7 @@ export interface MusicContextType extends MusicState {
 
   // Contrôles
   setVolume?: (volume: number) => void;
+  setMuted?: (muted: boolean) => void;
   toggleMute?: () => void;
   toggleShuffle?: () => void;
   setRepeat?: (mode: 'off' | 'track' | 'playlist') => void;

--- a/src/utils/musicCompatibility.ts
+++ b/src/utils/musicCompatibility.ts
@@ -20,6 +20,23 @@ export function ensurePlaylist(playlist: any): MusicPlaylist {
   return ensuredPlaylist;
 }
 
+// Generic converter to normalize any playlist-like object
+export function convertToPlaylist(data: any): MusicPlaylist {
+  if (!data) {
+    return { id: `playlist-${Date.now()}`, title: 'Playlist', tracks: [] };
+  }
+  // If an array is provided, assume it's a list of tracks
+  if (Array.isArray(data)) {
+    return {
+      id: `playlist-${Date.now()}`,
+      title: 'Playlist',
+      tracks: data.map(ensureTrack)
+    };
+  }
+
+  return ensurePlaylist(data);
+}
+
 // Function to ensure track compatibility
 export function ensureTrack(track: any): MusicTrack {
   if (!track) return {


### PR DESCRIPTION
## Summary
- add convertToPlaylist helper and export
- sync MusicContext with history queue management
- remove unused convertToPlaylist import
- update music types with setMuted
- document music module fixes
- update changelog

## Testing
- `npm run type-check`
