### PR TITLE
Add tests for RBAC enforcement

### DIFF
--- a/src/tests/protectedRouteB2B.test.ts
+++ b/src/tests/protectedRouteB2B.test.ts
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { routes } from '@/router';
+import ProtectedRoute from '@/components/ProtectedRoute';
+
+// Ensure B2B user dashboard route is protected
+
+test('b2b user dashboard route is wrapped with ProtectedRoute', () => {
+  const b2bUserRoute = routes.find(r => r.path === 'b2b/user');
+  assert.ok(b2bUserRoute, 'b2b user route should exist');
+  assert.equal(b2bUserRoute!.element.type, ProtectedRoute);
+  const child = b2bUserRoute!.children?.find(c => c.path === 'dashboard');
+  assert.ok(child, 'dashboard child route should exist');
+});
+
+// Ensure B2B admin dashboard route is protected
+
+test('b2b admin dashboard route is wrapped with ProtectedRoute', () => {
+  const b2bAdminRoute = routes.find(r => r.path === 'b2b/admin');
+  assert.ok(b2bAdminRoute, 'b2b admin route should exist');
+  assert.equal(b2bAdminRoute!.element.type, ProtectedRoute);
+  const child = b2bAdminRoute!.children?.find(c => c.path === 'dashboard');
+  assert.ok(child, 'dashboard child route should exist');
+});

--- a/src/tests/supabaseFunctionsAuth.test.ts
+++ b/src/tests/supabaseFunctionsAuth.test.ts
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+
+const functionsDir = join(process.cwd(), 'supabase', 'functions');
+
+const functionFolders = readdirSync(functionsDir, { withFileTypes: true })
+  .filter(d => d.isDirectory() && d.name !== '_shared')
+  .map(d => d.name);
+
+test('all supabase functions call authorizeRole', () => {
+  for (const folder of functionFolders) {
+    const file = join(functionsDir, folder, 'index.ts');
+    const content = readFileSync(file, 'utf8');
+    assert.ok(/authorizeRole\(/.test(content), `${folder}/index.ts should call authorizeRole`);
+  }
+});


### PR DESCRIPTION
## Summary
- add unit tests for B2B user/admin route protection
- verify all edge functions use `authorizeRole`

## Testing
- `npm test`