### PR TITLE
Add basic breath rituals UI and tests

### DIFF
--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -5,6 +5,13 @@ import { LoadingIllustration } from '@/components/ui/loading-illustration';
 
 // Lazy load components
 const Home = React.lazy(() => import('./Home'));
+const BreathHome = React.lazy(() => import('./pages/BreathHome'));
+const FlowWalkStart = React.lazy(() => import('./pages/FlowWalkStart'));
+const FlowWalkLive = React.lazy(() => import('./pages/FlowWalkLive'));
+const FlowWalkSummary = React.lazy(() => import('./pages/FlowWalkSummary'));
+const GlowMugStart = React.lazy(() => import('./pages/GlowMugStart'));
+const GlowMugLive = React.lazy(() => import('./pages/GlowMugLive'));
+const GlowMugSummary = React.lazy(() => import('./pages/GlowMugSummary'));
 
 const AppRouter: React.FC = () => {
   console.log('AppRouter rendering with React:', !!React);
@@ -13,6 +20,13 @@ const AppRouter: React.FC = () => {
     <React.Suspense fallback={<LoadingIllustration />}>
       <Routes>
         <Route path="/" element={<Home />} />
+        <Route path="/breath" element={<BreathHome />} />
+        <Route path="/breath/flowwalk" element={<FlowWalkStart />} />
+        <Route path="/breath/flowwalk/live" element={<FlowWalkLive />} />
+        <Route path="/breath/flowwalk/summary" element={<FlowWalkSummary />} />
+        <Route path="/breath/glowmug" element={<GlowMugStart />} />
+        <Route path="/breath/glowmug/live" element={<GlowMugLive />} />
+        <Route path="/breath/glowmug/summary" element={<GlowMugSummary />} />
         <Route path="/*" element={<Home />} />
       </Routes>
     </React.Suspense>

--- a/src/components/BreathGauge.tsx
+++ b/src/components/BreathGauge.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface BreathGaugeProps {
+  coherence: boolean;
+}
+
+export const BreathGauge: React.FC<BreathGaugeProps> = ({ coherence }) => {
+  const color = coherence ? 'border-green-400' : 'border-blue-500';
+  return (
+    <div
+      role="presentation"
+      className={`w-16 h-16 rounded-full border-8 ${color} transition-colors`}
+    ></div>
+  );
+};
+
+export default BreathGauge;

--- a/src/components/HrvDeltaChip.tsx
+++ b/src/components/HrvDeltaChip.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface HrvDeltaChipProps {
+  delta: number;
+}
+
+export const HrvDeltaChip: React.FC<HrvDeltaChipProps> = ({ delta }) => {
+  const sign = delta >= 0 ? '+' : '';
+  return (
+    <span className="px-2 py-1 rounded-full bg-slate-100 text-sm text-slate-700">
+      {sign}{delta} RMSSD
+    </span>
+  );
+};
+
+export default HrvDeltaChip;

--- a/src/components/PastelButton.tsx
+++ b/src/components/PastelButton.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Button, ButtonProps } from './ui/button';
+
+export const PastelButton: React.FC<ButtonProps> = ({ className = '', ...props }) => {
+  return (
+    <Button
+      className={`bg-gradient-to-r from-pink-200 to-blue-200 text-slate-700 hover:from-pink-300 hover:to-blue-300 ${className}`}
+      {...props}
+    />
+  );
+};
+
+export default PastelButton;

--- a/src/components/__tests__/BreathGauge.test.tsx
+++ b/src/components/__tests__/BreathGauge.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@/tests/utils';
+import { describe, it, expect } from 'vitest';
+import BreathGauge from '../BreathGauge';
+
+describe('BreathGauge', () => {
+  it('passe au vert si coherence true', () => {
+    render(<BreathGauge coherence={true} />);
+    const gauge = screen.getByRole('presentation');
+    expect(gauge.className).toContain('border-green-400');
+  });
+});

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import { useUserMode } from '@/contexts/UserModeContext';
 import { SidebarProvider } from '@/components/ui/sidebar/SidebarContext';
 import { Button } from '@/components/ui/button';
-import { Home, Settings, User } from 'lucide-react';
+import { Home, Settings, User, Wind } from 'lucide-react';
+import { Link } from 'react-router-dom';
 
 export const Sidebar: React.FC = () => {
   const { userMode } = useUserMode();
@@ -12,18 +13,30 @@ export const Sidebar: React.FC = () => {
     <SidebarProvider>
       <div className="w-64 h-full bg-background border-r p-4">
         <div className="space-y-2">
-          <Button variant="ghost" className="w-full justify-start">
-            <Home className="mr-2 h-4 w-4" />
-            Accueil
-          </Button>
-          <Button variant="ghost" className="w-full justify-start">
-            <User className="mr-2 h-4 w-4" />
-            Profil
-          </Button>
-          <Button variant="ghost" className="w-full justify-start">
-            <Settings className="mr-2 h-4 w-4" />
-            Paramètres
-          </Button>
+          <Link to="/">
+            <Button variant="ghost" className="w-full justify-start">
+              <Home className="mr-2 h-4 w-4" />
+              Accueil
+            </Button>
+          </Link>
+          <Link to="/profile">
+            <Button variant="ghost" className="w-full justify-start">
+              <User className="mr-2 h-4 w-4" />
+              Profil
+            </Button>
+          </Link>
+          <Link to="/settings">
+            <Button variant="ghost" className="w-full justify-start">
+              <Settings className="mr-2 h-4 w-4" />
+              Paramètres
+            </Button>
+          </Link>
+          <Link to="/breath">
+            <Button variant="ghost" className="w-full justify-start">
+              <Wind className="mr-2 h-4 w-4" />
+              Respirer
+            </Button>
+          </Link>
         </div>
       </div>
     </SidebarProvider>

--- a/src/hooks/useBreathMic.ts
+++ b/src/hooks/useBreathMic.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+
+export const useBreathMic = () => {
+  const [rpm, setRpm] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setRpm(10 + Math.round(Math.random() * 4));
+    }, 2000);
+    return () => clearInterval(id);
+  }, []);
+
+  return { rpm };
+};
+
+export default useBreathMic;

