### PR TITLE
Add metrics ingest endpoints

### DIFF
--- a/docs/BACK_API.md
+++ b/docs/BACK_API.md
@@ -1,0 +1,18 @@
+# Endpoints Metrics API
+
+Ce document récapitule les routes disponibles pour l'ingestion des widgets et la consultation des métriques.
+
+## POST
+
+- `/functions/v1/micro-breaks` – enregistre les données du widget micro-break.
+- `/functions/v1/bubble-sessions` – enregistre les sessions Bubble.
+- `/functions/v1/silk-wallpaper` – enregistre les mesures du fond d'écran Silk.
+
+Chaque POST attend un JSON conforme aux schémas Zod définis dans `supabase/functions/_shared/schemas.ts`. Un identifiant est renvoyé avec un code **201** en cas de succès.
+
+## GET
+
+- `/functions/v1/me-metrics?range=7d|30d` – retourne les métriques personnelles de l'utilisateur authentifié.
+- `/functions/v1/rh-metrics?team=ID&range=w4|w8` – retourne les agrégats anonymisés pour l'équipe. Nécessite le rôle `rh_manager`.
+
+Le champ `share_metrics` du profil permet à l'utilisateur de se soustraire au partage de données ; les politiques RLS appliquées dans la base filtrent automatiquement les lignes concernées.

--- a/src/e2e/supabaseFunctions.e2e.test.ts
+++ b/src/e2e/supabaseFunctions.e2e.test.ts
@@ -15,6 +15,11 @@ const functions: FnCheck[] = [
   { file: 'coach-ai/index.ts', roles: ['b2c', 'b2b_user', 'b2b_admin', 'admin'] },
   { file: 'monitor-api-usage/index.ts', roles: ['admin'] },
   { file: 'team-management/index.ts', roles: ['b2b_admin', 'admin'] },
+  { file: 'micro-breaks/index.ts', roles: ['b2c', 'b2b_user'] },
+  { file: 'bubble-sessions/index.ts', roles: ['b2c', 'b2b_user'] },
+  { file: 'silk-wallpaper/index.ts', roles: ['b2c', 'b2b_user'] },
+  { file: 'me-metrics/index.ts', roles: ['b2c', 'b2b_user'] },
+  { file: 'rh-metrics/index.ts', roles: ['rh_manager'] },
 ];
 
 for (const fn of functions) {

--- a/supabase/functions/_shared/hash_user.ts
+++ b/supabase/functions/_shared/hash_user.ts
@@ -1,0 +1,7 @@
+import { createHash } from 'https://deno.land/std@0.208.0/hash/mod.ts';
+
+export function hash(value: string): string {
+  const h = createHash('sha256');
+  h.update(value);
+  return h.toString();
+}

--- a/supabase/functions/_shared/http.ts
+++ b/supabase/functions/_shared/http.ts
@@ -1,0 +1,20 @@
+import { authorizeRole } from './auth.ts';
+import { hash } from './hash_user.ts';
+
+export function json(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  });
+}
+
+export function getUserHash(token?: string): string {
+  return hash(token ?? '');
+}
+
+export async function requireRole(req: Request, role: string) {
+  const { user, status } = await authorizeRole(req, [role]);
+  if (!user) {
+    throw json(status, { error: 'forbidden' });
+  }
+}

