### PR TITLE
Implement VR weekly ETL

### DIFF
--- a/docs/etl_vr.md
+++ b/docs/etl_vr.md
@@ -1,0 +1,12 @@
+# ETL VR Weekly Views
+
+Ces vues matérialisées consolident les sessions **Bio‑Nebula** et **Glow‑Collective** sur une base hebdomadaire.
+
+```mermaid
+flowchart TD
+    A[vr_nebula_sessions] --> C(metrics_weekly_vr)
+    B[vr_dome_sessions] --> D(metrics_weekly_vr_org)
+    C --> D
+```
+
+La procédure `refresh_metrics_vr()` rafraîchit ces vues et est exécutée chaque nuit via **pg_cron**.

--- a/migrations/V20250610__vr_weekly.sql
+++ b/migrations/V20250610__vr_weekly.sql
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------
+  VR weekly metrics materialized views and refresh job
+---------------------------------------------------------------------------*/
+
+/* 1-A — Vue matérialisée utilisateur · metrics_weekly_vr */
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.metrics_weekly_vr AS
+SELECT
+  user_id_hash,
+  date_trunc('week', ts_finish)::date AS week_start,
+
+  percentile_cont(0.5) within group (order by rmssd_delta) AS hrv_gain_median,
+  avg(coherence_score)                                     AS coherence_avg
+FROM   vr_nebula_sessions
+GROUP  BY user_id_hash, week_start
+WITH   NO DATA;
+
+CREATE UNIQUE INDEX IF NOT EXISTS pk_metrics_weekly_vr
+  ON public.metrics_weekly_vr(user_id_hash, week_start);
+
+/* 1-B — Vue matérialisée organisation · metrics_weekly_vr_org */
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.metrics_weekly_vr_org AS
+SELECT
+  uom.org_id,
+  m.week_start,
+  count(*)                              AS members,
+  avg(m.hrv_gain_median)                AS org_hrv_gain,
+  avg(m.coherence_avg)                  AS org_coherence,
+  avg(d.synchrony_idx)                  AS org_sync_idx,
+  avg(d.team_pa)                        AS org_team_pa
+FROM public.metrics_weekly_vr  m
+JOIN public.user_org_map       uom USING (user_id_hash)
+LEFT JOIN (
+    SELECT  org_id,
+            date_trunc('week', ts)::date     AS week_start,
+            avg(hr_std)   AS synchrony_idx,
+            avg(valence)  AS team_pa
+    FROM    vr_dome_sessions v
+    JOIN    user_org_map    u USING (user_id_hash)
+    GROUP   BY org_id, week_start
+) d USING (org_id, week_start)
+GROUP BY uom.org_id, m.week_start
+WITH NO DATA;
+
+CREATE UNIQUE INDEX IF NOT EXISTS pk_metrics_weekly_vr_org
+  ON public.metrics_weekly_vr_org(org_id, week_start);
+
+/* 1-C — Droits lecture */
+GRANT SELECT ON metrics_weekly_vr, metrics_weekly_vr_org TO service_role;
+
+/* 2-A — Procédure de rafraîchissement */
+CREATE OR REPLACE PROCEDURE public.refresh_metrics_vr()
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  PERFORM REFRESH MATERIALIZED VIEW CONCURRENTLY public.metrics_weekly_vr;
+  PERFORM REFRESH MATERIALIZED VIEW CONCURRENTLY public.metrics_weekly_vr_org;
+END $$;
+
+/* 2-B — Planification pg_cron (03 h 15 UTC) */
+SELECT cron.schedule(
+  job_name  => 'refresh_metrics_vr',
+  schedule  => '15 3 * * *',
+  command   => $$CALL public.refresh_metrics_vr();$$
+);

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "db:migrate": "flyway -locations=filesystem:./migrations migrate",
     "db:refresh:scan": "psql $DATABASE_URL -c 'CALL public.refresh_metrics_scan();'",
     "db:refresh:gam": "psql $DATABASE_URL -c 'CALL public.refresh_metrics_gam();'",
+    "db:refresh:vr": "psql $DATABASE_URL -c 'CALL public.refresh_metrics_vr()'",
     "db:migrate": "supabase db push",
     "test:sql": "pgtap-run tests/sql/**/*.sql --dsn $DATABASE_URL",
     "db:refresh:journal": "psql $DATABASE_URL -c 'CALL public.refresh_metrics_weekly_journal();'",

--- a/tests/db/vr_weekly.test.ts
+++ b/tests/db/vr_weekly.test.ts
@@ -1,0 +1,11 @@
+import { it, expect } from 'vitest';
+import db from '../../database/tests/db/helpers/db';
+
+it('refresh populates user weekly row', async () => {
+  await db.raw('CALL public.refresh_metrics_vr()');
+  const row = await db
+      .selectFrom('metrics_weekly_vr')
+      .where('user_id_hash','=', 'hashA')
+      .executeTakeFirst();
+  expect(row?.hrv_gain_median).toBeDefined();
+});

--- a/tests/sql/vr_weekly.sql
+++ b/tests/sql/vr_weekly.sql
@@ -1,0 +1,32 @@
+BEGIN;
+SELECT plan(2);
+
+-- Mock : deux sessions Bio-Nebula, une session Glow-Collective
+INSERT INTO vr_nebula_sessions
+  (user_id_hash, ts_finish, rmssd_delta, coherence_score)
+VALUES
+ ('hashA', date_trunc('week', now()), 18, 70),
+ ('hashA', date_trunc('week', now()) + interval '1 day', 22, 80);
+
+INSERT INTO vr_dome_sessions
+  (user_id_hash, ts, hr_std, valence)
+VALUES ('hashA', date_trunc('week', now()), 6.0, 0.25);
+
+INSERT INTO user_org_map VALUES ('hashA', '00000000-0000-0000-0000-00000000AAAA')
+ON CONFLICT (user_id_hash) DO NOTHING;
+
+CALL public.refresh_metrics_vr();
+
+/* métrique perso */
+SELECT is(
+ (SELECT hrv_gain_median FROM public.metrics_weekly_vr
+  WHERE user_id_hash='hashA'), 20, 'median ΔRMSSD ok');
+
+/* métrique org */
+SELECT ok(
+ (SELECT org_sync_idx FROM public.metrics_weekly_vr_org
+  WHERE org_id='00000000-0000-0000-0000-00000000AAAA') IS NOT NULL,
+ 'org sync idx calculé');
+
+SELECT finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary
- add metrics_weekly_vr materialized views with refresh procedure
- schedule nightly refresh and expose refresh script
- create docs about VR ETL views
- add SQL and DB tests for VR weekly metrics

## Testing
- `npm run test:sql` *(fails: pgtap-run not found)*
- `npm run test:db:config` *(fails: vitest config and helper errors)*