### PR TITLE
Fix ts parsing in vitest

### DIFF
--- a/scripts/emergency-install.js
+++ b/scripts/emergency-install.js
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env node
 
 /**

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,6 +30,6 @@ export default defineConfig({
   },
   esbuild: {
     loader: 'tsx',
-    include: /src\/router\/.*\.ts$/,
+    include: /\.[jt]sx?$/,
   },
 });


### PR DESCRIPTION
## Summary
- adjust vitest esbuild config to parse `.ts` files as TSX

## Testing
- `npm run build`
- `npm run test -- --run --environment=jsdom` *(fails: assertion errors but no parse errors)*