### PR TITLE
Add critical access log CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Des audits complémentaires sont disponibles dans le dossier `docs` :
 - `shell-layout-point4-audit.md` : synthèse du Shell et de la navigation (point 4)
 - `user-preferences-point7-audit.md` : état actuel des préférences utilisateur et recommandations premium
 - `evaluation-improvement-point20-audit.md` : boucle de feedback et amélioration proactive (point 20)
+- `critical-access-logs-cli.md` : consultation et export des logs d'accès critiques
 
 
 ## Équipe et contribution

--- a/docs/critical-access-logs-cli.md
+++ b/docs/critical-access-logs-cli.md
@@ -1,0 +1,35 @@
+# Consultation des logs d'accès critiques
+
+Le script `scripts/viewCriticalAccessLogs.ts` fournit un accès sécurisé aux journaux
+`access_logs`. Il est destiné aux administrateurs disposant de la clé
+`SUPABASE_SERVICE_ROLE_KEY`.
+
+## Utilisation
+
+```bash
+npx ts-node scripts/viewCriticalAccessLogs.ts --start=2024-01-01 --end=2024-01-31 \
+  --user=123 --action=login --limit=50 --export=janvier.json
+```
+
+Options disponibles :
+
+- `--start` : date minimale (ISO) du log à récupérer
+- `--end` : date maximale
+- `--user` : filtre sur l'identifiant utilisateur
+- `--action` : filtre sur le type d'action ou la route
+- `--limit` : nombre maximum de résultats (100 par défaut)
+- `--export` : chemin du fichier d'export JSON
+
+Chaque exécution enregistre une entrée dans la table `admin_access_logs` afin de
+tracer qui a consulté les journaux et avec quels filtres. Les droits d'accès sont
+restreints à la clé de service et aux rôles administrateurs.
+
+## Procédure d'audit
+
+1. L'administrateur lance le script avec les filtres adaptés à la période ou
+   l'utilisateur cible.
+2. Les données peuvent être exportées pour analyse ou réponse à une demande RGPD.
+3. Une entrée d'audit est automatiquement ajoutée pour conserver la traçabilité.
+
+Cette interface complète les recommandations décrites dans
+`docs/responsible-data-audit-point16.md`.

--- a/scripts/viewCriticalAccessLogs.ts
+++ b/scripts/viewCriticalAccessLogs.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env ts-node
+import { createClient } from '@supabase/supabase-js';
+import { writeFileSync } from 'fs';
+import 'dotenv/config';
+
+export interface CliOptions {
+  start?: string;
+  end?: string;
+  user?: string;
+  action?: string;
+  limit?: number;
+  export?: string;
+}
+
+export function parseArgs(argv: string[]): CliOptions {
+  const opts: CliOptions = {};
+  for (const arg of argv) {
+    if (!arg.startsWith('--')) continue;
+    const [key, value] = arg.slice(2).split('=');
+    switch (key) {
+      case 'start':
+        opts.start = value;
+        break;
+      case 'end':
+        opts.end = value;
+        break;
+      case 'user':
+        opts.user = value;
+        break;
+      case 'action':
+        opts.action = value;
+        break;
+      case 'limit':
+        opts.limit = Number(value);
+        break;
+      case 'export':
+        opts.export = value;
+        break;
+      default:
+        console.warn(`Unknown option ${key}`);
+    }
+  }
+  return opts;
+}
+
+export async function fetchAccessLogs(opts: CliOptions) {
+  const supabaseUrl =
+    process.env.SUPABASE_URL ||
+    process.env.VITE_SUPABASE_URL ||
+    process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    '';
+  const serviceKey =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ||
+    process.env.VITE_SUPABASE_SERVICE_ROLE_KEY ||
+    '';
+
+  if (!supabaseUrl || !serviceKey) {
+    throw new Error('Missing Supabase configuration');
+  }
+
+  const supabase = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false, autoRefreshToken: false }
+  });
+
+  let query = supabase
+    .from('access_logs')
+    .select('*')
+    .order('timestamp', { ascending: false })
+    .limit(opts.limit ?? 100);
+
+  if (opts.start) query = query.gte('timestamp', opts.start);
+  if (opts.end) query = query.lte('timestamp', opts.end);
+  if (opts.user) query = query.eq('user_id', opts.user);
+  if (opts.action) query = query.ilike('action', `%${opts.action}%`);
+
+  const { data, error } = await query;
+  if (error) throw new Error(error.message);
+  return { data, supabase } as const;
+}
+
+async function run() {
+  const opts = parseArgs(process.argv.slice(2));
+  const { data, supabase } = await fetchAccessLogs(opts);
+
+  if (opts.export) {
+    writeFileSync(opts.export, JSON.stringify(data, null, 2));
+    console.log(`Exported ${data.length} logs to ${opts.export}`);
+  } else {
+    console.log(JSON.stringify(data, null, 2));
+  }
+
+  try {
+    await supabase.from('admin_access_logs').insert({
+      admin_id: process.env.ADMIN_ID || 'cli',
+      action: 'fetch_access_logs',
+      timestamp: new Date().toISOString(),
+      details: JSON.stringify(opts)
+    });
+  } catch (err) {
+    console.warn('Failed to record log access:', err);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  run().catch(err => {
+    console.error(err.message);
+    process.exit(1);
+  });
+}

--- a/src/tests/accessLogsCli.test.ts
+++ b/src/tests/accessLogsCli.test.ts
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseArgs } from '../../scripts/viewCriticalAccessLogs';
+
+test('parseArgs extracts options', () => {
+  const opts = parseArgs(['--user=42', '--limit=5', '--action=login']);
+  assert.equal(opts.user, '42');
+  assert.equal(opts.limit, 5);
+  assert.equal(opts.action, 'login');
+});


### PR DESCRIPTION
## Summary
- add `viewCriticalAccessLogs.ts` to query access logs
- document usage in new guide `critical-access-logs-cli.md`
- link guide from README
- test argument parser for the new CLI

## Testing
- `npm test`
- `npm run type-check`
- `npm run lint` *(fails: Missing script)*