--- a/src/hooks/useHRStream.ts
+++ b/src/hooks/useHRStream.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+export const useHRStream = () => {
+  const [hrPre] = useState(70);
+  const [hrv, setHrv] = useState(30);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setHrv(30 + Math.round(Math.random() * 10));
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return { hrPre, hrv };
+};
+
+export default useHRStream;

--- a/src/hooks/useHaptics.ts
+++ b/src/hooks/useHaptics.ts
@@ -1,0 +1,10 @@
+export const useHaptics = () => {
+  const pattern = (sequence: number[]) => {
+    if (typeof navigator !== 'undefined' && navigator.vibrate) {
+      navigator.vibrate(sequence);
+    }
+  };
+  return { pattern };
+};
+
+export default useHaptics;

--- a/src/hooks/usePedometer.ts
+++ b/src/hooks/usePedometer.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+
+export const usePedometer = () => {
+  const [cadence, setCadence] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setCadence(60 + Math.round(Math.random() * 20));
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return { cadence };
+};
+
+export default usePedometer;

--- a/src/pages/BreathHome.tsx
+++ b/src/pages/BreathHome.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import PastelButton from '@/components/PastelButton';
+import Shell from '@/Shell';
+
+const BreathHome: React.FC = () => {
+  return (
+    <Shell>
+      <div className="space-y-4">
+        <h1 className="text-3xl font-bold">Respirer</h1>
+        <div className="flex gap-4">
+          <Link to="/breath/flowwalk">
+            <PastelButton>Flow-Field Walk</PastelButton>
+          </Link>
+          <Link to="/breath/glowmug">
+            <PastelButton>Glow-Pulse Mug</PastelButton>
+          </Link>
+        </div>
+      </div>
+    </Shell>
+  );
+};
+
+export default BreathHome;

