### PR TITLE
feat: breath weekly endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,10 @@ jobs:
         timeout-minutes: 10
       - name: Refresh VR metrics before API tests
         run: psql "$DATABASE_URL" -c 'CALL public.refresh_metrics_vr();'
+      - name: Refresh breath metrics before API tests
+        run: psql "$DATABASE_URL" -c 'CALL public.refresh_metrics_breath();'
+      - name: Refresh breath org metrics before API tests
+        run: psql "$DATABASE_URL" -c 'CALL public.refresh_metrics_breath();'
       - name: Run API tests
         run: npm run test:api
       - name: Database migrations

--- a/docs/api/breath_weekly.md
+++ b/docs/api/breath_weekly.md
@@ -1,0 +1,9 @@
+# Endpoints Breath Weekly
+
+Ces routes exposent les KPI hebdomadaires de breathwork.
+
+## GET `/me/breath/weekly?since=YYYY-MM-DD`
+Retourne les métriques personnelles de l'utilisateur authentifié.
+
+## GET `/org/:orgId/breath/weekly?since=YYYY-MM-DD`
+Retourne les métriques agrégées pour une organisation (rôle admin requis).

--- a/openapi/breath.yaml
+++ b/openapi/breath.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: Breath API
+  version: 1.0.0
+paths:
+  /me/breath/weekly:
+    get:
+      summary: KPIs breath hebdo (utilisateur)
+      responses:
+        '200':
+          description: Weekly breath metrics
+  /org/{orgId}/breath/weekly:
+    get:
+      summary: KPIs breath hebdo (organisation)
+      parameters:
+        - in: path
+          name: orgId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Weekly breath org metrics

--- a/services/breath/handlers/getWeeklyOrg.ts
+++ b/services/breath/handlers/getWeeklyOrg.ts
@@ -1,0 +1,18 @@
+import { IncomingMessage, ServerResponse } from 'http';
+import { listWeeklyOrg } from '../lib/db';
+
+function parseSince(url: string | undefined): Date {
+  const sinceParam = new URL('http://localhost' + (url || '')).searchParams.get('since');
+  if (sinceParam) return new Date(sinceParam);
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - 56);
+  return d;
+}
+
+export async function getWeeklyOrg(req: IncomingMessage, res: ServerResponse, orgId: string) {
+  const since = parseSince(req.url);
+  const rows = listWeeklyOrg(orgId, since);
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify(rows));
+}

--- a/services/breath/handlers/getWeeklyUser.ts
+++ b/services/breath/handlers/getWeeklyUser.ts
@@ -1,0 +1,20 @@
+import { IncomingMessage, ServerResponse } from 'http';
+import { hash } from '../../journal/lib/hash';
+import { listWeekly } from '../lib/db';
+
+function parseSince(url: string | undefined): Date {
+  const sinceParam = new URL('http://localhost' + (url || '')).searchParams.get('since');
+  if (sinceParam) return new Date(sinceParam);
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - 56); // 8 weeks
+  return d;
+}
+
+export async function getWeeklyUser(req: IncomingMessage, res: ServerResponse, user: any) {
+  const since = parseSince(req.url);
+  const userHash = hash(user.sub);
+  const rows = listWeekly(userHash, since);
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify(rows));
+}

--- a/services/breath/index.ts
+++ b/services/breath/index.ts
@@ -1,0 +1,7 @@
+import { createApp } from './server';
+
+const app = createApp();
+const port = process.env.PORT || 3005;
+app.listen(port, () => {
+  console.log(`breath api listening on ${port}`);
+});

--- a/services/breath/lib/db.ts
+++ b/services/breath/lib/db.ts
@@ -1,0 +1,50 @@
+export type BreathWeeklyRow = {
+  user_id_hash: string;
+  week_start: string;
+  hrv_stress_idx: number | null;
+  coherence_avg: number | null;
+  mvpa_week: number | null;
+  relax_idx: number | null;
+  mindfulness_avg: number | null;
+  mood_score: number | null;
+};
+
+export type BreathWeeklyOrgRow = {
+  org_id: string;
+  week_start: string;
+  members: number;
+  org_hrv_idx: number | null;
+  org_coherence: number | null;
+  org_mvpa: number | null;
+  org_relax: number | null;
+  org_mindfulness: number | null;
+  org_mood: number | null;
+};
+
+const weekly: BreathWeeklyRow[] = [];
+const weeklyOrg: BreathWeeklyOrgRow[] = [];
+
+export function insertWeekly(row: BreathWeeklyRow) {
+  weekly.push(row);
+}
+
+export function insertWeeklyOrg(row: BreathWeeklyOrgRow) {
+  weeklyOrg.push(row);
+}
+
+export function listWeekly(userHash: string, since: Date): BreathWeeklyRow[] {
+  return weekly
+    .filter(r => r.user_id_hash === userHash && new Date(r.week_start) >= since)
+    .sort((a, b) => b.week_start.localeCompare(a.week_start));
+}
+
+export function listWeeklyOrg(orgId: string, since: Date): BreathWeeklyOrgRow[] {
+  return weeklyOrg
+    .filter(r => r.org_id === orgId && new Date(r.week_start) >= since)
+    .sort((a, b) => b.week_start.localeCompare(a.week_start));
+}
+
+export function clear() {
+  weekly.length = 0;
+  weeklyOrg.length = 0;
+}

