### PR TITLE
Implement role persistence and enforcement

### DIFF
--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -17,3 +17,15 @@ export async function requireAuth(req: Request) {
   }
   return data.user;
 }
+
+export async function requireRole(req: Request, allowedRoles: string | string[]) {
+  const user = await requireAuth(req);
+  if (!user) return null;
+  const roles = Array.isArray(allowedRoles) ? allowedRoles : [allowedRoles];
+  const userRole = (user.user_metadata?.role || '').toLowerCase();
+  if (!roles.map(r => r.toLowerCase()).includes(userRole)) {
+    console.warn('Role mismatch:', { userRole, allowedRoles: roles });
+    return null;
+  }
+  return user;
+}

--- a/supabase/functions/analyze-emotion/index.ts
+++ b/supabase/functions/analyze-emotion/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { requireAuth } from "../_shared/auth.ts";
+import { requireRole } from "../_shared/auth.ts";
 const openAIApiKey = Deno.env.get('OPENAI_API_KEY');
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -12,7 +12,7 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireAuth(req);
+  const user = await requireRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
       status: 401,

--- a/supabase/functions/analyze-journal/index.ts
+++ b/supabase/functions/analyze-journal/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { requireAuth } from '../_shared/auth.ts';
+import { requireRole } from '../_shared/auth.ts';
 const openAIApiKey = Deno.env.get('OPENAI_API_KEY');
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -12,7 +12,7 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireAuth(req);
+  const user = await requireRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
       status: 401,

--- a/supabase/functions/assistant-api/index.ts
+++ b/supabase/functions/assistant-api/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { requireAuth } from '../_shared/auth.ts';
+import { requireRole } from '../_shared/auth.ts';
 const openAIApiKey = Deno.env.get('OPENAI_API_KEY');
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -12,7 +12,7 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireAuth(req);
+  const user = await requireRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
       status: 401,

--- a/supabase/functions/chat-with-ai/index.ts
+++ b/supabase/functions/chat-with-ai/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { requireAuth } from "../_shared/auth.ts";
+import { requireRole } from "../_shared/auth.ts";
 const openAIApiKey = Deno.env.get('OPENAI_API_KEY');
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -15,7 +15,7 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireAuth(req);
+  const user = await requireRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
       status: 401,

