### PR TITLE
Implement dashboard route guards

### DIFF
--- a/src/pages/DashboardRedirect.tsx
+++ b/src/pages/DashboardRedirect.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useAuth } from '@/contexts/AuthContext';
+import { getModeDashboardPath, getModeLoginPath, normalizeUserMode } from '@/utils/userModeHelpers';
+import { logDashboardAccessDenied } from '@/utils/securityLogs';
+
+/**
+ * Redirects the user to the correct dashboard based on their role.
+ * Unauthenticated users are redirected to the appropriate login page.
+ */
+const DashboardRedirect: React.FC = () => {
+  const { isAuthenticated, user } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      logDashboardAccessDenied(null, location.pathname);
+      navigate(getModeLoginPath('b2c'), { replace: true });
+      return;
+    }
+
+    if (user) {
+      const role = normalizeUserMode(user.role);
+      navigate(getModeDashboardPath(role), { replace: true });
+    }
+  }, [isAuthenticated, user, navigate, location.pathname]);
+
+  return null;
+};
+
+export default DashboardRedirect;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -53,6 +53,7 @@ import B2CRegister from '@/pages/b2c/Register';
 import OnboardingModePage from '@/pages/OnboardingModePage';
 import OnboardingPage from '@/pages/OnboardingPage';
 import OnboardingExperiencePage from '@/pages/OnboardingExperiencePage';
+import DashboardRedirect from '@/pages/DashboardRedirect';
 
 
 // Define the application routes without creating a router instance
@@ -132,6 +133,31 @@ export const routes: RouteObject[] = [
   {
     path: 'b2b/admin/login',
     element: <B2BAdminLogin />
+  },
+  // Generic dashboard redirect
+  {
+    path: 'dashboard',
+    element: (
+      <ProtectedRoute>
+        <DashboardRedirect />
+      </ProtectedRoute>
+    )
+  },
+  {
+    path: 'dashboard-collaborateur',
+    element: (
+      <ProtectedRoute requiredRole="b2b_user">
+        <Navigate to="/b2b/user/dashboard" replace />
+      </ProtectedRoute>
+    )
+  },
+  {
+    path: 'dashboard-admin',
+    element: (
+      <ProtectedRoute requiredRole="b2b_admin">
+        <Navigate to="/b2b/admin/dashboard" replace />
+      </ProtectedRoute>
+    )
   },
   // B2C Protected Routes
   {

--- a/src/tests/securityLogsExports.test.ts
+++ b/src/tests/securityLogsExports.test.ts
@@ -1,0 +1,10 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { logDashboardAccessDenied } from '@/utils/securityLogs';
+
+// Basic export test
+
+test('securityLogs exports logDashboardAccessDenied', () => {
+  assert.equal(typeof logDashboardAccessDenied, 'function');
+});

--- a/src/utils/securityLogs.ts
+++ b/src/utils/securityLogs.ts
@@ -1,0 +1,21 @@
+import { trackEvent } from './analytics';
+
+/**
+ * Log an unauthorized dashboard access attempt.
+ * @param userId Identifier of the user or null for anonymous
+ * @param path URL attempted
+ */
+export function logDashboardAccessDenied(userId: string | null, path: string) {
+  const timestamp = new Date().toISOString();
+  trackEvent('dashboard_access_denied', {
+    properties: {
+      user: userId || 'anonymous',
+      path,
+      timestamp,
+    },
+    anonymous: !userId,
+  });
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(`[SECURITY] Access denied for ${userId || 'anonymous'} on ${path} at ${timestamp}`);
+  }
+}


### PR DESCRIPTION
## Summary
- log unauthorized dashboard access attempts
- redirect `/dashboard` to the proper dashboard based on role
- add guarded alias routes for collaborator and admin dashboards
- export test for securityLogs helper

## Testing
- `npm run test`
- `npm run type-check`