### PR TITLE
Implement basic mode logging with pluggable analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ EmotionsCare est une plateforme SaaS innovante dédiée au bien-être émotionne
 - **Gamification** : Défis, badges et récompenses pour encourager l'engagement
 - **Réalité Virtuelle** : Sessions de relaxation immersives en VR
 - **Cocoon social** : Communauté bienveillante pour partager et progresser ensemble
+- **Traçabilité** : Journalisation anonymisée des sélections de mode avec intégration d'APIs d'analytics
 
 ## Architecture technique
 

--- a/docs/mode-selection-logs.md
+++ b/docs/mode-selection-logs.md
@@ -1,0 +1,13 @@
+# Journalisation de la sélection de mode
+
+Les sélections de mode utilisateur sont enregistrées de manière anonymisée.
+
+- **Emplacement** : les événements sont envoyés via `src/utils/modeSelectionLogger.ts`.
+- **Structure** : chaque log contient:
+  - `mode` : identifiant du mode choisi (`b2c`, `b2b_user`, `b2b_admin`, ...)
+  - `timestamp` : date ISO de la sélection.
+
+Les événements sont transmis à l'API d'analytics configurée (voir `Analytics.setProvider`) uniquement si la préférence
+`privacy.analytics` est activée dans les préférences utilisateur.
+Les autres modules peuvent écouter le changement de mode via `modeEmitter` pour déclencher un onboarding ou des offres
+contextuelles.

--- a/src/contexts/UserModeContext.tsx
+++ b/src/contexts/UserModeContext.tsx
@@ -2,6 +2,7 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { UserModeType } from '@/types/userMode';
 import { normalizeUserMode } from '@/utils/userModeHelpers';
+import { logModeSelection } from '@/utils/modeSelectionLogger';
 
 interface UserModeContextValue {
   userMode: UserModeType;
@@ -40,6 +41,7 @@ export const UserModeProvider: React.FC<UserModeProviderProps> = ({ children }) 
     const normalizedMode = normalizeUserMode(mode) as UserModeType;
     setUserModeState(normalizedMode);
     localStorage.setItem('userMode', normalizedMode);
+    logModeSelection(normalizedMode);
   };
   
   const clearUserMode = () => {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -37,3 +37,7 @@ export { useChat } from './useChat';
 
 // Voice commands exports
 export { useVoiceCommands } from './useVoiceCommands';
+
+// Privacy and feature flag hooks
+export { useAnalyticsConsent } from './useAnalyticsConsent';
+export { useFeatureFlags } from './useFeatureFlags';

--- a/src/hooks/useAnalyticsConsent.ts
+++ b/src/hooks/useAnalyticsConsent.ts
@@ -1,0 +1,17 @@
+import { usePreferences } from '@/contexts/PreferencesContext';
+
+/**
+ * Hook returning whether analytics tracking is allowed according
+ * to the current user privacy preferences.
+ */
+export function useAnalyticsConsent(): boolean {
+  const { privacy } = usePreferences();
+  if (!privacy) return false;
+  if (typeof privacy === 'string') {
+    // simple preset: "private" disables analytics
+    return privacy !== 'private';
+  }
+  return !!privacy.analytics;
+}
+
+export default useAnalyticsConsent;

--- a/src/hooks/useFeatureFlags.ts
+++ b/src/hooks/useFeatureFlags.ts
@@ -1,0 +1,29 @@
+import { useLocalStorage } from './useLocalStorage';
+
+export interface ModeFlags {
+  b2c?: boolean;
+  b2b_user?: boolean;
+  b2b_admin?: boolean;
+}
+
+const DEFAULT_FLAGS: ModeFlags = {
+  b2c: true,
+  b2b_user: true,
+  b2b_admin: true,
+};
+
+/**
+ * Hook managing feature flags for user modes.
+ * Flags are stored in localStorage so they can be toggled at runtime.
+ */
+export function useFeatureFlags() {
+  const [flags, setFlags] = useLocalStorage<ModeFlags>('featureFlags', DEFAULT_FLAGS);
+
+  const setFlag = (name: keyof ModeFlags, value: boolean) => {
+    setFlags(prev => ({ ...prev, [name]: value }));
+  };
+
+  return { flags, setFlag };
+}
+
+export default useFeatureFlags;

--- a/src/tests/modeSelectionLogger.test.ts
+++ b/src/tests/modeSelectionLogger.test.ts
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Analytics, AnalyticsProvider } from '@/utils/analytics';
+import { modeEmitter } from '@/utils/modeChangeEmitter';
+import { logModeSelection } from '@/utils/modeSelectionLogger';
+
+// Mock localStorage with analytics enabled
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(global as any).localStorage = {
+  getItem() {
+    return JSON.stringify({ privacy: { analytics: true } });
+  },
+  setItem() {},
+  removeItem() {},
+};
+
+test('logModeSelection emits event and tracks analytics', () => {
+  const events: any[] = [];
+  const received: any[] = [];
+
+  const provider: AnalyticsProvider = {
+    trackPageView: () => {},
+    trackEvent: (cat, act, label) => {
+      events.push({ cat, act, label });
+    },
+  };
+
+  Analytics.setProvider(provider);
+  modeEmitter.on('modeChange', (log) => received.push(log));
+
+  logModeSelection('b2c');
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0].act, 'select');
+  assert.equal(received.length, 1);
+  assert.equal(received[0].mode, 'b2c');
+});

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,29 +1,50 @@
 
 /**
- * Analytics utility module
- * Handles tracking and reporting user interactions in the application
+ * Analytics utility module.
+ * Provides a pluggable provider system so different analytics backends
+ * can be used (Amplitude, Segment, Matomo, ...).
  */
 
