### PR TITLE
Add music weekly ETL views and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,12 @@ jobs:
       - name: Run tests
         run: npm run test -- --environment=jsdom
         timeout-minutes: 5
+
+      - name: Supabase migrate
+        run: npm run db:migrate
+
+      - name: SQL unit tests
+        run: npm run test:sql
+
+      - name: DB integration tests
+        run: npm run test:db

--- a/docs/etl_music.md
+++ b/docs/etl_music.md
@@ -1,0 +1,32 @@
+# ETL Musicothérapie
+
+Ce module s'appuie sur deux vues matérialisées pour agréger les données des sessions
+`biotune_sessions` et `neon_walk_sessions`.
+
+```
+biotune_sessions        neon_walk_sessions
+        \                     /
+         \                   /
+      metrics_weekly_music
+               |
+      metrics_weekly_music_org
+```
+
+La fonction `refresh_metrics_music()` met à jour ces vues et est planifiée tous
+les jours à 03h10 UTC via `pg_cron`.
+
+Exemple de requête pour consulter les métriques d'un utilisateur :
+
+```sql
+select *
+from public.metrics_weekly_music
+where user_id_hash = 'hashA'
+order by week_start desc;
+```
+
+Pour voir la planification :
+
+```sql
+select * from cron.job
+where job_name = 'refresh_metrics_music';
+```

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "test:e2e": "vitest run --dir src/e2e --reporter=json --outputFile=reports/e2e-report.json",
     "build:dev": "vite build --mode development",
     "type-check": "tsc --noEmit",
