### PR TITLE
Add gamification weekly ETL views

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,12 @@ jobs:
           DB_NAME: testdb
           DB_USER: runner
           DB_PASS: runner
+      - name: Flyway migrate
+        run: npm run flyway:migrate
+      - name: Refresh gam metrics
+        run: npm run db:refresh:gam
+        env:
+          DATABASE_URL: postgres://runner:runner@localhost:5432/testdb
       - name: SQL unit tests
         run: npm run test:sql
         env:

--- a/docs/etl_gam.md
+++ b/docs/etl_gam.md
@@ -1,0 +1,13 @@
+# ETL Gamification
+
+Ces vues matérialisées agrègent les tables `echo_crystal`, `bb_chain` et `neon_challenge` de façon hebdomadaire.
+
+```mermaid
+flowchart TD
+    A[echo_crystal] --> C(metrics_weekly_gam)
+    B[bb_chain] --> C
+    D[neon_challenge] --> C
+    C --> E(metrics_weekly_gam_org)
+```
+
+La fonction `refresh_metrics_gam()` met à jour ces vues et est déclenchée chaque nuit via **pg_cron**.

--- a/migrations/V20250609__gam_weekly.sql
+++ b/migrations/V20250609__gam_weekly.sql
@@ -1,0 +1,77 @@
+/*---------------------------------------------------------------------------
+  GAM weekly metrics materialized views and refresh job
+---------------------------------------------------------------------------*/
+
+/* 1-A – Vue matérialisée UTILISATEUR  --------------------------- */
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.metrics_weekly_gam AS
+SELECT
+    ec.user_id_hash,
+    date_trunc('week', COALESCE(ec.ts, bc.ts, nc.ts))::date AS week_start,
+
+    /* Affect positif : moyenne Joy cristaux  ------------------- */
+    AVG(ec.pos_affect)                       AS pa_avg,
+
+    /* Rire authentique : % “genuine” --------------------------- */
+    AVG(CASE WHEN ec.genuine_flag THEN 1 ELSE 0 END)    AS laugh_genuine_ratio,
+
+    /* Connectedness : profondeur moyenne de chaîne ------------- */
+    AVG(bc.depth)                            AS conn_depth_avg,
+
+    /* Engagement : total partages semaine ---------------------- */
+    SUM(bc.share_count)                      AS shares_total,
+
+    /* Activité physique : Σ minutes MVPA ----------------------- */
+    SUM(nc.mvpa_min)                         AS mvpa_min,
+
+    /* Auto-efficacité : % jours avec streak -------------------- */
+    AVG(CASE WHEN nc.streak_flag THEN 1 ELSE 0 END)     AS streak_ratio
+FROM   public.echo_crystal      ec
+FULL   JOIN public.bb_chain     bc USING (user_id_hash)
+FULL   JOIN public.neon_challenge nc USING (user_id_hash)
+GROUP  BY ec.user_id_hash, week_start
+WITH NO DATA;
+
+CREATE UNIQUE INDEX IF NOT EXISTS metrics_weekly_gam_pk
+    ON public.metrics_weekly_gam(user_id_hash, week_start);
+
+/* 1-B – Vue matérialisée ORGANISATION -------------------------- */
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.metrics_weekly_gam_org AS
+SELECT
+    m.org_id,
+    m.week_start,
+    COUNT(*)                           AS n_members,
+    AVG(m.pa_avg)                      AS pa_org_avg,
+    AVG(m.laugh_genuine_ratio)         AS laugh_ratio_org,
+    AVG(m.conn_depth_avg)              AS conn_depth_org,
+    SUM(m.shares_total)                AS shares_org,
+    AVG(m.mvpa_min)                    AS mvpa_org,
+    AVG(m.streak_ratio)                AS streak_org
+FROM (
+    SELECT uom.org_id, w.*
+    FROM   public.metrics_weekly_gam w
+    JOIN   public.user_org_map uom USING (user_id_hash)
+) m
+GROUP BY m.org_id, m.week_start
+WITH NO DATA;
+
+CREATE UNIQUE INDEX IF NOT EXISTS metrics_weekly_gam_org_pk
+    ON public.metrics_weekly_gam_org(org_id, week_start);
+
+/* 1-C – Droits minimalistes ------------------------------------ */
+GRANT SELECT ON metrics_weekly_gam      TO service_role;
+GRANT SELECT ON metrics_weekly_gam_org  TO service_role;
+
+/* 2-A Fonction idempotente */
+CREATE OR REPLACE FUNCTION public.refresh_metrics_gam() RETURNS void AS $$
+BEGIN
+  PERFORM REFRESH MATERIALIZED VIEW CONCURRENTLY public.metrics_weekly_gam;
+  PERFORM REFRESH MATERIALIZED VIEW CONCURRENTLY public.metrics_weekly_gam_org;
+END;
+$$ LANGUAGE plpgsql;
+
+/* 2-B Planification (pg_cron ou Supabase scheduler) */
+SELECT cron.schedule(
+  job_name  => 'refresh_metrics_gam',
+  schedule  => '15 3 * * *',          -- 03 h 15 UTC
+  command   => $$CALL public.refresh_metrics_gam();$$
+);

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:api": "vitest run --config vitest.api.config.ts",
     "db:migrate": "flyway -locations=filesystem:./migrations migrate",
     "db:refresh:scan": "psql $DATABASE_URL -c 'CALL public.refresh_metrics_scan();'",
