### PR TITLE
Implement role-based guards for edge functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ NEXT_PUBLIC_WEB_URL=http://localhost:3000
 
 > **Note**
 > L'ancienne variable `SKIP_AUTH_CHECK` utilisée pour désactiver l'authentification en développement a été supprimée. Les tableaux de bord sont désormais toujours protégés.
-> Toutes les fonctions backend vérifient désormais la session via `requireAuth` dans `supabase/functions/_shared/auth.ts`. Chaque tentative d'accès non authentifiée est enregistrée dans la table `auth_attempts` pour audit.
+> Toutes les fonctions backend passent désormais par `authorizeRole` dans `supabase/functions/_shared/auth.ts` pour vérifier l'authentification **et** le rôle. Chaque tentative d'accès refusée est enregistrée dans la table `auth_attempts`.
 
 ### Utilisateurs de test
 

--- a/docs/auth-middleware.md
+++ b/docs/auth-middleware.md
@@ -3,17 +3,16 @@
 Le fichier `supabase/functions/_shared/auth.ts` centralise la vérification d'authentification pour toutes les fonctions Edge.
 
 ```ts
-import { requireAuth } from '../_shared/auth.ts';
+import { authorizeRole } from '../_shared/auth.ts';
 ```
 
-## Fonction `requireAuth`
-- Récupère le token d'authentification depuis l'en-tête `Authorization` ou le cookie `sb-access-token`.
-- Valide le token via Supabase Auth.
-- Si la session est invalide ou absente, la tentative est enregistrée dans la table `auth_attempts` via `logUnauthorizedAccess`.
-- Retourne l'utilisateur authentifié ou `null`.
+## Fonction `authorizeRole`
+- Combine l'authentification et la vérification du rôle.
+- Retourne `{ user, status }` où `status` vaut `401` si la session est invalide ou `403` si le rôle est interdit.
+- Toutes les tentatives refusées sont enregistrées via `logUnauthorizedAccess`.
 
 ## Fonction `logUnauthorizedAccess`
 - Insère un log contenant l'IP, la route et le motif du refus.
 - Permet un audit simple des accès non autorisés.
 
-Toutes les fonctions du répertoire `supabase/functions/` utilisent `requireAuth` pour empêcher l'accès aux tableaux de bord ou aux API sans session valide.
+Toutes les fonctions du répertoire `supabase/functions/` utilisent `authorizeRole` afin de bloquer systématiquement les accès non autorisés.

--- a/docs/responsible-data-audit-point16.md
+++ b/docs/responsible-data-audit-point16.md
@@ -18,7 +18,7 @@ Ce document analyse l’état actuel du dépôt concernant la gestion responsabl
 ## 3. Gestion actuelle des droits et des logs
 
 - Aucun module de journalisation centralisé n’est présent. Les pages admin affichent un tableau d’exemple `AccessLogsTable` avec des données simulées.
-- Les accès aux fonctions Supabase utilisent `requireAuth`, mais il n’existe pas de suivi des actions (export, suppression, etc.).
+- Les accès aux fonctions Supabase utilisent `authorizeRole`, mais il n’existe pas de suivi des actions (export, suppression, etc.).
 
 ## 4. Export, effacement et anonymisation
 

--- a/docs/security-privacy-audit-point12.md
+++ b/docs/security-privacy-audit-point12.md
@@ -18,7 +18,7 @@ Ce document récapitule l'état actuel observé dans le dépôt concernant la s�
 ## 3. Stockage des données et RGPD
 
 - La base de données et l'authentification reposent sur Supabase (`@supabase/supabase-js`).
-- Des fonctions Supabase telles que `gdpr-assistant` et `explain-gdpr` (dossier `supabase/functions/`) offrent une aide liée au RGPD et vérifient l'authentification via `requireAuth`.
+- Des fonctions Supabase telles que `gdpr-assistant` et `explain-gdpr` (dossier `supabase/functions/`) offrent une aide liée au RGPD et vérifient l'authentification et le rôle via `authorizeRole`.
 - Le README mentionne un tableau de bord `/b2b/admin/security` et un widget de suivi des incidents.
 - Aucune stratégie complète de logs ni de stockage chiffré n'est présente dans le code.
 
