### PR TITLE
Add layout provider and updated shell audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 # Changelog
 Toutes les modifications notables apportées à ce projet seront documentées dans ce fichier.
 
+## [1.1.10] - 2025-05-28
+
+### Ajouté
+- `LayoutProvider` intègre `AppProviders` pour centraliser la gestion du sidebar et du mode plein écran.
+- Rapport d'audit `docs/shell-layout-point4-audit.md` récapitulant la structure du Shell et de la navigation.
+- Test `layoutContextExports.test.ts` vérifiant les exports du contexte de layout.
+
+### Modifié
+- Mise à jour de `docs/layout-shell-audit.md` et `docs/shell-navigation-premium-audit.md` avec la nouvelle hiérarchie des providers.
+- `README.md` référence le nouveau document d'audit et précise l'utilisation de `LayoutProvider`.
+
 ## [1.1.8] - 2025-05-26
 
 ### Corrigé

--- a/README.md
+++ b/README.md
@@ -173,9 +173,9 @@ Le `ThemeContext` expose également des préférences d'accessibilité comme `so
 - **ThemeContext** - Gestion du thème (clair/sombre)
 - **AuthContext** - Authentification et informations utilisateur
 - **UserModeContext** - Mode utilisateur (B2B/B2C)
-- **LayoutContext** - Mise en page et navigation
+- **LayoutContext** - Mise en page et navigation (sidebar, plein écran)
 - **MusicContext** - Lecture et gestion de la musique (source unique via `useMusic`)
-L'ordre d'injection de ces contextes est géré par le composant `AppProviders`. La hiérarchie complète est détaillée dans `docs/layout-shell-audit.md`.
+L'ordre d'injection de ces contextes est géré par le composant `AppProviders`. La hiérarchie complète (avec `LayoutProvider`) est détaillée dans `docs/layout-shell-audit.md` et `docs/shell-navigation-premium-audit.md`.
 
 ## Préférences utilisateur par défaut
 
@@ -323,6 +323,7 @@ Des audits complémentaires sont disponibles dans le dossier `docs` :
 - `module-registry.md` : registre des modules et roadmap
 - `scan-audio-type-fixes.md` : corrections de typage pour les modules scan/audio
 - `ui-polish-restoration.md` : rétablissement de l'apparence initiale
+- `shell-layout-point4-audit.md` : synthèse du Shell et de la navigation (point 4)
 
 
 ## Équipe et contribution

--- a/docs/layout-shell-audit.md
+++ b/docs/layout-shell-audit.md
@@ -24,11 +24,12 @@ Ce rapport résume l'analyse du composant `Shell`, de la navigation et de la ges
     AuthProvider
       UserPreferencesProvider
         UserModeProvider
