### PR TITLE
Implement post-login redirect for particuliers

### DIFF
--- a/src/pages/b2c/DashboardPage.tsx
+++ b/src/pages/b2c/DashboardPage.tsx
@@ -36,11 +36,19 @@ const UPCOMING_ACTIVITIES = [
 ];
 
 const B2CDashboardPage: React.FC = () => {
-  const { user } = useAuth();
+  const { user, isLoading } = useAuth();
+  const [isDataLoading, setIsDataLoading] = useState(true);
   const [currentMood, setCurrentMood] = useState<'happy' | 'neutral' | 'sad'>('neutral');
   const [quote, setQuote] = useState("");
   const [showMoodSelector, setShowMoodSelector] = useState(true);
   const { normalizedMode } = useUserModeHelpers();
+
+  useEffect(() => {
+    if (!isLoading && user) {
+      // In a real app this would fetch personalized modules or stats
+      setIsDataLoading(false);
+    }
+  }, [isLoading, user]);
   
   // Set a random inspirational quote on load
   useEffect(() => {
@@ -51,7 +59,15 @@ const B2CDashboardPage: React.FC = () => {
     setCurrentMood(mood);
     setShowMoodSelector(false);
   };
-  
+
+  if (isLoading || isDataLoading) {
+    return (
+      <div className="flex items-center justify-center h-screen">
+        <p className="text-muted-foreground">Chargement du profil...</p>
+      </div>
+    );
+  }
+
   return (
     <div className="min-h-screen bg-background pb-16">
       {/* Header with greeting and user info */}

--- a/src/pages/b2c/Login.tsx
+++ b/src/pages/b2c/Login.tsx
@@ -9,6 +9,7 @@ import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/contexts/AuthContext';
+import { normalizeUserMode } from '@/utils/userModeHelpers';
 import AnimatedFormField from '@/components/auth/AnimatedFormField';
 import B2CAuthLayout from '@/components/auth/B2CAuthLayout';
 import MagicLinkAuth from '@/components/auth/MagicLinkAuth';
@@ -60,15 +61,22 @@ const B2CLoginPage: React.FC = () => {
     setLoading(true);
     
     try {
-      await login(email, password, rememberMe);
-      
-      // Trigger the transition animation
-      setShowTransition(true);
-      
-      // Store a flag in sessionStorage to show transition on page reload if needed
-      sessionStorage.setItem('just_logged_in', 'true');
-      
-      // The navigation will happen after the transition completes
+      const loggedIn = await login(email, password, rememberMe);
+
+      if (loggedIn && normalizeUserMode(loggedIn.role) === 'b2c') {
+        // Trigger the transition animation
+        setShowTransition(true);
+
+        // Store a flag in sessionStorage to show transition on page reload if needed
+        sessionStorage.setItem('just_logged_in', 'true');
+      } else {
+        toast({
+          title: 'Accès non autorisé',
+          description: "Ce compte n'est pas de type particulier",
+          variant: 'destructive'
+        });
+        return;
+      }
     } catch (error: any) {
       console.error('Login error:', error);
       

--- a/src/tests/roleRedirect.test.ts
+++ b/src/tests/roleRedirect.test.ts
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getRoleHomePath } from '@/hooks/use-role-redirect';
+
+// Ensure correct dashboard path for b2c role
+
+test('getRoleHomePath returns b2c dashboard', () => {
+  const path = getRoleHomePath('b2c');
+  assert.equal(path, '/b2c/dashboard');
+});


### PR DESCRIPTION
## Summary
- ensure B2C login only accepts 'particulier' role
- preload user info before rendering dashboard
- show loader while dashboard data loads
- test role helper for B2C path

## Testing
- `npm test`
- `npm run type-check`