### PR TITLE
Add notes support for music sessions

### DIFF
--- a/src/services/music/session-service.ts
+++ b/src/services/music/session-service.ts
@@ -1,0 +1,29 @@
+import { MusicSession } from '@/types/music';
+
+const sessions: MusicSession[] = [];
+
+export async function createMusicSession(session: Omit<MusicSession, 'id' | 'createdAt' | 'updatedAt'> & { notes?: string }): Promise<MusicSession> {
+  const newSession: MusicSession = {
+    id: Math.random().toString(36).slice(2),
+    createdAt: new Date().toISOString(),
+    ...session,
+  };
+  sessions.push(newSession);
+  return new Promise(resolve => setTimeout(() => resolve(newSession), 300));
+}
+
+export async function updateMusicSession(id: string, updates: Partial<MusicSession>): Promise<MusicSession> {
+  const index = sessions.findIndex(s => s.id === id);
+  if (index === -1) {
+    throw new Error('Session not found');
+  }
+  const updated = { ...sessions[index], ...updates, updatedAt: new Date().toISOString() };
+  sessions[index] = updated;
+  return new Promise(resolve => setTimeout(() => resolve(updated), 300));
+}
+
+export async function getUserMusicSessions(userId: string): Promise<MusicSession[]> {
+  return new Promise(resolve =>
+    setTimeout(() => resolve(sessions.filter(s => s.userId === userId)), 200)
+  );
+}

--- a/src/types/music.d.ts
+++ b/src/types/music.d.ts
@@ -106,3 +106,13 @@ export interface MusicContextType {
   createPlaylist: (name: string, tracks?: MusicTrack[]) => void;
   playEmotion: (emotion: string) => void;
 }
+
+export interface MusicSession {
+  id: string;
+  userId: string;
+  playlistId?: string;
+  trackIds: string[];
+  createdAt: string | Date;
+  updatedAt?: string | Date;
+  notes?: string;
+}

--- a/src/types/music.ts
+++ b/src/types/music.ts
@@ -140,3 +140,13 @@ export interface TrackInfoProps {
   track: MusicTrack | null;
   compact?: boolean;
 }
+
+export interface MusicSession {
+  id: string;
+  userId: string;
+  playlistId?: string;
+  trackIds: string[];
+  createdAt: string | Date;
+  updatedAt?: string | Date;
+  notes?: string;
+}


### PR DESCRIPTION
## Summary
- extend music types with `MusicSession` including `notes`
- implement a demo `session-service` with create/update functions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check`
- `npm test` *(fails: Cannot find package 'ts-node')*