### PR TITLE
Add SocialCocon context and audit doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Le `ThemeContext` expose également des préférences d'accessibilité comme `so
 - **UserModeContext** - Mode utilisateur (B2B/B2C)
 - **LayoutContext** - Mise en page et navigation (sidebar, plein écran)
 - **MusicContext** - Lecture et gestion de la musique (source unique via `useMusic`)
+- **SocialCoconContext** - Gestion des posts, commentaires et réactions du cocon social
 L'ordre d'injection de ces contextes est géré par le composant `AppProviders`. La hiérarchie complète (avec `LayoutProvider`) est détaillée dans `docs/layout-shell-audit.md` et `docs/shell-navigation-premium-audit.md`.
 
 ## Préférences utilisateur par défaut

--- a/docs/socialcocon-audit.md
+++ b/docs/socialcocon-audit.md
@@ -1,0 +1,42 @@
+# Audit du module SocialCocon
+
+Ce rapport dresse l'état actuel du module SocialCocon et propose une base technique
+pour centraliser la logique du réseau social interne.
+
+## Constat actuel
+
+- Les pages `B2BUserCocon` et `B2BAdminSocialCocon` présentent un exemple de contenu
+  statique sans persistance.
+- Aucun contexte ou provider n'encapsule les interactions sociales.
+- Les types relatifs aux posts ou commentaires ne sont pas regroupés.
+
+## Implémentation minimale
+
+Un `SocialCoconContext` est introduit sous `src/contexts` avec les hooks
+`useSocialCocon`, `addPost`, `likePost`, `addComment` et `getNotifications`.
+Les données sont stockées localement (localStorage) pour illustrer la
+persistance en attendant l'intégration à Supabase ou à une API dédiée.
+Les types stricts sont définis dans `src/types/social.ts`.
+
+```
+SocialCoconProvider
+  └─ exposes posts, addPost, likePost, addComment, getNotifications
+```
+
+Ce provider pourra être injecté au niveau du layout général pour rendre ces
+fonctionnalités accessibles dans l'ensemble de l'application.
+
+## RGPD et évolutions prévues
+
+- Les entités `SocialPost` possèdent un champ `anonymized` pour anticiper
+  l'anonymisation automatique dans les contextes B2B.
+- Le service de notifications expose les données par utilisateur pour
+  faciliter le droit à l'export/suppression.
+- Cette base est prête à accueillir une modération IA, des badges et une
+  gamification plus avancée.
+
+## Tests
+
+Un test `socialCoconContextExports.test.ts` vérifie la présence des exports du
+nouveau contexte. Des tests supplémentaires pourront valider les actions
+(`addPost`, `likePost`, etc.) lorsqu'une librairie de test React sera ajoutée.

