### PR TITLE
Add admin team management API and UI

### DIFF
--- a/docs/admin-endpoints.md
+++ b/docs/admin-endpoints.md
@@ -1,0 +1,14 @@
+# Endpoints Admin
+
+Ce document liste les principaux appels back utilisés par le dashboard administration.
+
+## Gestion des équipes
+
+| Action | Endpoint Supabase | Description |
+|-------|------------------|-------------|
+| Lister les équipes | `team-management` action `list` | Retourne l'ensemble des équipes disponibles. |
+| Créer une équipe | `team-management` action `create` | Ajoute une nouvelle équipe. |
+| Mettre à jour une équipe | `team-management` action `update` | Modifie les informations d'une équipe. |
+| Supprimer une équipe | `team-management` action `delete` | Supprime l'équipe ciblée. |
+
+Chaque appel est protégé par `authorizeRole` et nécessite le rôle `b2b_admin` ou `admin`. Les opérations sont journalisées dans la table `admin_logs`.

--- a/src/pages/b2b/admin/Teams.tsx
+++ b/src/pages/b2b/admin/Teams.tsx
@@ -1,17 +1,74 @@
-
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { teamService } from '@/services/teamService';
+import { TeamSummary } from '@/types/dashboard';
+import { useToast } from '@/hooks/use-toast';
 
 const B2BAdminTeams: React.FC = () => {
+  const [teams, setTeams] = useState<TeamSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [newName, setNewName] = useState('');
+  const { toast } = useToast();
+
+  const loadTeams = async () => {
+    setLoading(true);
+    try {
+      const data = await teamService.listTeams();
+      setTeams(data);
+    } catch (e: any) {
+      console.error(e);
+      toast({ title: 'Erreur', description: "Impossible de charger les équipes", variant: 'destructive' });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const addTeam = async () => {
+    if (!newName) return;
+    try {
+      const team = await teamService.createTeam(newName);
+      setTeams((t) => [...t, team]);
+      setNewName('');
+    } catch (e: any) {
+      console.error(e);
+      toast({ title: 'Erreur', description: "Création d'équipe échouée", variant: 'destructive' });
+    }
+  };
+
+  useEffect(() => {
+    loadTeams();
+  }, []);
+
   return (
-    <div className="container mx-auto py-6">
-      <h1 className="text-3xl font-bold mb-6">Gestion des Équipes</h1>
-      <p className="text-muted-foreground mb-4">
-        Gérez vos équipes, visualisez leur bien-être émotionnel et organisez des activités collectives.
-      </p>
-      
-      {/* Content to be implemented */}
-      <div className="p-8 text-center text-muted-foreground">
-        Contenu de gestion des équipes pour le profil administrateur (B2B Admin)
+    <div className="container mx-auto py-6 space-y-4">
+      <h1 className="text-3xl font-bold">Gestion des Équipes</h1>
+      <div className="flex gap-2">
+        <Input placeholder="Nouvelle équipe" value={newName} onChange={(e) => setNewName(e.target.value)} />
+        <Button onClick={addTeam}>Ajouter</Button>
+        <Button variant="outline" onClick={loadTeams} disabled={loading}>Rafraîchir</Button>
+      </div>
+      <div className="mt-4">
+        {loading ? (
+          <p>Chargement...</p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr>
+                <th className="text-left">ID</th>
+                <th className="text-left">Nom</th>
+              </tr>
+            </thead>
+            <tbody>
+              {teams.map((team) => (
+                <tr key={team.id} className="border-t">
+                  <td>{team.id}</td>
+                  <td>{team.name}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
       </div>
     </div>
   );

--- a/src/services/__tests__/teamService.test.ts
+++ b/src/services/__tests__/teamService.test.ts
@@ -1,0 +1,18 @@
+import { vi, describe, it, expect } from 'vitest';
+import { supabase } from '@/integrations/supabase/client';
+import { teamService } from '../teamService';
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    functions: { invoke: vi.fn() }
+  }
+}));
+
+describe('teamService', () => {
+  it('listTeams calls team-management function', async () => {
+    (supabase.functions.invoke as any).mockResolvedValue({ data: { teams: [] }, error: null });
+    const teams = await teamService.listTeams();
+    expect(supabase.functions.invoke).toHaveBeenCalledWith('team-management', { body: { action: 'list', payload: undefined } });
+    expect(teams).toEqual([]);
+  });
+});

--- a/src/services/teamService.ts
+++ b/src/services/teamService.ts
@@ -1,0 +1,38 @@
+import { supabase } from '@/integrations/supabase/client';
+import { TeamSummary } from '@/types/dashboard';
+
+export interface TeamPayload {
+  id?: string;
+  name?: string;
+  fields?: Record<string, any>;
+}
+
+async function invoke(action: string, payload?: TeamPayload) {
+  const { data, error } = await supabase.functions.invoke('team-management', {
+    body: { action, payload }
+  });
+  if (error) throw error;
+  return data;
+}
+
+export const teamService = {
+  async listTeams(): Promise<TeamSummary[]> {
+    const data = await invoke('list');
+    return data?.teams || [];
+  },
+
+  async createTeam(name: string): Promise<TeamSummary> {
+    const data = await invoke('create', { name });
+    return data.team;
+  },
+
+  async updateTeam(id: string, fields: Record<string, any>): Promise<TeamSummary> {
+    const data = await invoke('update', { id, fields });
+    return data.team;
+  },
+
+  async deleteTeam(id: string): Promise<boolean> {
+    await invoke('delete', { id });
+    return true;
+  }
+};

--- a/supabase/functions/team-management/index.ts
+++ b/supabase/functions/team-management/index.ts
@@ -1,0 +1,102 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { authorizeRole } from '../_shared/auth.ts';
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';
+const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') || '';
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+async function listTeams() {
+  const { data, error } = await supabase.from('teams').select('*');
+  if (error) throw error;
+  return data;
+}
+
+async function createTeam(name: string) {
+  const { data, error } = await supabase.from('teams').insert({ name }).select().single();
+  if (error) throw error;
+  return data;
+}
+
+async function updateTeam(id: string, fields: Record<string, any>) {
+  const { data, error } = await supabase.from('teams').update(fields).eq('id', id).select().single();
+  if (error) throw error;
+  return data;
+}
+
+async function deleteTeam(id: string) {
+  const { error } = await supabase.from('teams').delete().eq('id', id);
+  if (error) throw error;
+}
+
+async function logAction(userId: string, action: string, details: string) {
+  try {
+    await supabase.from('admin_logs').insert({ admin_id: userId, action, details });
+  } catch (err) {
+    console.error('Failed to log admin action:', err);
+  }
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const { user, status } = await authorizeRole(req, ['b2b_admin', 'admin']);
+  if (!user) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const { action, payload } = await req.json();
+
+    switch (action) {
+      case 'list':
+        const teams = await listTeams();
+        return new Response(JSON.stringify({ teams }), {
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      case 'create':
+        if (!payload?.name) throw new Error('Name required');
+        const newTeam = await createTeam(payload.name);
+        await logAction(user.id, 'create_team', newTeam.id);
+        return new Response(JSON.stringify({ team: newTeam }), {
+          status: 201,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      case 'update':
+        if (!payload?.id) throw new Error('ID required');
+        const updated = await updateTeam(payload.id, payload.fields || {});
+        await logAction(user.id, 'update_team', payload.id);
+        return new Response(JSON.stringify({ team: updated }), {
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      case 'delete':
+        if (!payload?.id) throw new Error('ID required');
+        await deleteTeam(payload.id);
+        await logAction(user.id, 'delete_team', payload.id);
+        return new Response(JSON.stringify({ success: true }), {
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      default:
+        return new Response(JSON.stringify({ error: 'Unknown action' }), {
+          status: 400,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+    }
+  } catch (error) {
+    console.error('team-management error:', error);
+    return new Response(JSON.stringify({ error: 'Server error', message: error.message }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- implement `team-management` supabase edge function for CRUD on teams
- add `teamService` for frontend API calls with Vitest test
- update admin Teams page to load and create teams
- document admin endpoints

## Testing
- `npm test`