--- a/services/breath/server.ts
+++ b/services/breath/server.ts
@@ -1,0 +1,43 @@
+import { createServer, IncomingMessage, ServerResponse } from 'http';
+import { getWeeklyUser } from './handlers/getWeeklyUser';
+import { getWeeklyOrg } from './handlers/getWeeklyOrg';
+
+function getUser(req: IncomingMessage) {
+  const auth = req.headers['authorization'];
+  if (auth && auth.startsWith('Bearer ')) {
+    const token = auth.substring(7);
+    return { sub: token, role: token.startsWith('admin:') ? 'admin' : 'user', org: token.split(':')[1] };
+  }
+  return null;
+}
+
+export function createApp() {
+  return createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    const user = getUser(req);
+    if (!user) {
+      res.statusCode = 401;
+      res.end('Unauthorized');
+      return;
+    }
+
+    if (req.method === 'GET' && req.url?.startsWith('/me/breath/weekly')) {
+      await getWeeklyUser(req, res, user);
+      return;
+    }
+
+    const match = req.url?.match(/^\/org\/([^/]+)\/breath\/weekly/);
+    if (req.method === 'GET' && match) {
+      const orgId = match[1];
+      if (user.role !== 'admin' || user.org !== orgId) {
+        res.statusCode = 403;
+        res.end('forbidden');
+        return;
+      }
+      await getWeeklyOrg(req, res, orgId);
+      return;
+    }
+
+    res.statusCode = 404;
+    res.end('Not Found');
+  });
+}

--- a/services/breath/tests/breathWeekly.test.ts
+++ b/services/breath/tests/breathWeekly.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createApp } from '../server';
+import { insertWeekly, insertWeeklyOrg, clear } from '../lib/db';
+import { hash } from '../../journal/lib/hash';
+
+let server: any;
+let url: string;
+
+beforeEach(async () => {
+  clear();
+  await new Promise<void>(resolve => {
+    server = createApp().listen(0, () => {
+      const { port } = server.address();
+      url = `http://localhost:${port}`;
+      resolve();
+    });
+  });
+});
+
+afterEach(() => {
+  server.close();
+});
+
+describe('GET /me/breath/weekly', () => {
+  it('user fetches own breath KPIs', async () => {
+    insertWeekly({
+      user_id_hash: hash('hashX'),
+      week_start: '2025-05-19',
+      hrv_stress_idx: 25,
+      coherence_avg: 88,
+      mvpa_week: 40,
+      relax_idx: 6,
+      mindfulness_avg: 3.2,
+      mood_score: 0.5
+    });
+
+    const res = await fetch(url + '/me/breath/weekly', {
+      headers: { 'Authorization': 'Bearer hashX' }
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data)).toBe(true);
+  });
+});
+
+describe('GET /org/:orgId/breath/weekly', () => {
+  it('admin fetches org KPIs', async () => {
+    insertWeeklyOrg({
+      org_id: 'acme',
+      week_start: '2025-05-19',
+      members: 10,
+      org_hrv_idx: 22,
+      org_coherence: 80,
+      org_mvpa: 45,
+      org_relax: 7,
+      org_mindfulness: 2.8,
+      org_mood: 0.4
+    });
+
+    const res = await fetch(url + '/org/acme/breath/weekly', {
+      headers: { 'Authorization': 'Bearer admin:acme' }
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data[0]).toHaveProperty('members');
+  });
+});

--- a/vitest.api.config.ts
+++ b/vitest.api.config.ts
@@ -7,7 +7,8 @@ export default defineConfig({
       'services/journal/tests/**/*.ts',
       'services/scan/tests/**/*.ts',
       'services/gam/tests/**/*.ts',
-      'services/vr/tests/**/*.ts'
+      'services/vr/tests/**/*.ts',
+      'services/breath/tests/**/*.ts'
     ]
   }
 });


### PR DESCRIPTION
## Summary
- add breath weekly service with handlers, server and tests
- document breath weekly API and OpenAPI spec
- include breath tests in vitest config
- refresh breath metrics in CI before API tests

## Testing
- `npm run test:api`