--- a/src/contexts/SocialCoconContext.tsx
+++ b/src/contexts/SocialCoconContext.tsx
@@ -1,0 +1,104 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { SocialPost, SocialComment, Reaction, SocialNotification } from '@/types/social';
+
+interface SocialCoconContextType {
+  posts: SocialPost[];
+  addPost: (content: string, userId: string) => void;
+  likePost: (postId: string, userId: string) => void;
+  addComment: (postId: string, content: string, userId: string) => void;
+  getNotifications: (userId: string) => SocialNotification[];
+}
+
+const SocialCoconContext = createContext<SocialCoconContextType>({
+  posts: [],
+  addPost: () => {},
+  likePost: () => {},
+  addComment: () => {},
+  getNotifications: () => []
+});
+
+export const SocialCoconProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [posts, setPosts] = useState<SocialPost[]>([]);
+  const [notifications, setNotifications] = useState<SocialNotification[]>([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('ec_social_posts');
+    if (stored) setPosts(JSON.parse(stored));
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('ec_social_posts', JSON.stringify(posts));
+  }, [posts]);
+
+  const addPost = (content: string, userId: string) => {
+    const newPost: SocialPost = {
+      id: Date.now().toString(),
+      userId,
+      content,
+      createdAt: new Date().toISOString(),
+      comments: [],
+      reactions: []
+    };
+    setPosts(prev => [newPost, ...prev]);
+  };
+
+  const likePost = (postId: string, userId: string) => {
+    setPosts(prev => prev.map(p => {
+      if (p.id !== postId) return p;
+      const existing = p.reactions.find(r => r.userId === userId);
+      if (existing) return p;
+      const reaction: Reaction = {
+        id: Date.now().toString(),
+        postId,
+        userId,
+        type: 'like'
+      };
+      return { ...p, reactions: [...p.reactions, reaction] };
+    }));
+    setNotifications(prev => [
+      ...prev,
+      {
+        id: Date.now().toString(),
+        userId: posts.find(p => p.id === postId)?.userId || '',
+        type: 'like',
+        read: false,
+        createdAt: new Date().toISOString(),
+        data: { postId, from: userId }
+      }
+    ]);
+  };
+
+  const addComment = (postId: string, content: string, userId: string) => {
+    const comment: SocialComment = {
+      id: Date.now().toString(),
+      postId,
+      userId,
+      content,
+      createdAt: new Date().toISOString()
+    };
+    setPosts(prev => prev.map(p => p.id === postId ? { ...p, comments: [...p.comments, comment] } : p));
+    setNotifications(prev => [
+      ...prev,
+      {
+        id: Date.now().toString(),
+        userId: posts.find(p => p.id === postId)?.userId || '',
+        type: 'comment',
+        read: false,
+        createdAt: new Date().toISOString(),
+        data: { postId, from: userId }
+      }
+    ]);
+  };
+
+  const getNotifications = (userId: string) => notifications.filter(n => n.userId === userId);
+
+  return (
+    <SocialCoconContext.Provider value={{ posts, addPost, likePost, addComment, getNotifications }}>
+      {children}
+    </SocialCoconContext.Provider>
+  );
+};
+
+export const useSocialCocon = () => useContext(SocialCoconContext);
+
+export default SocialCoconContext;

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -6,3 +6,4 @@ export { UserPreferencesContext, UserPreferencesProvider, useUserPreferences } f
 export { UserModeProvider, useUserMode } from './UserModeContext';
 export { MusicProvider, useMusic } from './MusicContext';
 export { SidebarProvider, useSidebar } from './SidebarContext';
+export { SocialCoconProvider, useSocialCocon } from './SocialCoconContext';

--- a/src/hooks/useSocialCocon.ts
+++ b/src/hooks/useSocialCocon.ts
@@ -1,0 +1,6 @@
+import { useContext } from 'react';
+import SocialCoconContext from '@/contexts/SocialCoconContext';
+
+export const useSocialCocon = () => useContext(SocialCoconContext);
+
+export default useSocialCocon;

--- a/src/tests/socialCoconContextExports.test.ts
+++ b/src/tests/socialCoconContextExports.test.ts
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { SocialCoconProvider, useSocialCocon } from '@/contexts/SocialCoconContext';
+
+// Basic export tests for SocialCoconContext module
+
+test('SocialCoconContext exports are available', () => {
+  assert.equal(typeof SocialCoconProvider, 'function');
+  assert.equal(typeof useSocialCocon, 'function');
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,5 +13,6 @@ export * from './layout';
 export * from './widget'; // Add if this exists
 export * from './music';
 export * from './onboarding';
+export * from './social';
 export * from '@types/orchestration';
 // Add other type exports as needed

--- a/src/types/social.ts
+++ b/src/types/social.ts
@@ -1,0 +1,42 @@
+export interface SocialPost {
+  id: string;
+  userId: string;
+  content: string;
+  createdAt: string;
+  comments: SocialComment[];
+  reactions: Reaction[];
+  anonymized?: boolean;
+}
+
+export interface SocialComment {
+  id: string;
+  postId: string;
+  userId: string;
+  content: string;
+  createdAt: string;
+}
+
+export interface Reaction {
+  id: string;
+  postId: string;
+  userId: string;
+  type: 'like' | 'love' | 'support';
+}
+
+export interface Badge {
+  id: string;
+  name: string;
+  description?: string;
+  icon?: string;
+  awardedAt?: string;
+  userId?: string;
+}
+
+export interface SocialNotification {
+  id: string;
+  userId: string;
+  type: 'comment' | 'like' | 'badge';
+  read: boolean;
+  data?: Record<string, unknown>;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary
- create SocialCoconContext with basic post/comment state
- add strict SocialPost and related types
- expose the provider via contexts index
- document the new module and update README
- include basic export test

## Testing
- `npm run test`
- `npm run type-check`