@@ -26,7 +26,7 @@ Ce document récapitule l'état actuel observé dans le dépôt concernant la s�
 
 1. **Persistance sécurisée des sessions** : prévoir un stockage en cookie `httpOnly` en production pour éviter l'accès JavaScript aux jetons. Actuellement, `localStorage` est utilisé.
 2. **Traçabilité et logs** : aucun module de journalisation centralisé n'est visible. Un service d'audit (logs d'accès, modifications sensibles) devrait être ajouté.
-3. **Règles RLS** : vérifier l'application de RLS sur toutes les tables Supabase. Les fonctions utilisent `requireAuth` mais les règles de base ne sont pas fournies.
+3. **Règles RLS** : vérifier l'application de RLS sur toutes les tables Supabase. Les fonctions utilisent `authorizeRole` mais les règles de base ne sont pas fournies.
 4. **Consentement et export RGPD** : prévoir un module de gestion du consentement et des outils d'export/suppression des données utilisateur.
 5. **MFA** : aucune implémentation de double authentification n'a été identifiée. Une structure pour activer la MFA est recommandée.
 6. **Chiffrement au repos** : la documentation ne précise pas de mécanisme de chiffrement pour les données sensibles. Un chiffrage AES‑24 bits ou supérieur est recommandé.
@@ -35,7 +35,7 @@ Ce document récapitule l'état actuel observé dans le dépôt concernant la s�
 ## 5. Références utiles
 
 - `docs/audit-modules-1-8-summary.md` contient plusieurs remarques RGPD et sécurité pour chaque module de la plateforme.
-- Les fonctions Supabase du dossier `supabase/functions/` montrent l'utilisation de `requireAuth` pour restreindre l'accès aux API.
+- Les fonctions Supabase du dossier `supabase/functions/` montrent l'utilisation de `authorizeRole` pour restreindre l'accès aux API.
 
 ---
 

--- a/docs/security-privacy-point12-ultra-premium.md
+++ b/docs/security-privacy-point12-ultra-premium.md
@@ -14,7 +14,7 @@ les points à renforcer et propose une feuille de route pour atteindre un niveau
   `ProtectedRoute` (`src/components/ProtectedRoute.tsx`).
 - `UserModeContext` permet de distinguer `b2c`, `b2b_user` et `b2b_admin` afin de
   rediriger vers les bons tableaux de bord.
-- Les fonctions Supabase utilisent `requireAuth` (`supabase/functions/_shared/auth.ts`).
+  - Les fonctions Supabase utilisent `authorizeRole` (`supabase/functions/_shared/auth.ts`).
 
 **Recommandation** : centraliser tous les providers d'accès au plus haut niveau
 (Shell) et prévoir un stockage sécurisé des sessions via cookie `httpOnly` en

--- a/docs/security-risk-point22-audit.md
+++ b/docs/security-risk-point22-audit.md
@@ -11,7 +11,7 @@ Ce document détaille l'audit technique de la plateforme **EmotionsCare** pour l
 ## 2. Modules et services observés
 
 - `AuthProvider` et `ProtectedRoute` assurent l'authentification et la restriction par rôle (`b2c`, `b2b_user`, `b2b_admin`).
-- Les fonctions Supabase (`supabase/functions/*`) utilisent `requireAuth` pour contrôler l'accès.
+- Les fonctions Supabase (`supabase/functions/*`) utilisent `authorizeRole` pour contrôler l'accès.
 - `NotificationService` et `AuditLog` ne sont pas encore centralisés dans un service unique.
 
 ## 3. Gestion proactive des risques

--- a/supabase/functions/analyze-emotion/index.ts
+++ b/supabase/functions/analyze-emotion/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { requireRole } from "../_shared/auth.ts";
+import { authorizeRole } from "../_shared/auth.ts";
 const openAIApiKey = Deno.env.get('OPENAI_API_KEY');
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -12,10 +12,10 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
+  const { user, status } = await authorizeRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
+      status,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   try {

--- a/supabase/functions/analyze-journal/index.ts
+++ b/supabase/functions/analyze-journal/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { requireRole } from '../_shared/auth.ts';
+import { authorizeRole } from '../_shared/auth.ts';
 const openAIApiKey = Deno.env.get('OPENAI_API_KEY');
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -12,10 +12,10 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
+  const { user, status } = await authorizeRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
+      status,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   try {

--- a/supabase/functions/assistant-api/index.ts
+++ b/supabase/functions/assistant-api/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { requireRole } from '../_shared/auth.ts';
+import { authorizeRole } from '../_shared/auth.ts';
 const openAIApiKey = Deno.env.get('OPENAI_API_KEY');
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -12,10 +12,10 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
+  const { user, status } = await authorizeRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
+      status,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   try {

--- a/supabase/functions/chat-with-ai/index.ts
+++ b/supabase/functions/chat-with-ai/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { requireRole } from "../_shared/auth.ts";
+import { authorizeRole } from "../_shared/auth.ts";
 const openAIApiKey = Deno.env.get('OPENAI_API_KEY');
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -15,10 +15,10 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
+  const { user, status } = await authorizeRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
+      status,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   try {

--- a/supabase/functions/check-api-connection/index.ts
+++ b/supabase/functions/check-api-connection/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { requireRole } from '../_shared/auth.ts';
+import { authorizeRole } from '../_shared/auth.ts';
 const openAIApiKey = Deno.env.get('OPENAI_API_KEY');
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -12,10 +12,10 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireRole(req, ['admin', 'b2b_admin']);
+  const { user, status } = await authorizeRole(req, ['admin', 'b2b_admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
+      status,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   try {

--- a/supabase/functions/coach-ai/index.ts
+++ b/supabase/functions/coach-ai/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { requireRole } from '../_shared/auth.ts';
+import { authorizeRole } from '../_shared/auth.ts';
 import OpenAI from "https://esm.sh/openai@4.0.0";
 const openAIApiKey = Deno.env.get('OPENAI_API_KEY');
 const corsHeaders = {
@@ -13,10 +13,10 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
+  const { user, status } = await authorizeRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
+      status,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   try {

--- a/supabase/functions/enhanced-emotion-analyze/index.ts
+++ b/supabase/functions/enhanced-emotion-analyze/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { requireRole } from '../_shared/auth.ts';
+import { authorizeRole } from '../_shared/auth.ts';
 const openAIApiKey = Deno.env.get('OPENAI_API_KEY');
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -12,10 +12,10 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
+  const { user, status } = await authorizeRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
+      status,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   try {

--- a/supabase/functions/explain-gdpr/index.ts
+++ b/supabase/functions/explain-gdpr/index.ts
@@ -1,6 +1,6 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { requireRole } from '../_shared/auth.ts';
+import { authorizeRole } from '../_shared/auth.ts';
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
@@ -10,10 +10,10 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
+  const { user, status } = await authorizeRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
+      status,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   try {

--- a/supabase/functions/gdpr-assistant/index.ts
+++ b/supabase/functions/gdpr-assistant/index.ts
@@ -1,6 +1,6 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { requireRole } from '../_shared/auth.ts';
+import { authorizeRole } from '../_shared/auth.ts';
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
@@ -22,10 +22,10 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireRole(req, ['b2b_admin', 'admin']);
+  const { user, status } = await authorizeRole(req, ['b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
+      status,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   try {

--- a/supabase/functions/gdpr-request-template/index.ts
+++ b/supabase/functions/gdpr-request-template/index.ts
@@ -1,6 +1,6 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { requireRole } from '../_shared/auth.ts';
+import { authorizeRole } from '../_shared/auth.ts';
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
@@ -10,10 +10,10 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireRole(req, ['b2b_admin', 'admin']);
+  const { user, status } = await authorizeRole(req, ['b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
+      status,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   try {

--- a/supabase/functions/generate-vr-benefit/index.ts
+++ b/supabase/functions/generate-vr-benefit/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { requireRole } from '../_shared/auth.ts';
+import { authorizeRole } from '../_shared/auth.ts';
 const openAIApiKey = Deno.env.get('OPENAI_API_KEY');
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -12,10 +12,10 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
+  const { user, status } = await authorizeRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
+      status,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   try {

--- a/supabase/functions/monitor-api-usage/index.ts
+++ b/supabase/functions/monitor-api-usage/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { requireRole } from '../_shared/auth.ts';
+import { authorizeRole } from '../_shared/auth.ts';
 const openAIApiKey = Deno.env.get('OPENAI_API_KEY');
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -12,10 +12,10 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireRole(req, ['admin']);
+  const { user, status } = await authorizeRole(req, ['admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
+      status,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   try {

--- a/supabase/functions/process-emotion-gamification/index.ts
+++ b/supabase/functions/process-emotion-gamification/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.38.4';
-import { requireRole } from '../_shared/auth.ts';
+import { authorizeRole } from '../_shared/auth.ts';
 // Constants and helpers
 const EMOTION_POINTS: Record<string, number> = {
   'happy': 10,
@@ -22,10 +22,10 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
+  const { user, status } = await authorizeRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
+      status,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   

--- a/supabase/functions/send-invitation/index.ts
+++ b/supabase/functions/send-invitation/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-import { requireRole } from "../_shared/auth.ts";
+import { authorizeRole } from "../_shared/auth.ts";
 import { Resend } from "https://esm.sh/resend@2.0.0";
 // Configuration
 const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';
@@ -116,9 +116,9 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   
-  const user = await requireRole(req, ['b2b_admin', 'admin']);
+  const { user, status } = await authorizeRole(req, ['b2b_admin', 'admin']);
   if (!user) {
-    return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+    return new Response(JSON.stringify({ error: "Unauthorized" }), { status, headers: { ...corsHeaders, "Content-Type": "application/json" } });
   // Only allow POST for security
   if (req.method !== 'POST') {
       JSON.stringify({ error: 'Méthode non autorisée' }),

--- a/supabase/functions/text-to-voice/index.ts
+++ b/supabase/functions/text-to-voice/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { requireRole } from '../_shared/auth.ts';
+import { authorizeRole } from '../_shared/auth.ts';
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
@@ -11,9 +11,9 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
   }
-  const user = await requireRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
+  const { user, status } = await authorizeRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
   if (!user) {
-    return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+    return new Response(JSON.stringify({ error: "Unauthorized" }), { status, headers: { ...corsHeaders, "Content-Type": "application/json" } });
   try {
     const { text, voice } = await req.json();
     if (!text) {

--- a/supabase/functions/voice-assistant/index.ts
+++ b/supabase/functions/voice-assistant/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { requireRole } from '../_shared/auth.ts';
+import { authorizeRole } from '../_shared/auth.ts';
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
@@ -11,10 +11,10 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-  const user = await requireRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
+  const { user, status } = await authorizeRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
   if (!user) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
+      status,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   try {

--- a/supabase/functions/voice-to-text/index.ts
+++ b/supabase/functions/voice-to-text/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
-import { requireRole } from '../_shared/auth.ts';
+import { authorizeRole } from '../_shared/auth.ts';
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
@@ -34,9 +34,9 @@ serve(async (req) => {
   // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
-  const user = await requireRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
+  const { user, status } = await authorizeRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
   if (!user) {
-    return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+    return new Response(JSON.stringify({ error: "Unauthorized" }), { status, headers: { ...corsHeaders, "Content-Type": "application/json" } });
   try {
     const { audio } = await req.json();
     if (!audio) {


### PR DESCRIPTION
## Summary
- add `authorizeRole` helper that logs role mismatches
- update all edge functions to use `authorizeRole`
- document the new authorization helper
- refresh audit docs

## Testing
- `npm run type-check`
- `npm test` *(fails: getModeLoginPath is defined multiple times)*