### PR TITLE
Implement gam weekly KPI API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Changelog
 Toutes les modifications notables apportées à ce projet seront documentées dans ce fichier.
 
+
+## [1.1.13] - 2025-06-04
+
+### Ajouté
+- Endpoints KPIs gamification hebdomadaires (/me/gam/weekly et /org/:orgId/gam/weekly)
+
 ## [1.1.12] - 2025-06-03
 
 ### Ajouté

--- a/docs/api/gam_weekly.md
+++ b/docs/api/gam_weekly.md
@@ -1,0 +1,9 @@
+# Endpoints Gamification Weekly
+
+Ces routes exposent les KPI hebdomadaires de gamification.
+
+## GET `/me/gam/weekly?since=YYYY-MM-DD`
+Retourne les métriques personnelles de l'utilisateur authentifié.
+
+## GET `/org/:orgId/gam/weekly?since=YYYY-MM-DD`
+Retourne les métriques agrégées pour une organisation (rôle admin requis).

--- a/openapi/gam.yaml
+++ b/openapi/gam.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: Gamification API
+  version: 1.0.0
+paths:
+  /me/gam/weekly:
+    get:
+      summary: KPIs gamification hebdo (utilisateur)
+      responses:
+        '200':
+          description: Weekly gamification metrics
+  /org/{orgId}/gam/weekly:
+    get:
+      summary: KPIs gamification hebdo (organisation)
+      parameters:
+        - in: path
+          name: orgId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Weekly gamification org metrics

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:api": "vitest run --config vitest.api.config.ts",
     "db:migrate": "flyway -locations=filesystem:./migrations migrate",
     "db:refresh:scan": "psql $DATABASE_URL -c 'CALL public.refresh_metrics_scan();'",
+    "db:refresh:gam": "psql $DATABASE_URL -c 'CALL public.refresh_metrics_gam();'",
     "db:migrate": "supabase db push",
     "test:sql": "pgtap-run tests/sql/**/*.sql --dsn $DATABASE_URL",
     "db:refresh:journal": "psql $DATABASE_URL -c 'CALL public.refresh_metrics_weekly_journal();'",

--- a/services/gam/handlers/getWeeklyOrg.ts
+++ b/services/gam/handlers/getWeeklyOrg.ts
@@ -1,0 +1,18 @@
+import { IncomingMessage, ServerResponse } from 'http';
+import { listWeeklyOrg } from '../lib/db';
+
+function parseSince(url: string | undefined): Date {
+  const sinceParam = new URL('http://localhost' + (url || '')).searchParams.get('since');
+  if (sinceParam) return new Date(sinceParam);
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - 56);
+  return d;
+}
+
+export async function getWeeklyOrg(req: IncomingMessage, res: ServerResponse, orgId: string) {
+  const since = parseSince(req.url);
+  const rows = listWeeklyOrg(orgId, since);
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify(rows));
+}

--- a/services/gam/handlers/getWeeklyUser.ts
+++ b/services/gam/handlers/getWeeklyUser.ts
@@ -1,0 +1,20 @@
+import { IncomingMessage, ServerResponse } from 'http';
+import { hash } from '../../journal/lib/hash';
+import { listWeekly } from '../lib/db';
+
+function parseSince(url: string | undefined): Date {
+  const sinceParam = new URL('http://localhost' + (url || '')).searchParams.get('since');
+  if (sinceParam) return new Date(sinceParam);
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - 56); // 8 weeks
+  return d;
+}
+
+export async function getWeeklyUser(req: IncomingMessage, res: ServerResponse, user: any) {
+  const since = parseSince(req.url);
+  const userHash = hash(user.sub);
+  const rows = listWeekly(userHash, since);
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify(rows));
+}

--- a/services/gam/index.ts
+++ b/services/gam/index.ts
@@ -1,0 +1,7 @@
+import { createApp } from './server';
+
+const app = createApp();
+const port = process.env.PORT || 3003;
+app.listen(port, () => {
+  console.log(`gam api listening on ${port}`);
+});

--- a/services/gam/lib/db.ts
+++ b/services/gam/lib/db.ts
@@ -1,0 +1,50 @@
+export type GamWeeklyRow = {
+  user_id_hash: string;
+  week_start: string;
+  pa_avg: number;
+  laugh_genuine_ratio: number;
+  conn_depth_avg: number;
+  shares_total: number;
+  mvpa_min: number;
+  streak_ratio: number;
+};
+
+export type GamWeeklyOrgRow = {
+  org_id: string;
+  week_start: string;
+  n_members: number;
+  pa_avg: number;
+  laugh_genuine_ratio: number;
+  conn_depth_avg: number;
+  shares_total: number;
+  mvpa_min: number;
+  streak_ratio: number;
+};
+
+const weekly: GamWeeklyRow[] = [];
+const weeklyOrg: GamWeeklyOrgRow[] = [];
+
+export function insertWeekly(row: GamWeeklyRow) {
+  weekly.push(row);
+}
+
+export function insertWeeklyOrg(row: GamWeeklyOrgRow) {
+  weeklyOrg.push(row);
+}
+
+export function listWeekly(userHash: string, since: Date): GamWeeklyRow[] {
+  return weekly
+    .filter(r => r.user_id_hash === userHash && new Date(r.week_start) >= since)
+    .sort((a, b) => b.week_start.localeCompare(a.week_start));
+}
+
+export function listWeeklyOrg(orgId: string, since: Date): GamWeeklyOrgRow[] {
+  return weeklyOrg
+    .filter(r => r.org_id === orgId && new Date(r.week_start) >= since)
+    .sort((a, b) => b.week_start.localeCompare(a.week_start));
+}
+
+export function clear() {
+  weekly.length = 0;
+  weeklyOrg.length = 0;
+}