-          MusicProvider
-            OptimizationProvider
-              ExtensionsProvider
-                OrchestrationProvider
-                  {children}
+          LayoutProvider
+            MusicProvider
+              OptimizationProvider
+                ExtensionsProvider
+                  OrchestrationProvider
+                    {children}
 ```
 
 ## Améliorations parcours B2B

--- a/docs/shell-layout-point4-audit.md
+++ b/docs/shell-layout-point4-audit.md
@@ -1,0 +1,57 @@
+# Audit technique - Point 4 : Shell, layout général et navigation premium
+
+Ce document synthétise l'état actuel du Shell principal et de la navigation.
+Il complète `docs/layout-shell-audit.md` et `docs/shell-navigation-premium-audit.md` en rappelant la hiérarchie des providers et les points vérifiés lors de l'audit.
+
+## Schéma global
+
+```mermaid
+flowchart TD
+    App[App.tsx] --> Providers[AppProviders]
+    Providers --> Shell
+    Shell --> Router[AppRouter]
+    Router --> Pages
+```
+
+`AppProviders` encapsule tous les contextes globaux, désormais y compris `LayoutProvider` pour le sidebar et le mode plein écran.
+
+## Hiérarchie des contextes
+
+1. `ThemeProvider`
+2. `AuthProvider`
+3. `UserPreferencesProvider`
+4. `UserModeProvider`
+5. `LayoutProvider`
+6. `MusicProvider`
+7. `OptimizationProvider`
+8. `ExtensionsProvider`
+9. `OrchestrationProvider`
+10. `OnboardingProvider`
+11. `SupportProvider`
+
+Cette hiérarchie assure que les informations d'authentification, de préférences et de mise en page sont accessibles dans l'ensemble de l'application.
+
+## Navigation et routing
+
+- Le routage principal est géré par `AppRouter` et englobe toutes les routes B2C et B2B.
+- Les layouts B2B utilisent leurs propres composants (`B2BUserLayout`, `B2BAdminLayout`).
+- Les pages publiques et utilitaires sont encapsulées directement dans `Shell`.
+
+## Conventions de typage
+
+- Les interfaces du layout sont définies dans `src/types/layout.ts`.
+- Chaque contexte exporte ses propres types pour éviter le `any`.
+- Les chemins de navigation sont répertoriés dans `src/types/navigation.ts`.
+
+## Points de vérification
+
+- Pas de double layout : `Shell` centralise header, footer et barre de navigation.
+- `AppProviders` injecte les contextes dans l'ordre précisé ci-dessus.
+- Les pages utilisent `Shell` ou un layout B2B pour rester cohérentes.
+- Les tests unitaires valident la présence des exports des contextes.
+
+## Améliorations suggérées
+
+- Charger en lazy loading les modules volumineux (coach, settings).
+- Envisager un store léger pour synchroniser la navigation.
+- Préparer la compatibilité SSR/CSR pour une future migration Next.js.

--- a/docs/shell-navigation-premium-audit.md
+++ b/docs/shell-navigation-premium-audit.md
@@ -31,10 +31,11 @@ Chaque provider se trouve dans `src/contexts` ou `src/providers` :
 2. `AuthProvider`
 3. `UserPreferencesProvider`
 4. `UserModeProvider`
-5. `MusicProvider`
-6. `OptimizationProvider`
-7. `ExtensionsProvider`
-8. `OrchestrationProvider`
+5. `LayoutProvider`
+6. `MusicProvider`
+7. `OptimizationProvider`
+8. `ExtensionsProvider`
+9. `OrchestrationProvider`
 
 Cette hiérarchie garantit que tous les modules héritent des informations de thème, d'authentification et de préférences utilisateur.
 

--- a/src/providers/AppProviders.tsx
+++ b/src/providers/AppProviders.tsx
@@ -5,6 +5,7 @@ import { AuthProvider } from '@/contexts/AuthContext';
 import { UserPreferencesProvider } from '@/contexts/UserPreferencesContext';
 import { UserModeProvider } from '@/contexts/UserModeContext';
 import { MusicProvider } from '@/contexts/music/index';
+import { LayoutProvider } from '@/contexts/LayoutContext';
 import { OptimizationProvider } from '@/providers/OptimizationProvider';
 import { ExtensionsProvider } from '@/providers/ExtensionsProvider';
 import { OrchestrationProvider } from '@/contexts/OrchestrationContext';
@@ -23,20 +24,22 @@ const AppProviders: React.FC<LayoutProviderProps> = ({ children }) => (
     <AuthProvider>
       <UserPreferencesProvider>
         <UserModeProvider>
-          <MusicProvider>
-            <OptimizationProvider>
-              <ExtensionsProvider>
-                <OrchestrationProvider>
-                  <OnboardingProvider steps={DEFAULT_ONBOARDING_STEPS}>
-                    <SupportProvider>
-                      {children}
-                      <Toaster />
-                    </SupportProvider>
-                  </OnboardingProvider>
-                </OrchestrationProvider>
-              </ExtensionsProvider>
-            </OptimizationProvider>
-          </MusicProvider>
+          <LayoutProvider>
+            <MusicProvider>
+              <OptimizationProvider>
+                <ExtensionsProvider>
+                  <OrchestrationProvider>
+                    <OnboardingProvider steps={DEFAULT_ONBOARDING_STEPS}>
+                      <SupportProvider>
+                        {children}
+                        <Toaster />
+                      </SupportProvider>
+                    </OnboardingProvider>
+                  </OrchestrationProvider>
+                </ExtensionsProvider>
+              </OptimizationProvider>
+            </MusicProvider>
+          </LayoutProvider>
         </UserModeProvider>
       </UserPreferencesProvider>
     </AuthProvider>

--- a/src/tests/layoutContextExports.test.ts
+++ b/src/tests/layoutContextExports.test.ts
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { LayoutProvider, useLayout } from '@/contexts/LayoutContext';
+
+// Basic export tests for LayoutContext module
+
+test('LayoutContext exports are available', () => {
+  assert.equal(typeof LayoutProvider, 'function');
+  assert.equal(typeof useLayout, 'function');
+});


### PR DESCRIPTION
## Summary
- integrate `LayoutProvider` into `AppProviders`
- document new provider hierarchy and create point 4 audit doc
- reference audit docs in README
- add test for LayoutContext exports
- update changelog

## Testing
- `npm run type-check`
- `npm run test`
