### PR TITLE
Implement Glow Privacy prefs API

### DIFF
--- a/migrations/V20250609__privacy_prefs.sql
+++ b/migrations/V20250609__privacy_prefs.sql
@@ -1,0 +1,23 @@
+/* 1-A  TABLE ------------------------------------------------------- */
+CREATE TABLE IF NOT EXISTS public.privacy_prefs (
+  user_id_hash text PRIMARY KEY,
+  cam          boolean NOT NULL DEFAULT true,
+  mic          boolean NOT NULL DEFAULT true,
+  hr           boolean NOT NULL DEFAULT true,
+  gps          boolean NOT NULL DEFAULT true,
+  social       boolean NOT NULL DEFAULT true,
+  nft          boolean NOT NULL DEFAULT true,
+  updated_at   timestamptz NOT NULL DEFAULT now()
+);
+
+/* 1-B  RLS --------------------------------------------------------- */
+ALTER TABLE public.privacy_prefs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY p_priv_select ON public.privacy_prefs
+  FOR SELECT USING (user_id_hash = current_setting('request.jwt.claim.user_hash', true));
+
+CREATE POLICY p_priv_upsert ON public.privacy_prefs
+  FOR INSERT WITH CHECK (user_id_hash = current_setting('request.jwt.claim.user_hash', true))
+  FOR UPDATE USING (user_id_hash = current_setting('request.jwt.claim.user_hash', true));
+
+/* 1-C  Seed (création auto à la 1ʳᵉ connexion) : HANDLED côté API */

--- a/openapi/privacy.yaml
+++ b/openapi/privacy.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.0
+info:
+  title: Glow Privacy API
+  version: 1.0.0
+paths:
+  /user/privacy:
+    get:
+      summary: Récupère les préférences Glow Privacy
+      responses:
+        '200':
+          description: Objet préférences
+    put:
+      summary: Met à jour les préférences Glow Privacy
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                cam:    { type: boolean }
+                mic:    { type: boolean }
+                hr:     { type: boolean }
+                gps:    { type: boolean }
+                social: { type: boolean }
+                nft:    { type: boolean }
+      responses:
+        '204':
+          description: Preferences updated

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "jsdom": "^22.1.0",
     "lovable-tagger": "^1.1.8",
     "postcss": "^8.5.3",
+    "supertest": "^6.3.3",
     "tailwindcss": "^3.4.3",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.0.1",

--- a/services/privacy/handlers/getPrivacy.ts
+++ b/services/privacy/handlers/getPrivacy.ts
@@ -1,0 +1,19 @@
+import { IncomingMessage, ServerResponse } from "http";
+import { getPrefs, initPrefs } from "../lib/db";
+import { hash as hashUser } from '../../journal/lib/hash';
+export async function getPrivacy(req: IncomingMessage, res: ServerResponse, user: any) {
+  const userHash = hashUser(user.sub);
+  let row = getPrefs(userHash);
+  if (!row) {
+    row = initPrefs(userHash);
+    res.statusCode = 200;
+    res.setHeader('Content-Type','application/json');
+    const { user_id_hash, updated_at, ...prefs } = row;
+    res.end(JSON.stringify(prefs));
+    return;
+  }
+  const { user_id_hash, ...rest } = row;
+  res.statusCode = 200;
+  res.setHeader('Content-Type','application/json');
+  res.end(JSON.stringify(rest));
+}

--- a/services/privacy/handlers/updatePrivacy.ts
+++ b/services/privacy/handlers/updatePrivacy.ts
@@ -1,0 +1,25 @@
+import { IncomingMessage, ServerResponse } from 'http';
+import { updatePrefs, logChange } from '../lib/db';
+import { hash as hashUser } from '../../journal/lib/hash';
+
+export async function updatePrivacy(req: IncomingMessage, res: ServerResponse, user: any) {
+  const userHash = hashUser(user.sub);
+  let body = '';
+  for await (const chunk of req) body += chunk;
+  const data = JSON.parse(body || '{}');
+  const allowed = ['cam','mic','hr','gps','social','nft'];
+  const patch: any = {};
+  for (const key of allowed) if (key in data) patch[key] = data[key];
+
+  if (Object.keys(patch).length === 0) {
+    res.statusCode = 400;
+    res.setHeader('Content-Type','application/json');
+    res.end(JSON.stringify({ error: 'Empty payload' }));
+    return;
+  }
+
+  updatePrefs(userHash, patch);
+  logChange(userHash, patch);
+  res.statusCode = 204;
+  res.end();
+}

--- a/services/privacy/index.ts
+++ b/services/privacy/index.ts
@@ -1,0 +1,7 @@
+import { createApp } from './server';
+
+const app = createApp();
+const port = process.env.PORT || 3010;
+app.listen(port, () => {
+  console.log(`privacy api listening on ${port}`);
+});