-export class Analytics {
-  /**
-   * Initialize analytics tracking
-   */
-  static initialize() {
-    console.log("Analytics initialized");
-    // Actual implementation would connect to an analytics service
+export interface AnalyticsProvider {
+  trackPageView(path: string): void;
+  trackEvent(category: string, action: string, label?: string): void;
+}
+
+/**
+ * Default analytics provider that simply logs to the console.
+ * This keeps analytics fully anonymous while no provider is configured.
+ */
+class ConsoleAnalyticsProvider implements AnalyticsProvider {
+  trackPageView(path: string) {
+    console.log(`[analytics] page: ${path}`);
   }
 
-  /**
-   * Track a page view
-   */
-  static trackPageView(path: string) {
-    console.log(`Page viewed: ${path}`);
-  }
-
-  /**
-   * Track a user event
-   */
-  static trackEvent(category: string, action: string, label?: string) {
-    console.log(`Event tracked: ${category} - ${action} ${label ? '- ' + label : ''}`);
+  trackEvent(category: string, action: string, label?: string) {
+    console.log(`[analytics] event: ${category}/${action}${label ? ' - ' + label : ''}`);
   }
 }
+
+// Current provider instance. Starts with the console provider.
+let provider: AnalyticsProvider = new ConsoleAnalyticsProvider();
+
+export const Analytics = {
+  /**
+   * Replace the analytics provider. This enables plug & play integrations
+   * with any analytics API.
+   */
+  setProvider(newProvider: AnalyticsProvider) {
+    provider = newProvider;
+  },
+
+  /** Track a page view. */
+  trackPageView(path: string) {
+    provider.trackPageView(path);
+  },
+
+  /** Track a user event. */
+  trackEvent(category: string, action: string, label?: string) {
+    provider.trackEvent(category, action, label);
+  },
+};
+
+export type { AnalyticsProvider };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,3 +4,6 @@ export * from './safeOpen';
 export * from './formatDate';
 export * from './roleUtils';
 export * from '@/lib/ai/gdpr-service';
+export * from './analytics';
+export * from './modeChangeEmitter';
+export * from './modeSelectionLogger';

--- a/src/utils/modeChangeEmitter.ts
+++ b/src/utils/modeChangeEmitter.ts
@@ -1,0 +1,7 @@
+import { EventEmitter } from 'events';
+
+/**
+ * Global event emitter used to notify modules when the user mode changes.
+ * Other modules can listen to 'modeChange' to react accordingly.
+ */
+export const modeEmitter = new EventEmitter();

--- a/src/utils/modeSelectionLogger.ts
+++ b/src/utils/modeSelectionLogger.ts
@@ -1,0 +1,38 @@
+import { Analytics } from './analytics';
+import { modeEmitter } from './modeChangeEmitter';
+
+interface ModeLog {
+  mode: string;
+  timestamp: string;
+}
+
+/**
+ * Determine if analytics is enabled based on stored preferences.
+ * This avoids storing any personal data if the user opted out.
+ */
+function analyticsEnabled(): boolean {
+  try {
+    const prefsRaw = localStorage.getItem('userPreferences');
+    if (!prefsRaw) return false;
+    const prefs = JSON.parse(prefsRaw);
+    if (typeof prefs.privacy === 'string') {
+      return prefs.privacy !== 'private';
+    }
+    return !!prefs.privacy?.analytics;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Log a mode selection event in an anonymised way.
+ */
+export function logModeSelection(mode: string) {
+  const log: ModeLog = { mode, timestamp: new Date().toISOString() };
+  if (analyticsEnabled()) {
+    Analytics.trackEvent('mode', 'select', mode);
+    // Additional logging backend could be added here
+  }
+  // Emit event for other modules
+  modeEmitter.emit('modeChange', log);
+}

--- a/src/utils/userModeHelpers.ts
+++ b/src/utils/userModeHelpers.ts
@@ -123,19 +123,20 @@ export const getModeDashboardPath = (mode: UserModeType | string): string => {
 /**
  * Get display name for a user mode
  */
+// Display names for each mode. Can be overridden for i18n.
+let displayNames: Record<string, string> = {
+  b2c: 'Particulier',
+  b2b_admin: 'Administrateur B2B',
+  b2b_user: 'Collaborateur B2B',
+  admin: 'Administrateur',
+  default: 'Utilisateur',
+};
+
+export const setUserModeDisplayNames = (names: Partial<typeof displayNames>) => {
+  displayNames = { ...displayNames, ...names };
+};
+
 export const getUserModeDisplayName = (mode: string): string => {
   const normalizedMode = normalizeUserMode(mode);
-  
-  switch(normalizedMode) {
-    case 'b2c':
-      return 'Particulier';
-    case 'b2b_admin':
-      return 'Administrateur B2B';
-    case 'b2b_user':
-      return 'Collaborateur B2B';
-    case 'admin':
-      return 'Administrateur';
-    default:
-      return 'Utilisateur';
-  }
+  return displayNames[normalizedMode as keyof typeof displayNames] || displayNames.default;
 };


### PR DESCRIPTION
## Summary
- add pluggable analytics provider
- hook user mode changes and emit events
- add privacy-aware mode selection logger
- expose hooks for analytics consent and feature flags
- document where mode logs are stored
- add unit test for logger

## Testing
- `npm test` *(fails: Cannot find package 'ts-node')*