### PR TITLE
Implement B2C dashboard API service

### DIFF
--- a/docs/b2c-dashboard-api.md
+++ b/docs/b2c-dashboard-api.md
@@ -1,0 +1,14 @@
+# API Dashboard Particulier
+
+Ce document récapitule les modules visibles dans le dashboard B2C et l'endpoint Supabase associé. Chaque appel passe par les fonctions Edge et nécessite qu'un utilisateur authentifié possède le rôle **b2c**.
+
+| Module / Bouton | Endpoint Supabase | Description du flux |
+|-----------------|------------------|---------------------|
+| Météo émotionnelle / Scan | `/functions/v1/analyze-emotion` | Analyse du texte, des emojis ou d'un audio pour fournir un score et un feedback personnalisé. |
+| Journal émotionnel | `/functions/v1/analyze-journal` | Enregistre l'entrée de journal et renvoie une analyse IA en français. |
+| Coach IA | `/functions/v1/coach-ai` (action `get_recommendation`) | Envoie la question de l'utilisateur et récupère la réponse du coach. |
+| Musicothérapie | `/functions/v1/coach-ai` (action `generate_music`) | Génère une recommandation ou une playlist adaptée à l'émotion courante. |
+| Export / Reporting | `/functions/v1/enhanced-emotion-analyze` | Prépare un rapport d'activité émotionnelle pouvant être exporté en CSV/PDF. |
+| Feedback & Notifications | `/functions/v1/monitor-api-usage` | Journalise l'action et renvoie un accusé de réception ou une alerte. |
+
+Chaque fonction est protégée par `authorizeRole` et retourne des erreurs JSON explicites (status 4xx/5xx) en cas de problème.

--- a/src/services/b2cDashboardService.ts
+++ b/src/services/b2cDashboardService.ts
@@ -1,0 +1,59 @@
+import { supabase } from '@/integrations/supabase/client';
+
+/**
+ * Service pour centraliser les appels du dashboard particulier
+ */
+export interface AnalyzeEmotionPayload {
+  emojis?: string[];
+  text?: string;
+  audio_url?: string;
+}
+
+export interface AnalyzeEmotionResult {
+  score?: number;
+  ai_feedback: string;
+}
+
+export interface JournalAnalysisResult {
+  ai_feedback: string;
+}
+
+export interface CoachResponse {
+  response: string;
+}
+
+export const b2cDashboardService = {
+  async analyzeEmotion(payload: AnalyzeEmotionPayload): Promise<AnalyzeEmotionResult> {
+    const { data, error } = await supabase.functions.invoke('analyze-emotion', {
+      body: payload,
+    });
+    if (error) throw error;
+    return data as AnalyzeEmotionResult;
+  },
+
+  async analyzeJournal(content: string, journalId?: string): Promise<JournalAnalysisResult> {
+    const { data, error } = await supabase.functions.invoke('analyze-journal', {
+      body: { content, journal_id: journalId },
+    });
+    if (error) throw error;
+    return data as JournalAnalysisResult;
+  },
+
+  async sendCoachMessage(prompt: string, emotion?: string): Promise<CoachResponse> {
+    const { data, error } = await supabase.functions.invoke('coach-ai', {
+      body: { action: 'get_recommendation', prompt, emotion },
+    });
+    if (error) throw error;
+    return data as CoachResponse;
+  },
+
+  async generateMusicRecommendation(emotion: string): Promise<CoachResponse> {
+    const { data, error } = await supabase.functions.invoke('coach-ai', {
+      body: { action: 'generate_music', emotion },
+    });
+    if (error) throw error;
+    return data as CoachResponse;
+  },
+};
+
+export default b2cDashboardService;

--- a/src/tests/b2cDashboardService.test.ts
+++ b/src/tests/b2cDashboardService.test.ts
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import b2cDashboardService from '@/services/b2cDashboardService';
+
+// Ensure main service functions are defined
+
+test('b2cDashboardService exposes expected methods', () => {
+  assert.equal(typeof b2cDashboardService.analyzeEmotion, 'function');
+  assert.equal(typeof b2cDashboardService.analyzeJournal, 'function');
+  assert.equal(typeof b2cDashboardService.sendCoachMessage, 'function');
+  assert.equal(typeof b2cDashboardService.generateMusicRecommendation, 'function');
+});


### PR DESCRIPTION
## Summary
- document supabase endpoints for the B2C dashboard
- add `b2cDashboardService` with calls to edge functions
- test exposure of new service methods

## Testing
- `npm test`