+    "db:refresh:gam": "psql $DATABASE_URL -c 'CALL public.refresh_metrics_gam();'",
     "db:migrate": "supabase db push",
     "test:sql": "pgtap-run tests/sql/**/*.sql --dsn $DATABASE_URL",
     "db:refresh:journal": "psql $DATABASE_URL -c 'CALL public.refresh_metrics_weekly_journal();'",

--- a/tests/db/gam_weekly.test.ts
+++ b/tests/db/gam_weekly.test.ts
@@ -1,0 +1,9 @@
+import { expect, it } from 'vitest';
+import db from '../../database/tests/db/helpers/db';
+
+it('refresh populates weekly row', async () => {
+  await db.exec('CALL public.refresh_metrics_gam()');
+  const row = await db.selectFrom('metrics_weekly_gam')
+                      .limit(1).executeTakeFirst();
+  expect(row).toBeTruthy();
+});

--- a/tests/sql/gam_weekly.sql
+++ b/tests/sql/gam_weekly.sql
@@ -1,0 +1,31 @@
+BEGIN;
+SELECT plan(3);
+
+-- Insère trois lignes d’exemple (une par table) ---------------
+INSERT INTO echo_crystal
+  (user_id_hash, joy_idx, arousal_voice, laugh_db, laugh_pitch,
+   crystal_type, color_hex, sparkle_level)
+VALUES ('hashX', 0.9, 0.4, 70, 260,'gem','#FF88CC',0.9);
+
+INSERT INTO bb_chain (user_id_hash) VALUES ('hashX'); -- depth 0
+INSERT INTO bb_chain (user_id_hash,parent_id) SELECT 'hashX', id FROM bb_chain WHERE depth=0; -- depth 1
+
+INSERT INTO neon_challenge (user_id_hash, steps, km, streak_flag)
+VALUES ('hashX', 4000, 3.2, true);
+
+CALL public.refresh_metrics_gam();
+
+SELECT is(
+  (SELECT shares_total FROM metrics_weekly_gam WHERE user_id_hash='hashX'), 2,
+  'shares_total agrégé');
+
+SELECT ok(
+  (SELECT mvpa_min FROM metrics_weekly_gam WHERE user_id_hash='hashX') > 0,
+  'mvpa agrégé');
+
+SELECT isnt_null(
+  (SELECT pa_org_avg FROM metrics_weekly_gam_org LIMIT 1),
+  'vue org peuplée');
+
+SELECT finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary
- add ETL for gamification metrics
- schedule nightly refresh job
- provide pgtap and vitest tests
- document gamification ETL
- run Flyway + refresh in CI

## Testing
- `npm run test:sql` *(fails: pgtap-run not found)*
- `npm run test:db` *(fails: pgtap-run not found)*