--- a/src/pages/FlowWalkLive.tsx
+++ b/src/pages/FlowWalkLive.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Shell from '@/Shell';
+import { useBreathStore } from '@/store/breathSlice';
+import usePedometer from '@/hooks/usePedometer';
+import useBreathMic from '@/hooks/useBreathMic';
+import useHRStream from '@/hooks/useHRStream';
+import BreathGauge from '@/components/BreathGauge';
+
+const FlowWalkLive: React.FC = () => {
+  const navigate = useNavigate();
+  const { cadence } = usePedometer();
+  const { rpm } = useBreathMic();
+  const { hrPre, hrv } = useHRStream();
+  const setFlowWalk = useBreathStore(state => state.setFlowWalk);
+
+  const coherence = Math.abs(cadence - rpm * 6) <= cadence * 0.1;
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setFlowWalk(prev => ({ rpmSeries: [...(prev.rpmSeries || []), rpm], cadenceSeries: [...(prev.cadenceSeries || []), cadence] }));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [rpm, cadence, setFlowWalk]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      navigate('/breath/flowwalk/summary');
+    }, 180000);
+    return () => clearTimeout(timer);
+  }, [navigate]);
+
+  return (
+    <Shell>
+      <div className="space-y-4">
+        <h1 className="text-xl font-bold">Marche en cours</h1>
+        <BreathGauge coherence={coherence} />
+        <div>Cadence: {cadence} spm</div>
+        <div>Rythme: {rpm} rpm</div>
+        <div>HRV: {hrv}</div>
+        <div>HR pré: {hrPre}</div>
+      </div>
+    </Shell>
+  );
+};
+
+export default FlowWalkLive;

--- a/src/pages/FlowWalkStart.tsx
+++ b/src/pages/FlowWalkStart.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import PastelButton from '@/components/PastelButton';
+import Shell from '@/Shell';
+import { useBreathStore } from '@/store/breathSlice';
+
+const FlowWalkStart: React.FC = () => {
+  const navigate = useNavigate();
+  const setFlowWalk = useBreathStore(state => state.setFlowWalk);
+
+  const handleStart = () => {
+    setFlowWalk({ start: new Date() });
+    navigate('/breath/flowwalk/live');
+  };
+
+  return (
+    <Shell>
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold">Flow-Field Walk</h1>
+        <p>Marchez 3 minutes en synchronisant votre souffle.</p>
+        <PastelButton onClick={handleStart}>Commencer</PastelButton>
+      </div>
+    </Shell>
+  );
+};
+
+export default FlowWalkStart;

--- a/src/pages/FlowWalkSummary.tsx
+++ b/src/pages/FlowWalkSummary.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import Shell from '@/Shell';
+import { useBreathStore } from '@/store/breathSlice';
+import HrvDeltaChip from '@/components/HrvDeltaChip';
+
+const FlowWalkSummary: React.FC = () => {
+  const { flowWalk } = useBreathStore();
+  const coherencePct = 0; // placeholder
+
+  React.useEffect(() => {
+    // analytics placeholder
+    console.log('flowwalk_end', coherencePct, flowWalk.rpmSeries.length);
+  }, []);
+
+  return (
+    <Shell>
+      <div className="space-y-4">
+        <h1 className="text-xl font-bold">Résumé Flow Walk</h1>
+        <HrvDeltaChip delta={flowWalk.rpmSeries.length} />
+      </div>
+    </Shell>
+  );
+};
+
+export default FlowWalkSummary;

--- a/src/pages/GlowMugLive.tsx
+++ b/src/pages/GlowMugLive.tsx
@@ -1,0 +1,28 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Shell from '@/Shell';
+import useHaptics from '@/hooks/useHaptics';
+
+const GlowMugLive: React.FC = () => {
+  const navigate = useNavigate();
+  const { pattern } = useHaptics();
+
+  useEffect(() => {
+    pattern([0, 5000, 5000]);
+    const timer = setTimeout(() => {
+      navigate('/breath/glowmug/summary');
+    }, 120000);
+    return () => clearTimeout(timer);
+  }, [navigate, pattern]);
+
+  return (
+    <Shell>
+      <div className="space-y-4">
+        <h1 className="text-xl font-bold">Glow Mug</h1>
+        <p>Vibration active...</p>
+      </div>
+    </Shell>
+  );
+};
+
+export default GlowMugLive;

