### PR TITLE
Fix home redirect and protect dashboard

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -7,6 +7,7 @@ import { normalizeUserMode, getModeLoginPath, getModeDashboardPath } from '@/uti
 import { motion, AnimatePresence } from 'framer-motion';
 import { Loader2 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
+import { useActivity } from '@/hooks/useActivity';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
@@ -22,6 +23,7 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
   const { user, isAuthenticated, isLoading } = useAuth();
   const location = useLocation();
   const { toast } = useToast();
+  const { logActivity } = useActivity({ anonymize: true });
   const [isTransitioning, setIsTransitioning] = useState(false);
   const [accessDenied, setAccessDenied] = useState(false);
 
@@ -88,6 +90,12 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
       loginPath = getModeLoginPath('b2b_user');
     }
     
+    // Log blocked access attempt for monitoring purposes
+    logActivity('unauthorized_access', {
+      path: location.pathname,
+      timestamp: new Date().toISOString(),
+    });
+
     return (
       <AnimatePresence mode="wait">
         {isTransitioning ? (

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
 import { Link } from 'react-router-dom';
+import { ROUTES } from '@/types/navigation';
 
 const HomePage: React.FC = () => {
   return (
@@ -16,7 +17,8 @@ const HomePage: React.FC = () => {
         
         <div className="flex flex-col sm:flex-row gap-4 justify-center">
           <Button asChild size="lg" className="bg-primary">
-            <Link to="/b2c">Accès Particulier</Link>
+            {/* Redirect individuals to login to enforce authentication */}
+            <Link to={ROUTES.b2c.login}>Accès Particulier</Link>
           </Button>
           <Button asChild size="lg" variant="outline">
             <Link to="/b2b/selection">Accès Entreprise</Link>

--- a/src/pages/ImmersiveHome.tsx
+++ b/src/pages/ImmersiveHome.tsx
@@ -6,6 +6,7 @@ import { useUserMode } from '@/contexts/UserModeContext';
 import { trackEvent, trackPageView } from '@/utils/analytics';
 import { logModeSelection } from '@/utils/modeSelectionLogger';
 import { getModeLabel } from '@/utils/userModeHelpers';
+import { ROUTES } from '@/types/navigation';
 import { Mic, MicOff, Volume, VolumeX, Moon, Sun, Globe } from 'lucide-react';
 import '@/styles/immersive-home.css';
 import { toast } from 'sonner';
@@ -149,6 +150,8 @@ const ImmersiveHome: React.FC = () => {
   };
   
   // Handle user mode selection
+  // Always redirect users to the appropriate login page so that
+  // the dashboard cannot be reached without authentication.
   const handleModeSelect = (mode: 'b2c' | 'b2b-user' | 'b2b-admin') => {
     // Haptic feedback on mobile
     if ('vibrate' in navigator) {
@@ -173,16 +176,17 @@ const ImmersiveHome: React.FC = () => {
     );
     
     // Navigate based on mode
+    // Always redirect to the corresponding login screen
     setTimeout(() => {
-      switch(mode) {
+      switch (mode) {
         case 'b2b-admin':
-          navigate('/b2b/admin/login');
+          navigate(ROUTES.b2bAdmin.login);
           break;
         case 'b2b-user':
-          navigate('/b2b/user/login');
+          navigate(ROUTES.b2bUser.login);
           break;
         case 'b2c':
-          navigate('/b2c');
+          navigate(ROUTES.b2c.login);
           break;
       }
     }, 600);

--- a/src/tests/protectedRoute.test.ts
+++ b/src/tests/protectedRoute.test.ts
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { routes } from '@/router';
+import ProtectedRoute from '@/components/ProtectedRoute';
+
+// Verify that the B2C dashboard is protected by the auth guard
+test('b2c dashboard route is wrapped with ProtectedRoute', () => {
+  const b2cRoute = routes.find(r => r.path === 'b2c');
+  assert.ok(b2cRoute, 'b2c route should exist');
+  assert.equal(b2cRoute!.element.type, ProtectedRoute);
+  const child = b2cRoute!.children?.find(c => c.path === 'dashboard');
+  assert.ok(child, 'dashboard child route should exist');
+});


### PR DESCRIPTION
## Summary
- route "Je suis un particulier" button to login
- enforce login redirection in ImmersiveHome
- log unauthorized dashboard access attempts
- add unit test to ensure dashboard route is protected

## Testing
- `npm test`
- `npm run type-check`
