### PR TITLE
Implement centralized audit logging

### DIFF
--- a/docs/audit-logging.md
+++ b/docs/audit-logging.md
@@ -1,0 +1,18 @@
+# Journalisation centralisée
+
+Ce projet utilise désormais un module `logAccess` pour tracer tous les accès aux fonctions Edge sensibles. Le helper se trouve dans `supabase/functions/_shared/logging.ts` et écrit dans la table `audit_logs`.
+
+Chaque enregistrement contient :
+
+- `timestamp` : date ISO
+- `user_id` : identifiant de l'utilisateur ou `null`
+- `role` : rôle Supabase lorsqu'il est connu
+- `route` : chemin appelé
+- `action` : type d'action (ex. `access`, `send_invitation`)
+- `result` : `success`, `denied` ou `error`
+- `ip_address` et `user_agent`
+- `details` optionnel
+
+L'appel à `authorizeRole` journalise automatiquement les succès. Les refus sont historisés via `logUnauthorizedAccess`.
+
+Pour consulter les logs, interroger simplement la table `audit_logs` depuis le tableau de bord Supabase ou via une fonction d'export.

--- a/supabase/functions/_shared/logging.ts
+++ b/supabase/functions/_shared/logging.ts
@@ -1,0 +1,28 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';
+const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') || '';
+
+const logClient = createClient(supabaseUrl, serviceKey);
+
+export interface AccessLogEntry {
+  user_id: string | null;
+  role?: string | null;
+  route: string;
+  action: string;
+  result: 'success' | 'denied' | 'error';
+  ip_address?: string | null;
+  user_agent?: string | null;
+  details?: string | null;
+}
+
+export async function logAccess(entry: AccessLogEntry): Promise<void> {
+  try {
+    await logClient.from('audit_logs').insert({
+      ...entry,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error('Failed to log access:', error);
+  }
+}


### PR DESCRIPTION
## Summary
- add `logAccess` helper for Edge functions
- log successful and denied accesses
- record invitation actions in `send-invitation`
- document audit log usage

## Testing
- `npm test`
- `npm run type-check`
- `npm run lint` *(fails: Missing script)*