--- a/supabase/functions/check-api-connection/index.ts
+++ b/supabase/functions/check-api-connection/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { requireAuth } from '../_shared/auth.ts';
+import { requireRole } from '../_shared/auth.ts';
 const openAIApiKey = Deno.env.get('OPENAI_API_KEY');
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -12,7 +12,7 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireAuth(req);
+  const user = await requireRole(req, ['admin', 'b2b_admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
       status: 401,

--- a/supabase/functions/coach-ai/index.ts
+++ b/supabase/functions/coach-ai/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { requireAuth } from '../_shared/auth.ts';
+import { requireRole } from '../_shared/auth.ts';
 import OpenAI from "https://esm.sh/openai@4.0.0";
 const openAIApiKey = Deno.env.get('OPENAI_API_KEY');
 const corsHeaders = {
@@ -13,7 +13,7 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireAuth(req);
+  const user = await requireRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
       status: 401,

--- a/supabase/functions/enhanced-emotion-analyze/index.ts
+++ b/supabase/functions/enhanced-emotion-analyze/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { requireAuth } from '../_shared/auth.ts';
+import { requireRole } from '../_shared/auth.ts';
 const openAIApiKey = Deno.env.get('OPENAI_API_KEY');
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -12,7 +12,7 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireAuth(req);
+  const user = await requireRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
       status: 401,

--- a/supabase/functions/explain-gdpr/index.ts
+++ b/supabase/functions/explain-gdpr/index.ts
@@ -1,6 +1,6 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { requireAuth } from '../_shared/auth.ts';
+import { requireRole } from '../_shared/auth.ts';
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
@@ -10,7 +10,7 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireAuth(req);
+  const user = await requireRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
       status: 401,

--- a/supabase/functions/gdpr-assistant/index.ts
+++ b/supabase/functions/gdpr-assistant/index.ts
@@ -1,6 +1,6 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { requireAuth } from '../_shared/auth.ts';
+import { requireRole } from '../_shared/auth.ts';
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
@@ -22,7 +22,7 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireAuth(req);
+  const user = await requireRole(req, ['b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
       status: 401,

--- a/supabase/functions/gdpr-request-template/index.ts
+++ b/supabase/functions/gdpr-request-template/index.ts
@@ -1,6 +1,6 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { requireAuth } from '../_shared/auth.ts';
+import { requireRole } from '../_shared/auth.ts';
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
@@ -10,7 +10,7 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireAuth(req);
+  const user = await requireRole(req, ['b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
       status: 401,

--- a/supabase/functions/generate-vr-benefit/index.ts
+++ b/supabase/functions/generate-vr-benefit/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { requireAuth } from '../_shared/auth.ts';
+import { requireRole } from '../_shared/auth.ts';
 const openAIApiKey = Deno.env.get('OPENAI_API_KEY');
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -12,7 +12,7 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireAuth(req);
+  const user = await requireRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
       status: 401,

--- a/supabase/functions/monitor-api-usage/index.ts
+++ b/supabase/functions/monitor-api-usage/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { requireAuth } from '../_shared/auth.ts';
+import { requireRole } from '../_shared/auth.ts';
 const openAIApiKey = Deno.env.get('OPENAI_API_KEY');
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -12,7 +12,7 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireAuth(req);
+  const user = await requireRole(req, ['admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
       status: 401,

--- a/supabase/functions/process-emotion-gamification/index.ts
+++ b/supabase/functions/process-emotion-gamification/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.38.4';
-import { requireAuth } from '../_shared/auth.ts';
+import { requireRole } from '../_shared/auth.ts';
 // Constants and helpers
 const EMOTION_POINTS: Record<string, number> = {
   'happy': 10,
@@ -22,7 +22,7 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireAuth(req);
+  const user = await requireRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
       status: 401,

--- a/supabase/functions/send-invitation/index.ts
+++ b/supabase/functions/send-invitation/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-import { requireAuth } from "../_shared/auth.ts";
+import { requireRole } from "../_shared/auth.ts";
 import { Resend } from "https://esm.sh/resend@2.0.0";
 // Configuration
 const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';
@@ -116,7 +116,7 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   
-  const user = await requireAuth(req);
+  const user = await requireRole(req, ['b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } });
   // Only allow POST for security

--- a/supabase/functions/text-to-voice/index.ts
+++ b/supabase/functions/text-to-voice/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { requireAuth } from '../_shared/auth.ts';
+import { requireRole } from '../_shared/auth.ts';
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
@@ -11,7 +11,7 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
   }
-  const user = await requireAuth(req);
+  const user = await requireRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } });
   try {

--- a/supabase/functions/voice-assistant/index.ts
+++ b/supabase/functions/voice-assistant/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { requireAuth } from '../_shared/auth.ts';
+import { requireRole } from '../_shared/auth.ts';
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
@@ -11,7 +11,7 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireAuth(req);
+  const user = await requireRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
       status: 401,

--- a/supabase/functions/voice-to-text/index.ts
+++ b/supabase/functions/voice-to-text/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { requireAuth } from '../_shared/auth.ts';
+import { requireRole } from '../_shared/auth.ts';
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
@@ -34,7 +34,7 @@ serve(async (req) => {
   // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
-  const user = await requireAuth(req);
+  const user = await requireRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } });
   try {


### PR DESCRIPTION
## Summary
- persist user role in secure cookie during auth flows
- wipe role cookie on signout
- add role-check helper for Supabase functions
- restrict serverless endpoints by role

## Testing
- `npm test`