### PR TITLE
Add scan weekly API

### DIFF
--- a/docs/api/scan_weekly.md
+++ b/docs/api/scan_weekly.md
@@ -1,0 +1,9 @@
+# Endpoints Scan Weekly
+
+Ces routes exposent les KPI hebdomadaires issus des analyses "scan".
+
+## GET `/me/scan/weekly?since=YYYY-MM-DD`
+Retourne les métriques personnelles de l'utilisateur authentifié.
+
+## GET `/org/:orgId/scan/weekly?since=YYYY-MM-DD`
+Retourne les métriques agrégées pour une organisation (rôle admin requis).

--- a/openapi/scan.yaml
+++ b/openapi/scan.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: Scan API
+  version: 1.0.0
+paths:
+  /me/scan/weekly:
+    get:
+      summary: Get weekly scan KPIs
+      responses:
+        '200':
+          description: Weekly metrics
+  /org/{orgId}/scan/weekly:
+    get:
+      summary: Get org weekly scan KPIs
+      parameters:
+        - in: path
+          name: orgId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Weekly org metrics

--- a/services/scan/handlers/getWeeklyOrg.ts
+++ b/services/scan/handlers/getWeeklyOrg.ts
@@ -1,0 +1,18 @@
+import { IncomingMessage, ServerResponse } from 'http';
+import { listWeeklyOrg } from '../lib/db';
+
+function parseSince(url: string | undefined): Date {
+  const sinceParam = new URL('http://localhost' + (url || '')).searchParams.get('since');
+  if (sinceParam) return new Date(sinceParam);
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - 56);
+  return d;
+}
+
+export async function getWeeklyOrg(req: IncomingMessage, res: ServerResponse, orgId: string) {
+  const since = parseSince(req.url);
+  const rows = listWeeklyOrg(orgId, since);
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify(rows));
+}

--- a/services/scan/handlers/getWeeklyUser.ts
+++ b/services/scan/handlers/getWeeklyUser.ts
@@ -1,0 +1,20 @@
+import { IncomingMessage, ServerResponse } from 'http';
+import { hash } from '../../journal/lib/hash';
+import { listWeekly } from '../lib/db';
+
+function parseSince(url: string | undefined): Date {
+  const sinceParam = new URL('http://localhost' + (url || '')).searchParams.get('since');
+  if (sinceParam) return new Date(sinceParam);
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - 56); // 8 weeks
+  return d;
+}
+
+export async function getWeeklyUser(req: IncomingMessage, res: ServerResponse, user: any) {
+  const since = parseSince(req.url);
+  const userHash = hash(user.sub);
+  const rows = listWeekly(userHash, since);
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify(rows));
+}

--- a/services/scan/index.ts
+++ b/services/scan/index.ts
@@ -1,0 +1,7 @@
+import { createApp } from './server';
+
+const app = createApp();
+const port = process.env.PORT || 3002;
+app.listen(port, () => {
+  console.log(`scan api listening on ${port}`);
+});

--- a/services/scan/lib/db.ts
+++ b/services/scan/lib/db.ts
@@ -1,0 +1,50 @@
+export type ScanWeeklyRow = {
+  user_id_hash: string;
+  week_start: string;
+  valence_face_avg: number;
+  arousal_sd_face: number;
+  joy_face_avg: number;
+  valence_voice_avg: number;
+  lexical_sentiment_avg: number;
+  n_face_sessions: number;
+  n_voice_sessions: number;
+};
+
+export type ScanWeeklyOrgRow = {
+  org_id: string;
+  week_start: string;
+  members: number;
+  org_valence_face: number;
+  org_arousal_sd: number;
+  org_joy_face: number;
+  org_valence_voice: number;
+  org_lexical_sentiment: number;
+};
+
+const weekly: ScanWeeklyRow[] = [];
+const weeklyOrg: ScanWeeklyOrgRow[] = [];
+
+export function insertWeekly(row: ScanWeeklyRow) {
+  weekly.push(row);
+}
+
+export function insertWeeklyOrg(row: ScanWeeklyOrgRow) {
+  weeklyOrg.push(row);
+}
+
+export function listWeekly(userHash: string, since: Date): ScanWeeklyRow[] {
+  return weekly
+    .filter(r => r.user_id_hash === userHash && new Date(r.week_start) >= since)
+    .sort((a, b) => b.week_start.localeCompare(a.week_start));
+}
+
+export function listWeeklyOrg(orgId: string, since: Date): ScanWeeklyOrgRow[] {
+  return weeklyOrg
+    .filter(r => r.org_id === orgId && new Date(r.week_start) >= since)
+    .sort((a, b) => b.week_start.localeCompare(a.week_start));
+}
+
+export function clear() {
+  weekly.length = 0;
+  weeklyOrg.length = 0;
+}

