### PR TITLE
Add breath dashboard components

### DIFF
--- a/public/locales/en/breath.json
+++ b/public/locales/en/breath.json
@@ -1,0 +1,9 @@
+{
+  "title": "Breath Dashboard",
+  "hrvStress": "HRV-Stress Index",
+  "coherence": "Coherence",
+  "mvpa": "Active Minutes",
+  "relax": "Relaxation",
+  "mindfulness": "Mindfulness",
+  "mood": "Mood"
+}

--- a/public/locales/fr/breath.json
+++ b/public/locales/fr/breath.json
@@ -1,0 +1,9 @@
+{
+  "title": "Tableau Respiratoire",
+  "hrvStress": "Indice Stress HRV",
+  "coherence": "Cohérence",
+  "mvpa": "Minutes Actives",
+  "relax": "Relaxation",
+  "mindfulness": "Pleine conscience",
+  "mood": "Humeur"
+}

--- a/src/components/breath/BreathHeatmap.tsx
+++ b/src/components/breath/BreathHeatmap.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { BreathOrgRow } from '@/services/breathApi';
+
+interface Props {
+  data: BreathOrgRow[];
+}
+
+const colorFor = (v: number) => {
+  if (v > 0.7) return 'bg-green-300';
+  if (v > 0.4) return 'bg-yellow-300';
+  return 'bg-red-300';
+};
+
+const BreathHeatmap: React.FC<Props> = ({ data }) => {
+  const kpis = ['hrv_stress_idx','coherence_avg','mvpa_minutes','relax_pct','mindfulness_pct','mood_avg'] as const;
+  return (
+    <table className="min-w-full text-center text-xs" role="grid">
+      <thead>
+        <tr>
+          <th></th>
+          {data.map(row => (
+            <th key={row.week}>{row.week}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {kpis.map(k => (
+          <tr key={k}>
+            <td className="font-medium">{k}</td>
+            {data.map(row => (
+              <td key={row.week + k} className={colorFor((row as any)[k])}>
+                {(row as any)[k].toFixed(1)}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+export default BreathHeatmap;

--- a/src/components/breath/BreathSummaryCards.tsx
+++ b/src/components/breath/BreathSummaryCards.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { BreathRow } from '@/services/breathApi';
+
+interface Props {
+  data: BreathRow | null;
+  locale?: string;
+}
+
+const labels = {
+  hrvStress: 'HRV-Stress',
+  coherence: 'Coherence',
+  mvpa: 'MVPA',
+  relax: 'Relax',
+  mindfulness: 'Mindfulness',
+  mood: 'Mood',
+};
+
+const BreathSummaryCards: React.FC<Props> = ({ data, locale = 'en-US' }) => {
+  const nf = new Intl.NumberFormat(locale);
+  const cards = [
+    { key: 'hrv_stress_idx', label: labels.hrvStress },
+    { key: 'coherence_avg', label: labels.coherence },
+    { key: 'mvpa_minutes', label: labels.mvpa },
+    { key: 'relax_pct', label: labels.relax },
+    { key: 'mindfulness_pct', label: labels.mindfulness },
+    { key: 'mood_avg', label: labels.mood },
+  ] as const;
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+      {cards.map(c => (
+        <Card role="article" key={c.key} className="text-center">
+          <CardHeader>
+            <CardTitle className="text-sm">{c.label}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {data && (
+              <div className="text-2xl font-bold" data-testid={`value-${c.key}`}>
+                {nf.format((data as any)[c.key])}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+};
+
+export default BreathSummaryCards;

--- a/src/components/breath/BreathTrendChart.tsx
+++ b/src/components/breath/BreathTrendChart.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { BreathRow } from '@/services/breathApi';
+
+interface Props {
+  data: BreathRow[];
+  height?: number;
+}
+
+const BreathTrendChart: React.FC<Props> = ({ data, height = 200 }) => {
+  return (
+    <div style={{ width: '100%', height }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data} margin={{ top: 5, right: 20, left: 10, bottom: 5 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="week" />
+          <YAxis domain={[0, 'dataMax']} aria-label="Breath KPIs" />
+          <Tooltip />
+          <Line type="monotone" dataKey="hrv_stress_idx" stroke="#ef4444" name="HRV" />
+          <Line type="monotone" dataKey="coherence_avg" stroke="#22c55e" name="Coherence" />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default BreathTrendChart;

--- a/src/components/breath/KpiInfoDrawer.tsx
+++ b/src/components/breath/KpiInfoDrawer.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle, DrawerTrigger } from '@/components/ui/drawer';
+
+interface Props {
+  title: string;
+  children: React.ReactNode;
+}
+
+const KpiInfoDrawer: React.FC<Props> = ({ title, children }) => (
+  <Drawer>
+    <DrawerTrigger asChild>
+      <button aria-label="info" className="ml-2 text-sm">i</button>
+    </DrawerTrigger>
+    <DrawerContent>
+      <DrawerHeader>
+        <DrawerTitle>{title}</DrawerTitle>
+      </DrawerHeader>
+      <div className="p-4 text-sm">{children}</div>
+    </DrawerContent>
+  </Drawer>
+);
+
+export default KpiInfoDrawer;

--- a/src/components/breath/MembersSparkBar.tsx
+++ b/src/components/breath/MembersSparkBar.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { BarChart, Bar, XAxis, Tooltip, ResponsiveContainer } from 'recharts';
+
+interface Row { week: string; member_count: number; }
+
+interface Props { data: Row[]; }
+
+const MembersSparkBar: React.FC<Props> = ({ data }) => (
+  <div style={{ width: '100%', height: 80 }}>
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={data} margin={{ top: 5, right: 10, left: 10, bottom: 0 }}>
+        <XAxis dataKey="week" hide />
+        <Tooltip />
+        <Bar dataKey="member_count" fill="#60a5fa" />
+      </BarChart>
+    </ResponsiveContainer>
+  </div>
+);
+
+export default MembersSparkBar;

--- a/src/components/breath/__tests__/BreathHeatmap.test.tsx
+++ b/src/components/breath/__tests__/BreathHeatmap.test.tsx
@@ -1,0 +1,16 @@
+import { screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@/tests/utils';
+import BreathHeatmap from '../BreathHeatmap';
+
+const data = [
+  { week: 'w1', hrv_stress_idx: 0.2, coherence_avg: 0.5, mvpa_minutes: 1, relax_pct: 0.6, mindfulness_pct: 0.7, mood_avg: 0.8, member_count: 3 },
+];
+
+describe('BreathHeatmap', () => {
+  it('heat-map colors cells by threshold', () => {
+    render(<BreathHeatmap data={data} />);
+    const cells = screen.getAllByRole('cell');
+    expect(cells[1].className).toContain('bg-red-300');
+  });
+});

--- a/src/pages/BreathOrgPage.tsx
+++ b/src/pages/BreathOrgPage.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import dayjs from 'dayjs';
+import Shell from '@/Shell';
+import BreathHeatmap from '@/components/breath/BreathHeatmap';
+import MembersSparkBar from '@/components/breath/MembersSparkBar';
+import { useBreathDataStore } from '@/store/useBreathStore';
+
+const ORG_ID = '1';
+
+const BreathOrgPage: React.FC = () => {
+  const [rows, setRows] = React.useState([]);
+  const getOrg = useBreathDataStore(s => s.getOrgWeekly);
+
+  React.useEffect(() => {
+    getOrg(ORG_ID, dayjs().subtract(8, 'week')).then(setRows);
+  }, [getOrg]);
+
+  return (
+    <Shell>
+      <div className="space-y-6 py-4">
+        <h1 className="text-2xl font-bold">Breath KPIs</h1>
+        <MembersSparkBar data={rows} />
+        <BreathHeatmap data={rows} />
+      </div>
+    </Shell>
+  );
+};
+
+export default BreathOrgPage;

--- a/src/pages/BreathUserPage.tsx
+++ b/src/pages/BreathUserPage.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import dayjs from 'dayjs';
+import Shell from '@/Shell';
+import BreathSummaryCards from '@/components/breath/BreathSummaryCards';
+import BreathTrendChart from '@/components/breath/BreathTrendChart';
+import { useBreathDataStore } from '@/store/useBreathStore';
+
+const BreathUserPage: React.FC = () => {
+  const [rows, setRows] = React.useState([]);
+  const getWeekly = useBreathDataStore(s => s.getUserWeekly);
+
+  React.useEffect(() => {
+    getWeekly(dayjs().subtract(4, 'week')).then(setRows);
+  }, [getWeekly]);
+
+  const latest = rows[rows.length - 1] || null;
+
+  return (
+    <Shell>
+      <div className="space-y-6 py-4">
+        <h1 className="text-2xl font-bold">Respiration</h1>
+        <BreathSummaryCards data={latest} />
+        <BreathTrendChart data={rows} />
+      </div>
+    </Shell>
+  );
+};
+
+export default BreathUserPage;

--- a/src/pages/__tests__/BreathUserPage.test.tsx
+++ b/src/pages/__tests__/BreathUserPage.test.tsx
@@ -1,0 +1,24 @@
+import { screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@/tests/utils';
+import { GlobalInterceptor } from '@/utils/globalInterceptor';
+import BreathUserPage from '../BreathUserPage';
+
+const mockRows = [
+  { week: '2024-01', hrv_stress_idx: 1, coherence_avg: 2, mvpa_minutes: 3, relax_pct: 4, mindfulness_pct: 5, mood_avg: 6 },
+];
+
+vi.mock('@/utils/globalInterceptor');
+
+describe('BreathUserPage', () => {
+  it('renders 6 KPI cards with data', async () => {
+    vi.mocked(GlobalInterceptor.secureFetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: mockRows }),
+    } as any);
+
+    render(<BreathUserPage />);
+    expect(await screen.findByText(/HRV-Stress/i)).toBeVisible();
+    expect(screen.getAllByRole('article')).toHaveLength(6);
+  });
+});

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -17,6 +17,8 @@ const B2BUserDashboard = React.lazy(() => import('./pages/b2b/user/B2BUserDashbo
 const B2BAdminLoginPage = React.lazy(() => import('./pages/auth/B2BAdminLoginPage'));
 const B2BAdminDashboard = React.lazy(() => import('./pages/b2b/admin/B2BAdminDashboard'));
 const AuditPage = React.lazy(() => import('./pages/audit/AuditPage'));
+const BreathUserPage = React.lazy(() => import('./pages/BreathUserPage'));
+const BreathOrgPage = React.lazy(() => import('./pages/BreathOrgPage'));
 
 // Layout Components
 const B2CLayout = React.lazy(() => import('./layouts/B2CLayout'));
@@ -68,6 +70,10 @@ export const routes = [
         path: 'dashboard',
         element: withSuspense(B2CDashboard)(),
       },
+      {
+        path: 'dashboard/breath',
+        element: withSuspense(BreathUserPage)(),
+      },
     ],
   },
   // B2B User Routes
@@ -109,6 +115,10 @@ export const routes = [
       {
         path: 'dashboard',
         element: withSuspense(B2BAdminDashboard)(),
+      },
+      {
+        path: 'breath',
+        element: withSuspense(BreathOrgPage)(),
       },
     ],
   },

--- a/src/services/breathApi.ts
+++ b/src/services/breathApi.ts
@@ -1,0 +1,37 @@
+import dayjs from 'dayjs';
+import { GlobalInterceptor } from '@/utils/globalInterceptor';
+
+export interface BreathRow {
+  week: string;
+  hrv_stress_idx: number;
+  coherence_avg: number;
+  mvpa_minutes: number;
+  relax_pct: number;
+  mindfulness_pct: number;
+  mood_avg: number;
+}
+
+export interface BreathOrgRow extends BreathRow {
+  member_count: number;
+}
+
+export const fetchUserWeekly = async (since?: string): Promise<BreathRow[]> => {
+  const qs = since ? `?since=${since}` : '';
+  const res = await GlobalInterceptor.secureFetch(`/me/breath/weekly${qs}`);
+  if (!res) throw new Error('Request failed');
+  const { data } = await res.json();
+  return data as BreathRow[];
+};
+
+export const fetchOrgWeekly = async (
+  orgId: string,
+  since?: string
+): Promise<BreathOrgRow[]> => {
+  const qs = since ? `?since=${since}` : '';
+  const res = await GlobalInterceptor.secureFetch(
+    `/org/${orgId}/breath/weekly${qs}`
+  );
+  if (!res) throw new Error('Request failed');
+  const { data } = await res.json();
+  return data as BreathOrgRow[];
+};

--- a/src/store/useBreathStore.ts
+++ b/src/store/useBreathStore.ts
@@ -1,0 +1,41 @@
+import { create } from 'zustand';
+import dayjs from 'dayjs';
+import { fetchUserWeekly, fetchOrgWeekly, BreathRow, BreathOrgRow } from '@/services/breathApi';
+
+interface CacheEntry<T> {
+  data: T;
+  timestamp: number;
+}
+
+interface BreathDataStore {
+  userWeekly?: CacheEntry<BreathRow[]>;
+  orgWeekly: Record<string, CacheEntry<BreathOrgRow[]>>;
+  getUserWeekly: (since?: dayjs.Dayjs) => Promise<BreathRow[]>;
+  getOrgWeekly: (orgId: string, since?: dayjs.Dayjs) => Promise<BreathOrgRow[]>;
+}
+
+const FIVE_MIN = 5 * 60 * 1000;
+
+export const useBreathDataStore = create<BreathDataStore>((set, get) => ({
+  orgWeekly: {},
+  async getUserWeekly(since) {
+    const cache = get().userWeekly;
+    if (cache && Date.now() - cache.timestamp < FIVE_MIN) {
+      return cache.data;
+    }
+    const data = await fetchUserWeekly(since?.format('YYYY-MM-DD'));
+    set({ userWeekly: { data, timestamp: Date.now() } });
+    return data;
+  },
+  async getOrgWeekly(orgId, since) {
+    const cache = get().orgWeekly[orgId];
+    if (cache && Date.now() - cache.timestamp < FIVE_MIN) {
+      return cache.data;
+    }
+    const data = await fetchOrgWeekly(orgId, since?.format('YYYY-MM-DD'));
+    set(state => ({
+      orgWeekly: { ...state.orgWeekly, [orgId]: { data, timestamp: Date.now() } }
+    }));
+    return data;
+  }
+}));


### PR DESCRIPTION
## Summary
- create breath API service and zustand store
- implement breath summary cards, trend chart, heatmap and sparkbar
- add user and admin breath pages
- add i18n resources
- extend router
- include basic tests for widgets

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm run tsc`
- `npm run test -- --coverage` *(fails: missing @vitest/coverage-v8)*