--- a/src/pages/GlowMugStart.tsx
+++ b/src/pages/GlowMugStart.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import PastelButton from '@/components/PastelButton';
+import Shell from '@/Shell';
+
+const GlowMugStart: React.FC = () => {
+  const navigate = useNavigate();
+
+  const handleStart = () => {
+    navigate('/breath/glowmug/live');
+  };
+
+  return (
+    <Shell>
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold">Glow-Pulse Mug</h1>
+        <p>Respirez avec votre mug pendant 2 minutes.</p>
+        <PastelButton onClick={handleStart}>Commencer</PastelButton>
+      </div>
+    </Shell>
+  );
+};
+
+export default GlowMugStart;

--- a/src/pages/GlowMugSummary.tsx
+++ b/src/pages/GlowMugSummary.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Shell from '@/Shell';
+import { useBreathStore } from '@/store/breathSlice';
+
+const GlowMugSummary: React.FC = () => {
+  const { glowMug } = useBreathStore();
+
+  React.useEffect(() => {
+    console.log('glowmug_end');
+  }, []);
+
+  return (
+    <Shell>
+      <div className="space-y-4">
+        <h1 className="text-xl font-bold">Résumé Glow Mug</h1>
+        <div>HR post: {glowMug.hrPost}</div>
+      </div>
+    </Shell>
+  );
+};
+
+export default GlowMugSummary;

--- a/src/pages/__tests__/FlowWalkStart.test.tsx
+++ b/src/pages/__tests__/FlowWalkStart.test.tsx
@@ -1,0 +1,16 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@/tests/utils';
+vi.mock('@/Shell', () => ({ __esModule: true, default: ({ children }: any) => <>{children}</> }));
+import FlowWalkStart from '../FlowWalkStart';
+
+describe('FlowWalkStart', () => {
+  it('bouton "Commencer" déclenche navigation', async () => {
+    localStorage.setItem('user', JSON.stringify({ id: '1', email: 't@test.com' }));
+    render(<FlowWalkStart />);
+    await userEvent.click(screen.getByText('Commencer'));
+    expect(window.location.pathname).toBe('/breath/flowwalk/live');
+    localStorage.clear();
+  });
+});

--- a/src/store/breathSlice.ts
+++ b/src/store/breathSlice.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+
+export interface FlowWalkData {
+  start?: Date;
+  steps?: number;
+  rpmSeries: number[];
+  cadenceSeries: number[];
+}
+
+export interface GlowMugData {
+  hrPre?: number;
+  hrPost?: number;
+  mood?: number;
+}
+
+export interface BreathState {
+  flowWalk: FlowWalkData;
+  glowMug: GlowMugData;
+  setFlowWalk: (data: Partial<FlowWalkData>) => void;
+  reset: () => void;
+}
+
+export const useBreathStore = create<BreathState>((set) => ({
+  flowWalk: { rpmSeries: [], cadenceSeries: [] },
+  glowMug: {},
+  setFlowWalk: (data) =>
+    set((state) => ({ flowWalk: { ...state.flowWalk, ...data } })),
+  reset: () => set({ flowWalk: { rpmSeries: [], cadenceSeries: [] }, glowMug: {} }),
+}));


### PR DESCRIPTION
## Summary
- create breath ritual pages and navigation
- implement placeholder sensor hooks and breath store
- add PastelButton, BreathGauge and HRV chip components
- wire breath routes in router and sidebar menu
- add tests for navigation and gauge color

## Testing
- `npx vitest run src/pages/__tests__/FlowWalkStart.test.tsx src/components/__tests__/BreathGauge.test.tsx`