--- a/services/privacy/lib/db.ts
+++ b/services/privacy/lib/db.ts
@@ -1,0 +1,48 @@
+export type PrivacyPrefs = {
+  user_id_hash: string;
+  cam: boolean;
+  mic: boolean;
+  hr: boolean;
+  gps: boolean;
+  social: boolean;
+  nft: boolean;
+  updated_at: string;
+};
+
+export const DEFAULT_PREFS: Omit<PrivacyPrefs,'user_id_hash'|'updated_at'> = {
+  cam: true,
+  mic: true,
+  hr: true,
+  gps: true,
+  social: true,
+  nft: true
+};
+
+const prefs = new Map<string, PrivacyPrefs>();
+
+export function getPrefs(hash: string): PrivacyPrefs | undefined {
+  return prefs.get(hash);
+}
+
+export function initPrefs(hash: string): PrivacyPrefs {
+  const row: PrivacyPrefs = { user_id_hash: hash, updated_at: new Date().toISOString(), ...DEFAULT_PREFS };
+  prefs.set(hash, row);
+  return row;
+}
+
+export function updatePrefs(hash: string, patch: Partial<PrivacyPrefs>): void {
+  const current = prefs.get(hash) ?? initPrefs(hash);
+  const updated: PrivacyPrefs = { ...current, ...patch, updated_at: new Date().toISOString(), user_id_hash: hash };
+  prefs.set(hash, updated);
+}
+
+export const auditLog: { user_id_hash: string; action: string; details: string }[] = [];
+
+export function logChange(hash: string, patch: Partial<PrivacyPrefs>): void {
+  auditLog.push({ user_id_hash: hash, action: 'opt_change', details: JSON.stringify(patch) });
+}
+
+export function clear() {
+  prefs.clear();
+  auditLog.length = 0;
+}

--- a/services/privacy/server.ts
+++ b/services/privacy/server.ts
@@ -1,0 +1,36 @@
+import { createServer, IncomingMessage, ServerResponse } from 'http';
+import { getPrivacy } from './handlers/getPrivacy';
+import { updatePrivacy } from './handlers/updatePrivacy';
+
+function getUser(req: IncomingMessage) {
+  const auth = req.headers['authorization'];
+  if (auth && auth.startsWith('Bearer ')) {
+    const token = auth.substring(7);
+    return { sub: token };
+  }
+  return null;
+}
+
+export function createApp() {
+  return createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    const user = getUser(req);
+    if (!user) {
+      res.statusCode = 401;
+      res.end('Unauthorized');
+      return;
+    }
+
+    if (req.method === 'GET' && req.url === '/user/privacy') {
+      await getPrivacy(req, res, user);
+      return;
+    }
+
+    if (req.method === 'PUT' && req.url === '/user/privacy') {
+      await updatePrivacy(req, res, user);
+      return;
+    }
+
+    res.statusCode = 404;
+    res.end('Not Found');
+  });
+}

--- a/services/privacy/tests/privacyPrefs.test.ts
+++ b/services/privacy/tests/privacyPrefs.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createApp } from '../server';
+import { clear, auditLog } from '../lib/db';
+
+let server: any;
+let url: string;
+
+beforeEach(async () => {
+  clear();
+  await new Promise<void>(resolve => {
+    server = createApp().listen(0, () => {
+      const { port } = server.address();
+      url = `http://localhost:${port}`;
+      resolve();
+    });
+  });
+});
+
+afterEach(() => {
+  server.close();
+});
+
+describe('PUT /user/privacy', () => {
+  it('updates a single flag', async () => {
+    const res1 = await fetch(url + '/user/privacy', {
+      method: 'PUT',
+      headers: { Authorization: 'Bearer h123', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mic: false })
+    });
+    expect(res1.status).toBe(204);
+
+    const res2 = await fetch(url + '/user/privacy', {
+      headers: { Authorization: 'Bearer h123' }
+    });
+    const data = await res2.json();
+    expect(data.mic).toBe(false);
+    expect(auditLog.length).toBe(1);
+  });
+});

--- a/vitest.api.config.ts
+++ b/vitest.api.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
       'services/scan/tests/**/*.ts',
       'services/gam/tests/**/*.ts',
       'services/vr/tests/**/*.ts',
-      'services/breath/tests/**/*.ts'
+      'services/breath/tests/**/*.ts',
+      'services/privacy/tests/**/*.ts'
     ]
   }
 });


### PR DESCRIPTION
## Summary
- add `privacy_prefs` migration with RLS
- implement minimal privacy service exposing GET/PUT `/user/privacy`
- log changes to in-memory audit table
- include openapi documentation
- add integration test and config update

## Testing
- `npm run test:api`