### PR TITLE
Implement scan dashboard widgets

### DIFF
--- a/docs/scan-dashboard.md
+++ b/docs/scan-dashboard.md
@@ -1,0 +1,10 @@
+# Scan Dashboard Widgets
+
+This document outlines the front-end widgets used to display KPIs from the emotion scan module.
+
+- **FaceMoodCard** – shows facial valence and displays a happy emoji when joy exceeds 0.5.
+- **VoiceToneCard** – visualises average voice valence with a gradient waveform.
+- **VolatilitySparkline** – tiny line chart of facial arousal deviation.
+- **TeamEmotionHeatmap** – small heatmap used on the admin dashboard.
+
+All widgets rely on data returned by the `/me/scan/weekly` and `/org/{id}/scan/weekly` endpoints.

--- a/src/components/dashboard/FaceMoodCard.tsx
+++ b/src/components/dashboard/FaceMoodCard.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { CircularProgressbar, buildStyles } from 'react-circular-progressbar';
+import 'react-circular-progressbar/dist/styles.css';
+import { motion } from 'framer-motion';
+
+interface FaceMoodCardProps {
+  data: {
+    valence_face_avg: number;
+    joy_face_avg: number;
+  };
+}
+
+const valenceColor = (v: number) => {
+  const hue = Math.min(Math.max(v, 0), 1) * 120; // 0 red -> 120 green
+  return `hsl(${hue}, 70%, 50%)`;
+};
+
+export const FaceMoodCard: React.FC<FaceMoodCardProps> = ({ data }) => {
+  const { valence_face_avg, joy_face_avg } = data;
+  const color = valenceColor(valence_face_avg);
+  return (
+    <Card className="flex flex-col items-center" aria-label={`Valence moyenne visage ${valence_face_avg.toFixed(2)} sur 1`}>
+      <CardHeader className="pb-2">
+        <CardTitle>Humeur visage</CardTitle>
+      </CardHeader>
+      <CardContent className="w-full flex flex-col items-center">
+        <motion.div animate={{ value: valence_face_avg }} className="w-24 h-24">
+          <CircularProgressbar
+            value={valence_face_avg * 100}
+            styles={buildStyles({ pathColor: color, trailColor: '#eee' })}
+          />
+        </motion.div>
+        {joy_face_avg > 0.5 && (
+          <span role="img" aria-label="happy" className="text-2xl mt-2">
+            😊
+          </span>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default FaceMoodCard;

--- a/src/components/dashboard/TeamEmotionHeatmap.tsx
+++ b/src/components/dashboard/TeamEmotionHeatmap.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface TeamEmotionHeatmapProps {
+  data: { week: string; ab: number; ev: number; joy: number; voice: number }[];
+}
+
+export const TeamEmotionHeatmap: React.FC<TeamEmotionHeatmapProps> = ({ data }) => {
+  return (
+    <div className="grid grid-cols-8 gap-1" aria-label="Heatmap équipe">
+      {data.map((row, i) => (
+        <div key={i} className="flex flex-col space-y-1">
+          {[row.ab, row.ev, row.joy, row.voice].map((v, j) => (
+            <div
+              key={j}
+              className="w-3 h-3 rounded"
+              style={{ backgroundColor: `rgba(0,0,0,${v})` }}
+            ></div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default TeamEmotionHeatmap;

--- a/src/components/dashboard/VoiceToneCard.tsx
+++ b/src/components/dashboard/VoiceToneCard.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface VoiceToneCardProps {
+  data: {
+    valence_voice_avg: number;
+    lexical_sentiment_avg: number;
+  };
+}
+
+const toneColor = (v: number) => {
+  const hue = Math.min(Math.max(v, 0), 1) * 120; // 0 red -> 120 green
+  return `hsl(${hue},70%,50%)`;
+};
+
+export const VoiceToneCard: React.FC<VoiceToneCardProps> = ({ data }) => {
+  const { valence_voice_avg, lexical_sentiment_avg } = data;
+  const color = toneColor(valence_voice_avg);
+  return (
+    <Card aria-label={`Valence moyenne voix ${valence_voice_avg.toFixed(2)} sur 1`}>
+      <CardHeader className="pb-2">
+        <CardTitle>Ton de la voix</CardTitle>
+      </CardHeader>
+      <CardContent className="relative overflow-hidden p-6">
+        <div
+          className="h-20 rounded-lg w-full"
+          style={{
+            background: `linear-gradient(90deg, ${color}, #eee)`,
+            maskImage: 'radial-gradient(circle at 50% 50%, white, transparent)',
+            WebkitMaskImage: 'radial-gradient(circle at 50% 50%, white, transparent)'
+          }}
+        ></div>
+        <div className="text-sm text-muted-foreground mt-2">
+          Sentiment lexical moyen : {(lexical_sentiment_avg * 100).toFixed(0)}% positif
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default VoiceToneCard;

--- a/src/components/dashboard/VolatilitySparkline.tsx
+++ b/src/components/dashboard/VolatilitySparkline.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { LineChart, Line, ResponsiveContainer, Tooltip } from 'recharts';
+
+interface VolatilitySparklineProps {
+  series: { week: string; value: number }[];
+}
+
+export const VolatilitySparkline: React.FC<VolatilitySparklineProps> = ({ series }) => {
+  return (
+    <div className="w-24 h-8" aria-label="Variation émotionnelle">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={series} margin={{ top: 2, bottom: 2 }}>
+          <Tooltip formatter={(v: number) => v.toFixed(2)} />
+          <Line type="monotone" dataKey="value" stroke="#8884d8" fillOpacity={0.2} dot={false} strokeWidth={2} />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default VolatilitySparkline;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -28,6 +28,8 @@ export { default as useMusicRecommendation } from './useMusicRecommendation';
 
 // Emotion hooks
 export { useEmotionScan } from './useEmotionScan';
+export { useWeeklyScan } from './useWeeklyScan';
+export { useOrgScan } from './useOrgScan';
 
 // Theme hook
 export { useTheme } from './use-theme';

--- a/src/hooks/useOrgScan.ts
+++ b/src/hooks/useOrgScan.ts
@@ -1,0 +1,25 @@
+import dayjs from 'dayjs';
+import { useQuery } from '@tanstack/react-query';
+import { GlobalInterceptor } from '@/utils/globalInterceptor';
+
+export interface OrgScanRow {
+  week: string;
+  ab_avg: number;
+  ev_avg: number;
+  joy_face_avg: number;
+  valence_voice_avg: number;
+}
+
+export const useOrgScan = (
+  orgId: string,
+  since: dayjs.Dayjs = dayjs().subtract(8, 'week')
+) => {
+  return useQuery(['orgScan', orgId, since], async () => {
+    const res = await GlobalInterceptor.secureFetch(
+      `/org/${orgId}/scan/weekly?since=${since.format('YYYY-MM-DD')}`
+    );
+    if (!res) throw new Error('Request failed');
+    const { data } = await res.json();
+    return data as OrgScanRow[];
+  });
+};

--- a/src/hooks/useWeeklyScan.ts
+++ b/src/hooks/useWeeklyScan.ts
@@ -1,0 +1,25 @@
+import dayjs from 'dayjs';
+import { useQuery } from '@tanstack/react-query';
+import { GlobalInterceptor } from '@/utils/globalInterceptor';
+
+export interface WeeklyScanRow {
+  week: string;
+  valence_face_avg: number;
+  joy_face_avg: number;
+  valence_voice_avg: number;
+  lexical_sentiment_avg: number;
+  arousal_sd_face: number;
+}
+
+export const useWeeklyScan = (
+  since: dayjs.Dayjs = dayjs().subtract(8, 'week')
+) => {
+  return useQuery(['scanWeekly', since], async () => {
+    const res = await GlobalInterceptor.secureFetch(
+      `/me/scan/weekly?since=${since.format('YYYY-MM-DD')}`
+    );
+    if (!res) throw new Error('Request failed');
+    const { data } = await res.json();
+    return data as WeeklyScanRow[];
+  });
+};

--- a/src/tests/FaceMoodCard.test.tsx
+++ b/src/tests/FaceMoodCard.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import FaceMoodCard from '@/components/dashboard/FaceMoodCard';
+
+describe('FaceMoodCard', () => {
+  it('shows emoji when joy > .5', () => {
+    render(<FaceMoodCard data={{ joy_face_avg: 0.7, valence_face_avg: 0.2 }} />);
+    expect(screen.getByRole('img', { name: /happy/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add useWeeklyScan and useOrgScan API hooks
- implement FaceMoodCard, VoiceToneCard, VolatilitySparkline and TeamEmotionHeatmap components
- export new hooks
- document widgets
- test FaceMoodCard emoji behaviour

## Testing
- `npm test` *(fails: tests require env vars and DB access)*