### PR TITLE
Fix test utils and security log tests

### DIFF
--- a/src/hooks/__tests__/useMusic.test.ts
+++ b/src/hooks/__tests__/useMusic.test.ts
@@ -1,6 +1,21 @@
 
-import { renderHookWithMusicProvider } from '@/tests/utils';
+import { renderHookWithMusicProvider, renderHook } from '@/tests/utils';
 import { useMusic } from '../useMusic';
+import { vi } from 'vitest';
+
+const mockAudio = {
+  play: vi.fn().mockResolvedValue(undefined),
+  pause: vi.fn(),
+  load: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  volume: 0.7,
+};
+
+Object.defineProperty(window, 'Audio', {
+  writable: true,
+  value: vi.fn().mockImplementation(() => mockAudio),
+});
 
 describe('useMusic', () => {
   test('should initialize with default values', () => {

--- a/src/tests/globalInterceptor.test.tsx
+++ b/src/tests/globalInterceptor.test.tsx
@@ -1,7 +1,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GlobalInterceptor } from '@/utils/globalInterceptor';
-import { mockResponse } from './utils';
+import { mockResponse } from '@/tests/utils';
 
 // Mock du localStorage
 const localStorageMock = {
@@ -55,23 +55,9 @@ describe('GlobalInterceptor', () => {
         access_token: 'expired-token'
       }));
 
-      global.fetch = vi
-        .fn()
-        .mockResolvedValueOnce(
-          mockResponse({ ok: false, status: 401, json: { error: 'Unauthorized' } })
-        )
-        .mockResolvedValueOnce(
-          mockResponse({ ok: false, status: 401, json: { error: 'Unauthorized' } })
-        )
-        .mockResolvedValueOnce(
-          mockResponse({ ok: false, status: 401, json: { error: 'Unauthorized' } })
-        )
-        .mockResolvedValueOnce(
-          mockResponse({ ok: false, status: 401, json: { error: 'Unauthorized' } })
-        )
-        .mockResolvedValueOnce(
-          mockResponse({ ok: false, status: 401, json: { error: 'Unauthorized' } })
-        );
+      global.fetch = vi.fn().mockResolvedValue(
+        mockResponse({ ok: false, status: 401, json: { message: 'unauthorized' } })
+      );
 
       const resultPromise = GlobalInterceptor.secureFetch('/test', {});
       await vi.runAllTimersAsync();

--- a/src/tests/securityLogsExports.test.tsx
+++ b/src/tests/securityLogsExports.test.tsx
@@ -1,3 +1,5 @@
+/* @vitest-environment jsdom */
+
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/src/tests/sessionRedirectLogs.test.tsx
+++ b/src/tests/sessionRedirectLogs.test.tsx
@@ -1,3 +1,5 @@
+/* @vitest-environment jsdom */
+
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/src/tests/utils.tsx
+++ b/src/tests/utils.tsx
@@ -8,6 +8,7 @@ import { UserModeProvider } from '@/contexts/UserModeContext';
 import { MusicProvider } from '@/contexts/MusicContext';
 import { ThemeProvider } from '@/components/theme-provider';
 import { renderHook, RenderHookOptions } from '@testing-library/react';
+import { vi } from 'vitest';
 
 // Create a custom render function that includes providers
 const AllTheProviders = ({ children }: { children: React.ReactNode }) => {
@@ -42,12 +43,15 @@ const customRender = (
 ) => render(ui, { wrapper: AllTheProviders, ...options });
 
 // Create hook render utilities
-export const renderHookWithMusicProvider = <T,>(
+export function renderHookWithMusicProvider<T>(
   callback: () => T,
   options?: Omit<RenderHookOptions<T>, 'wrapper'>
-) => {
-  return renderHook(callback, { wrapper: AllTheProviders, ...options });
-};
+) {
+  return renderHook(callback, {
+    wrapper: ({ children }) => <MusicProvider>{children}</MusicProvider>,
+    ...options,
+  });
+}
 
 export const renderHookWithAuthProvider = <T,>(
   callback: () => T,
@@ -59,3 +63,11 @@ export const renderHookWithAuthProvider = <T,>(
 // Re-export everything
 export * from '@testing-library/react';
 export { customRender as render };
+
+export function mockResponse({ ok = true, status = 200, json }: { ok?: boolean; status?: number; json?: any }) {
+  return {
+    ok,
+    status,
+    json: vi.fn().mockResolvedValue(json),
+  } as any;
+}


### PR DESCRIPTION
TICKET CODEX — PASS 6 « Derniers FAIL : secureFetch, Music Context, routes » (copiez / collez ce bloc tel quel dans la PR ou le champ Ask Codex)

Implemented test helper updates and added missing mocks:
- simplified `renderHookWithMusicProvider` and added `mockResponse` utility.
- updated `globalInterceptor` tests to use new mock and authorization failure flow.
- renamed security log tests to `.tsx` and set jsdom environment.
- added Audio mocking in `useMusic` tests.

These updates adjust the failing mocks while keeping production code untouched.