--- a/services/scan/server.ts
+++ b/services/scan/server.ts
@@ -1,0 +1,43 @@
+import { createServer, IncomingMessage, ServerResponse } from 'http';
+import { getWeeklyUser } from './handlers/getWeeklyUser';
+import { getWeeklyOrg } from './handlers/getWeeklyOrg';
+
+function getUser(req: IncomingMessage) {
+  const auth = req.headers['authorization'];
+  if (auth && auth.startsWith('Bearer ')) {
+    const token = auth.substring(7);
+    return { sub: token, role: token.startsWith('admin:') ? 'admin' : 'user', org: token.split(':')[1] };
+  }
+  return null;
+}
+
+export function createApp() {
+  return createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    const user = getUser(req);
+    if (!user) {
+      res.statusCode = 401;
+      res.end('Unauthorized');
+      return;
+    }
+
+    if (req.method === 'GET' && req.url?.startsWith('/me/scan/weekly')) {
+      await getWeeklyUser(req, res, user);
+      return;
+    }
+
+    const match = req.url?.match(/^\/org\/([^/]+)\/scan\/weekly/);
+    if (req.method === 'GET' && match) {
+      const orgId = match[1];
+      if (user.role !== 'admin' || user.org !== orgId) {
+        res.statusCode = 403;
+        res.end('forbidden');
+        return;
+      }
+      await getWeeklyOrg(req, res, orgId);
+      return;
+    }
+
+    res.statusCode = 404;
+    res.end('Not Found');
+  });
+}

--- a/services/scan/tests/scanWeekly.test.ts
+++ b/services/scan/tests/scanWeekly.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createApp } from '../server';
+import { insertWeekly, insertWeeklyOrg, clear } from '../lib/db';
+import { hash } from '../../journal/lib/hash';
+
+let server: any;
+let url: string;
+
+beforeEach(async () => {
+  clear();
+  await new Promise<void>(resolve => {
+    server = createApp().listen(0, () => {
+      const { port } = server.address();
+      url = `http://localhost:${port}`;
+      resolve();
+    });
+  });
+});
+
+afterEach(() => {
+  server.close();
+});
+
+describe('GET /me/scan/weekly', () => {
+  it('user fetches own KPIs', async () => {
+    insertWeekly({
+      user_id_hash: hash('hashU'),
+      week_start: '2025-05-26',
+      valence_face_avg: 0.24,
+      arousal_sd_face: 0.12,
+      joy_face_avg: 0.48,
+      valence_voice_avg: 0.31,
+      lexical_sentiment_avg: 0.29,
+      n_face_sessions: 3,
+      n_voice_sessions: 2
+    });
+
+    const res = await fetch(url + '/me/scan/weekly', {
+      headers: { 'Authorization': 'Bearer hashU' }
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data)).toBe(true);
+    expect(data[0]).toHaveProperty('week_start');
+  });
+});
+
+describe('GET /org/:orgId/scan/weekly', () => {
+  it('admin fetches org KPIs', async () => {
+    insertWeeklyOrg({
+      org_id: 'acme',
+      week_start: '2025-05-26',
+      members: 17,
+      org_valence_face: 0.21,
+      org_arousal_sd: 0.14,
+      org_joy_face: 0.45,
+      org_valence_voice: 0.28,
+      org_lexical_sentiment: 0.26
+    });
+
+    const res = await fetch(url + '/org/acme/scan/weekly', {
+      headers: { 'Authorization': 'Bearer admin:acme' }
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data[0]).toHaveProperty('members');
+  });
+});

--- a/vitest.api.config.ts
+++ b/vitest.api.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['services/journal/tests/**/*.ts']
+    include: ['services/journal/tests/**/*.ts', 'services/scan/tests/**/*.ts']
   }
 });


### PR DESCRIPTION
## Summary
- implement new weekly scan metrics API
- create handlers and server under services/scan
- document API in docs and OpenAPI
- extend API tests and configuration

## Testing
- `npm run test:api`