### PR TITLE
Enforce B2B entry choice

### DIFF
--- a/src/components/B2BModeGuard.tsx
+++ b/src/components/B2BModeGuard.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useUserMode } from '@/contexts/UserModeContext';
+import { normalizeUserMode } from '@/utils/userModeHelpers';
+
+interface B2BModeGuardProps {
+  children: React.ReactNode;
+  requiredMode?: 'b2b_user' | 'b2b_admin';
+}
+
+const B2BModeGuard: React.FC<B2BModeGuardProps> = ({ children, requiredMode }) => {
+  const { userMode } = useUserMode();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    const normalized = normalizeUserMode(userMode);
+    const expected = requiredMode || (location.pathname.includes('/b2b/admin') ? 'b2b_admin' : 'b2b_user');
+    if (normalized !== expected) {
+      console.warn('[B2BModeGuard] access blocked without valid selection', {
+        path: location.pathname,
+        userMode,
+        expected
+      });
+      navigate('/b2b/selection', { replace: true });
+    }
+  }, [userMode, requiredMode, navigate, location.pathname]);
+
+  return <>{children}</>;
+};
+
+export default B2BModeGuard;

--- a/src/pages/b2b/admin/Login.tsx
+++ b/src/pages/b2b/admin/Login.tsx
@@ -9,6 +9,7 @@ import { Shield, ArrowLeft } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/hooks/use-toast';
+import B2BModeGuard from '@/components/B2BModeGuard';
 
 const B2BAdminLogin = () => {
   const [email, setEmail] = useState('');
@@ -70,6 +71,7 @@ const B2BAdminLogin = () => {
   };
 
   return (
+    <B2BModeGuard requiredMode="b2b_admin">
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-50 to-blue-50/70 p-4 dark:from-slate-900 dark:to-purple-900/20">
       {/* Ambient background */}
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
@@ -172,6 +174,7 @@ const B2BAdminLogin = () => {
         </Card>
       </motion.div>
     </div>
+    </B2BModeGuard>
   );
 };
 

--- a/src/pages/b2b/user/Login.tsx
+++ b/src/pages/b2b/user/Login.tsx
@@ -9,6 +9,7 @@ import { Building, ArrowLeft, ChevronRight, Loader2 } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/hooks/use-toast';
+import B2BModeGuard from '@/components/B2BModeGuard';
 
 const B2BUserLogin = () => {
   const [email, setEmail] = useState('');
@@ -82,6 +83,7 @@ const B2BUserLogin = () => {
   };
 
   return (
+    <B2BModeGuard requiredMode="b2b_user">
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-blue-100/50 p-4 dark:from-slate-900 dark:to-blue-900/20">
       {/* Ambient background with animation */}
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
@@ -244,6 +246,7 @@ const B2BUserLogin = () => {
         </Card>
       </motion.div>
     </div>
+    </B2BModeGuard>
   );
 };
 

--- a/src/tests/userModeHelpers.test.ts
+++ b/src/tests/userModeHelpers.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getModeLoginPath } from '@/utils/userModeHelpers';
+
+test('getModeLoginPath returns admin login path', () => {
+  assert.equal(getModeLoginPath('b2b_admin'), '/b2b/admin/login');
+});
+
+test('getModeLoginPath returns user login path', () => {
+  assert.equal(getModeLoginPath('b2b_user'), '/b2b/user/login');
+});
+
+test('getModeLoginPath falls back to b2c login', () => {
+  assert.equal(getModeLoginPath('unknown'), '/b2c/login');
+});

--- a/src/utils/userModeHelpers.ts
+++ b/src/utils/userModeHelpers.ts
@@ -61,6 +61,26 @@ export const areModesEquivalent = (mode1: string | UserModeType, mode2: string |
 };
 
 /**
+ * Gets the appropriate login path for a given user mode
+ * @param mode The user mode
+ * @returns Login path for the mode
+ */
+export const getModeLoginPath = (mode: string | UserModeType): string => {
+  const normalizedMode = normalizeUserMode(mode);
+
+  switch (normalizedMode) {
+    case 'b2c':
+      return '/b2c/login';
+    case 'b2b_user':
+      return '/b2b/user/login';
+    case 'b2b_admin':
+      return '/b2b/admin/login';
+    default:
+      return '/b2c/login'; // Default fallback
+  }
+};
+
+/**
  * Gets the appropriate dashboard path for a given user mode
  * @param mode The user mode
  * @returns Dashboard path for the mode


### PR DESCRIPTION
## Summary
- require explicit B2B mode selection before login or dashboard access
- add B2BModeGuard component
- guard B2B login pages
- enforce mode in ProtectedRoute
- add helper `getModeLoginPath`
- test login path helper

## Testing
- `npm run test`
- `npm run type-check`