-    "back:audit": "node --loader ts-node/esm scripts/full-back-audit.ts"
+    "back:audit": "node --loader ts-node/esm scripts/full-back-audit.ts",
+    "db:migrate": "supabase db push",
+    "test:sql": "pgtap-run tests/sql/**/*.sql --dsn $DATABASE_URL",
+    "test:db": "vitest run src/tests/db"
   },
   "dependencies": {
     "@chakra-ui/icons": "^2.2.4",
@@ -152,7 +155,10 @@
     "tailwindcss": "^3.4.3",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.19"
+    "vite": "^5.4.19",
+    "kysely": "^0.27.0",
+    "pg": "^8.11.3",
+    "pgtap-run": "^1.0.0"
   },
   "optionalDependencies": {
     "cypress": "^13.5.0",

--- a/src/tests/db/music_weekly.test.ts
+++ b/src/tests/db/music_weekly.test.ts
@@ -1,0 +1,41 @@
+import { Kysely, PostgresDialect } from 'kysely';
+import pg from 'pg';
+import { afterAll, beforeAll, expect, test } from 'vitest';
+
+interface MetricsWeeklyMusic {
+  user_id_hash: string;
+  week_start: string;
+  mvpa_min: number;
+}
+
+interface Database {
+  metrics_weekly_music: MetricsWeeklyMusic;
+  metrics_weekly_music_org: { org_id: number };
+}
+
+let db: Kysely<Database>;
+
+beforeAll(async () => {
+  const dialect = new PostgresDialect({
+    pool: new pg.Pool({ connectionString: process.env.DATABASE_URL })
+  });
+  db = new Kysely<Database>({ dialect });
+  await db.raw('call public.refresh_metrics_music()');
+});
+
+afterAll(async () => {
+  await db.destroy();
+});
+
+test('metrics populated', async () => {
+  const rows = await db.selectFrom('metrics_weekly_music').selectAll().execute();
+  expect(rows.length).toBeGreaterThan(0);
+});
+
+test('org view exists', async () => {
+  const exists = await db
+    .selectFrom('metrics_weekly_music_org')
+    .select('org_id')
+    .execute();
+  expect(exists.length).toBeGreaterThan(0);
+});

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -21,6 +21,7 @@ port = 54322
 # The database major version to use. This has to be the same as your remote database's. Run `SHOW
 # server_version;` on the remote database to check.
 major_version = 15
+extensions = ["pg_cron"]
 
 [studio]
 # Port to use for Supabase Studio.

--- a/supabase/migrations/20250606_music_etl.sql
+++ b/supabase/migrations/20250606_music_etl.sql
@@ -1,0 +1,18 @@
+/* 1. Fonction de refresh ---------------------------------------- */
+create or replace function public.refresh_metrics_music()
+returns void language plpgsql as $$
+begin
+  perform refresh materialized view concurrently public.metrics_weekly_music;
+  perform refresh materialized view concurrently public.metrics_weekly_music_org;
+end;
+$$;
+
+/* 2. Cron pg_cron (nécessite l'extension déjà enable) ----------- */
+-- enable extension if not yet
+create extension if not exists pg_cron;
+
+select cron.schedule(
+  job_name  => 'refresh_metrics_music',
+  schedule  => '10 3 * * *',
+  command   => $$call public.refresh_metrics_music();$$
+);

--- a/supabase/migrations/20250606_music_weekly.sql
+++ b/supabase/migrations/20250606_music_weekly.sql
@@ -1,0 +1,43 @@
+-- 1. VUE PAR UTILISATEUR -----------------------------------------
+create materialized view if not exists public.metrics_weekly_music as
+select
+  user_id_hash,
+  date_trunc('week', coalesce(ts_start, ts))::date as week_start,
+
+  percentile_cont(0.5) within group (order by rmssd_delta) as hrv_stress_idx,
+  avg(case when energy_mode = 'calm' then coherence end)     as coherence_avg,
+  sum(mvpa_min)                                              as mvpa_min,
+  avg(joy_idx)                                               as joy_avg
+
+from (
+  select user_id_hash, ts_start, rmssd_delta, coherence, energy_mode,
+         null::int as mvpa_min, null::real as joy_idx
+  from public.biotune_sessions
+  union all
+  select user_id_hash, ts, null::int, null::real, null::text,
+         mvpa_min, joy_idx
+  from public.neon_walk_sessions
+) u
+group by user_id_hash, week_start
+with no data;
+
+create unique index if not exists metrics_weekly_music_pk
+  on public.metrics_weekly_music (user_id_hash, week_start);
+
+-- 2. VUE PAR ORGANISATION ----------------------------------------
+create materialized view if not exists public.metrics_weekly_music_org as
+select
+  map.org_id,
+  m.week_start,
+  count(*)                                  as members,
+  avg(hrv_stress_idx)                       as org_hrv_idx,
+  avg(coherence_avg)                        as org_coherence,
+  avg(mvpa_min)                             as org_mvpa,
+  avg(joy_avg)                              as org_joy
+from public.metrics_weekly_music m
+join public.user_org_map map using (user_id_hash)
+group by map.org_id, m.week_start
+with no data;
+
+create unique index if not exists metrics_weekly_music_org_pk
+  on public.metrics_weekly_music_org (org_id, week_start);

--- a/tests/sql/music_weekly.sql
+++ b/tests/sql/music_weekly.sql
@@ -1,0 +1,26 @@
+BEGIN;
+SELECT plan(3);
+
+insert into public.biotune_sessions
+  (user_id_hash, duration_s, bpm_target, hrv_pre, hrv_post, energy_mode)
+values
+  ('hashA',300,70,50,80,'calm');
+
+insert into public.neon_walk_sessions
+  (user_id_hash, steps, avg_cadence, joy_idx)
+values ('hashA',3000,110,0.7);
+
+call public.refresh_metrics_music();
+
+SELECT is(
+  (select mvpa_min from public.metrics_weekly_music where user_id_hash='hashA'),
+  round((3000/100.0)*(110/120.0),2),
+  'mvpa computed');
+
+SELECT ok (
+  exists(select 1 from public.metrics_weekly_music_org),
+  'org view populated'
+);
+
+SELECT finish();
+ROLLBACK;


### PR DESCRIPTION
## Notes
- Added Supabase migrations for weekly music metrics and ETL refresh cron
- Configured `pg_cron` extension in `supabase/config.toml`
- Added pgTAP and Vitest tests
- Updated CI workflow to run DB migrations and tests
- Documented ETL process in `docs/etl_music.md`

## Testing
- `npm run test:sql` *(fails: pgtap-run not found)*
- `npm run test:db` *(fails: dependencies missing)*