--- a/services/gam/server.ts
+++ b/services/gam/server.ts
@@ -1,0 +1,43 @@
+import { createServer, IncomingMessage, ServerResponse } from 'http';
+import { getWeeklyUser } from './handlers/getWeeklyUser';
+import { getWeeklyOrg } from './handlers/getWeeklyOrg';
+
+function getUser(req: IncomingMessage) {
+  const auth = req.headers['authorization'];
+  if (auth && auth.startsWith('Bearer ')) {
+    const token = auth.substring(7);
+    return { sub: token, role: token.startsWith('admin:') ? 'admin' : 'user', org: token.split(':')[1] };
+  }
+  return null;
+}
+
+export function createApp() {
+  return createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    const user = getUser(req);
+    if (!user) {
+      res.statusCode = 401;
+      res.end('Unauthorized');
+      return;
+    }
+
+    if (req.method === 'GET' && req.url?.startsWith('/me/gam/weekly')) {
+      await getWeeklyUser(req, res, user);
+      return;
+    }
+
+    const match = req.url?.match(/^\/org\/([^/]+)\/gam\/weekly/);
+    if (req.method === 'GET' && match) {
+      const orgId = match[1];
+      if (user.role !== 'admin' || user.org !== orgId) {
+        res.statusCode = 403;
+        res.end('forbidden');
+        return;
+      }
+      await getWeeklyOrg(req, res, orgId);
+      return;
+    }
+
+    res.statusCode = 404;
+    res.end('Not Found');
+  });
+}

--- a/services/gam/tests/gamWeekly.test.ts
+++ b/services/gam/tests/gamWeekly.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createApp } from '../server';
+import { insertWeekly, insertWeeklyOrg, clear } from '../lib/db';
+import { hash } from '../../journal/lib/hash';
+
+let server: any;
+let url: string;
+
+beforeEach(async () => {
+  clear();
+  await new Promise<void>(resolve => {
+    server = createApp().listen(0, () => {
+      const { port } = server.address();
+      url = `http://localhost:${port}`;
+      resolve();
+    });
+  });
+});
+
+afterEach(() => {
+  server.close();
+});
+
+describe('GET /me/gam/weekly', () => {
+  it('returns personal weekly KPIs', async () => {
+    insertWeekly({
+      user_id_hash: hash('hashX'),
+      week_start: '2025-05-19',
+      pa_avg: 0.42,
+      laugh_genuine_ratio: 0.3,
+      conn_depth_avg: 1.7,
+      shares_total: 6,
+      mvpa_min: 155,
+      streak_ratio: 0.66
+    });
+
+    const res = await fetch(url + '/me/gam/weekly', {
+      headers: { 'Authorization': 'Bearer hashX' }
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data)).toBe(true);
+  });
+});
+
+describe('GET /org/:orgId/gam/weekly', () => {
+  it('admin fetches org KPIs', async () => {
+    insertWeeklyOrg({
+      org_id: 'acme',
+      week_start: '2025-05-19',
+      n_members: 123,
+      pa_avg: 0.42,
+      laugh_genuine_ratio: 0.3,
+      conn_depth_avg: 1.7,
+      shares_total: 6,
+      mvpa_min: 155,
+      streak_ratio: 0.66
+    });
+
+    const res = await fetch(url + '/org/acme/gam/weekly', {
+      headers: { 'Authorization': 'Bearer admin:acme' }
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data[0]).toHaveProperty('n_members');
+  });
+});

--- a/vitest.api.config.ts
+++ b/vitest.api.config.ts
@@ -3,6 +3,10 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['services/journal/tests/**/*.ts', 'services/scan/tests/**/*.ts']
+    include: [
+      'services/journal/tests/**/*.ts',
+      'services/scan/tests/**/*.ts',
+      'services/gam/tests/**/*.ts'
+    ]
   }
 });


### PR DESCRIPTION
## Notes
- `npm run db:refresh:gam` fails in this container because `psql` is missing

## Summary
- add gam weekly endpoints and tests
- document `/me/gam/weekly` and `/org/{orgId}/gam/weekly` in docs and OpenAPI
- include gam tests in vitest config
- update scripts and changelog

## Testing
- `npm run db:refresh:gam` *(fails: psql not found)*
- `npm run test:api`