--- a/supabase/functions/_shared/schemas.ts
+++ b/supabase/functions/_shared/schemas.ts
@@ -1,0 +1,25 @@
+import { z } from 'https://deno.land/x/zod@v3.22.4/mod.ts';
+
+export const MBreakSchema = z.object({
+  ts: z.string().datetime().optional(),
+  hr_pre: z.number().int().min(30).max(220).nullable(),
+  hr_post: z.number().int().min(30).max(220).nullable(),
+  valence_pre: z.number().min(-1).max(1).nullable(),
+  valence_post: z.number().min(-1).max(1).nullable(),
+  pss1: z.number().int().min(0).max(4).nullable(),
+});
+
+export const BubbleSchema = z.object({
+  ts: z.string().datetime().optional(),
+  bpm: z.number().int().min(4).max(30),
+  smile_amp: z.number().min(0).max(1),
+  hr_sdnn: z.number().int().min(0).max(200),
+  panas_pa: z.number().int().min(10).max(50),
+});
+
+export const SilkSchema = z.object({
+  ts: z.string().datetime().optional(),
+  hr_1min: z.number().int().min(30).max(220),
+  tap_len_ms: z.number().int().min(1).max(8000),
+  sms1: z.number().int().min(0).max(4),
+});

--- a/supabase/functions/_shared/supa_client.ts
+++ b/supabase/functions/_shared/supa_client.ts
@@ -1,0 +1,6 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const url = Deno.env.get('SUPABASE_URL') || '';
+const key = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') || '';
+
+export const supabase = createClient(url, key);

--- a/supabase/functions/bubble-sessions/index.ts
+++ b/supabase/functions/bubble-sessions/index.ts
@@ -1,0 +1,42 @@
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts';
+import { BubbleSchema } from '../_shared/schemas.ts';
+import { supabase } from '../_shared/supa_client.ts';
+import { getUserHash, json } from '../_shared/http.ts';
+import { authorizeRole } from '../_shared/auth.ts';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const { user, status } = await authorizeRole(req, ['b2c', 'b2b_user']);
+    if (!user) {
+      return json(status, { error: 'Unauthorized' });
+    }
+    const jwt = req.headers.get('authorization')?.replace('Bearer ', '') || '';
+    const userHash = getUserHash(jwt);
+    const body = await req.json();
+    const parsed = BubbleSchema.safeParse(body);
+    if (!parsed.success) {
+      return json(400, { error: parsed.error.errors });
+    }
+    const { data, error } = await supabase
+      .from('bubble_sessions')
+      .insert({ ...parsed.data, user_id_hash: userHash })
+      .select('id')
+      .single();
+    if (error) {
+      return json(500, { error });
+    }
+    return json(201, { id: data.id });
+  } catch (err) {
+    console.error('bubble-sessions error', err);
+    return json(500, { error: 'server_error' });
+  }
+});

--- a/supabase/functions/me-metrics/index.ts
+++ b/supabase/functions/me-metrics/index.ts
@@ -1,0 +1,40 @@
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts';
+import { supabase } from '../_shared/supa_client.ts';
+import { getUserHash, json } from '../_shared/http.ts';
+import { authorizeRole } from '../_shared/auth.ts';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const { user: authUser, status } = await authorizeRole(req, ['b2c', 'b2b_user']);
+    if (!authUser) {
+      return json(status, { error: 'Unauthorized' });
+    }
+    const range = new URL(req.url).searchParams.get('range') ?? '7d';
+    const jwt = req.headers.get('authorization')?.replace('Bearer ', '') || '';
+    const user = getUserHash(jwt);
+    const { data, error } = await supabase
+      .from('metrics_weekly')
+      .select('*')
+      .eq('user_id_hash', user)
+      .gte('ts', range === '30d'
+        ? new Date(Date.now() - 30 * 86400000).toISOString()
+        : new Date(Date.now() - 7 * 86400000).toISOString())
+      .order('ts', { ascending: true });
+    if (error) {
+      return json(500, { error });
+    }
+    return json(200, data);
+  } catch (err) {
+    console.error('me-metrics error', err);
+    return json(500, { error: 'server_error' });
+  }
+});

