### PR TITLE
B1: enforce backend auth guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ NEXT_PUBLIC_WEB_URL=http://localhost:3000
 
 > **Note**
 > L'ancienne variable `SKIP_AUTH_CHECK` utilisée pour désactiver l'authentification en développement a été supprimée. Les tableaux de bord sont désormais toujours protégés.
+> Toutes les fonctions backend vérifient désormais la session via `requireAuth` dans `supabase/functions/_shared/auth.ts`. Chaque tentative d'accès non authentifiée est enregistrée dans la table `auth_attempts` pour audit.
 
 ### Utilisateurs de test
 

--- a/docs/auth-middleware.md
+++ b/docs/auth-middleware.md
@@ -1,0 +1,19 @@
+# Auth Middleware
+
+Le fichier `supabase/functions/_shared/auth.ts` centralise la vérification d'authentification pour toutes les fonctions Edge.
+
+```ts
+import { requireAuth } from '../_shared/auth.ts';
+```
+
+## Fonction `requireAuth`
+- Récupère le token d'authentification depuis l'en-tête `Authorization` ou le cookie `sb-access-token`.
+- Valide le token via Supabase Auth.
+- Si la session est invalide ou absente, la tentative est enregistrée dans la table `auth_attempts` via `logUnauthorizedAccess`.
+- Retourne l'utilisateur authentifié ou `null`.
+
+## Fonction `logUnauthorizedAccess`
+- Insère un log contenant l'IP, la route et le motif du refus.
+- Permet un audit simple des accès non autorisés.
+
+Toutes les fonctions du répertoire `supabase/functions/` utilisent `requireAuth` pour empêcher l'accès aux tableaux de bord ou aux API sans session valide.

--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -1,17 +1,60 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
+// Centralised Supabase client for edge functions
+
 const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';
 const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY') || '';
 
 const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
+/**
+ * Log unauthorized access attempts for audit purposes.
+ */
+export async function logUnauthorizedAccess(
+  route: string,
+  reason: string,
+  userId: string | null = null,
+  ip: string | null = null
+) {
+  try {
+    await supabase.from('auth_attempts').insert({
+      user_id: userId,
+      route,
+      reason,
+      ip_address: ip,
+    });
+  } catch (logError) {
+    console.error('Failed to log auth attempt:', logError);
+  }
+}
+
+/**
+ * Validate the incoming request using the Authorization header or cookie.
+ * Returns the authenticated user or null if authentication fails.
+ */
 export async function requireAuth(req: Request) {
-  const authHeader = req.headers.get('Authorization') || '';
-  const token = authHeader.replace('Bearer ', '');
-  if (!token) return null;
+  const { pathname } = new URL(req.url);
+  const ip =
+    req.headers.get('x-forwarded-for') ||
+    req.headers.get('x-real-ip') ||
+    null;
+
+  let token = req.headers.get('Authorization')?.replace('Bearer ', '') || '';
+
+  if (!token) {
+    const cookieHeader = req.headers.get('cookie') || '';
+    const match = cookieHeader.match(/sb-access-token=([^;]+)/);
+    if (match) token = match[1];
+  }
+
+  if (!token) {
+    await logUnauthorizedAccess(pathname, 'missing_token', null, ip);
+    return null;
+  }
 
   const { data, error } = await supabase.auth.getUser(token);
   if (error || !data.user) {
+    await logUnauthorizedAccess(pathname, error?.message || 'invalid_token', null, ip);
     console.warn('Authentication failed:', error);
     return null;
   }


### PR DESCRIPTION
## Summary
- log unauthorized access in `requireAuth`
- verify token from Authorization header or cookie
- document new guard in README and docs

## Testing
- `npm run type-check`
- `npm test`