--- a/supabase/functions/micro-breaks/index.ts
+++ b/supabase/functions/micro-breaks/index.ts
@@ -1,0 +1,42 @@
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts';
+import { MBreakSchema } from '../_shared/schemas.ts';
+import { supabase } from '../_shared/supa_client.ts';
+import { getUserHash, json } from '../_shared/http.ts';
+import { authorizeRole } from '../_shared/auth.ts';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const { user, status } = await authorizeRole(req, ['b2c', 'b2b_user']);
+    if (!user) {
+      return json(status, { error: 'Unauthorized' });
+    }
+    const jwt = req.headers.get('authorization')?.replace('Bearer ', '') || '';
+    const userHash = getUserHash(jwt);
+    const body = await req.json();
+    const parsed = MBreakSchema.safeParse(body);
+    if (!parsed.success) {
+      return json(400, { error: parsed.error.errors });
+    }
+    const { data, error } = await supabase
+      .from('micro_breaks')
+      .insert({ ...parsed.data, user_id_hash: userHash })
+      .select('id')
+      .single();
+    if (error) {
+      return json(500, { error });
+    }
+    return json(201, { id: data.id });
+  } catch (err) {
+    console.error('micro-breaks error', err);
+    return json(500, { error: 'server_error' });
+  }
+});

--- a/supabase/functions/rh-metrics/index.ts
+++ b/supabase/functions/rh-metrics/index.ts
@@ -1,0 +1,42 @@
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts';
+import { supabase } from '../_shared/supa_client.ts';
+import { json, requireRole } from '../_shared/http.ts';
+import { authorizeRole } from '../_shared/auth.ts';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const { user, status } = await authorizeRole(req, ['rh_manager']);
+    if (!user) {
+      return json(status, { error: 'Unauthorized' });
+    }
+    await requireRole(req, 'rh_manager');
+    const p = new URL(req.url).searchParams;
+    const team = p.get('team');
+    const range = p.get('range') ?? 'w4';
+    const { data, error } = await supabase
+      .from('metrics_weekly_v')
+      .select('*')
+      .eq('team_id', team)
+      .gte('week', range === 'w8'
+        ? new Date(Date.now() - 56 * 86400000).toISOString()
+        : new Date(Date.now() - 28 * 86400000).toISOString())
+      .order('week', { ascending: true });
+    if (error) {
+      return json(500, { error });
+    }
+    return json(200, data);
+  } catch (err) {
+    if (err instanceof Response) return err;
+    console.error('rh-metrics error', err);
+    return json(500, { error: 'server_error' });
+  }
+});

--- a/supabase/functions/silk-wallpaper/index.ts
+++ b/supabase/functions/silk-wallpaper/index.ts
@@ -1,0 +1,42 @@
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts';
+import { SilkSchema } from '../_shared/schemas.ts';
+import { supabase } from '../_shared/supa_client.ts';
+import { getUserHash, json } from '../_shared/http.ts';
+import { authorizeRole } from '../_shared/auth.ts';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const { user, status } = await authorizeRole(req, ['b2c', 'b2b_user']);
+    if (!user) {
+      return json(status, { error: 'Unauthorized' });
+    }
+    const jwt = req.headers.get('authorization')?.replace('Bearer ', '') || '';
+    const userHash = getUserHash(jwt);
+    const body = await req.json();
+    const parsed = SilkSchema.safeParse(body);
+    if (!parsed.success) {
+      return json(400, { error: parsed.error.errors });
+    }
+    const { data, error } = await supabase
+      .from('silk_wallpaper')
+      .insert({ ...parsed.data, user_id_hash: userHash })
+      .select('id')
+      .single();
+    if (error) {
+      return json(500, { error });
+    }
+    return json(201, { id: data.id });
+  } catch (err) {
+    console.error('silk-wallpaper error', err);
+    return json(500, { error: 'server_error' });
+  }
+});


### PR DESCRIPTION
## Notes
- Added Deno edge functions for metrics ingestion and retrieval.
- Introduced shared helpers for hashing, HTTP responses and Supabase client.
- Documented new routes in `docs/BACK_API.md`.

## Testing
- `npm run test` *(fails: many unit tests fail due to missing environment variables)*