### PR TITLE
Fix frontend type-check and cleanup configs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,21 +1,7 @@
 
 # EMERGENCY ANTI-BUN CONFIGURATION - FORCE NPM ONLY
 engine-strict=true
-package-manager=npm
 package-lock=false
-scripts-prepend-node-path=true
-
-# BLOCK BUN COMPLETELY
-bun=false
-use-bun=false
-USE_BUN=false
-
-# Skip ALL heavy binaries to speed up installation
-cypress_install_binary=0
-cypress_skip_binary_install=1
-husky_skip_install=1
-puppeteer_skip_download=1
-playwright_skip_browser_download=1
 
 # Network optimizations for faster install
 prefer-offline=false
@@ -26,15 +12,6 @@ progress=true
 
 # Dependency resolution that avoids conflicts
 legacy-peer-deps=true
-auto-install-peers=true
-strict-peer-dependencies=false
-
-# Extended timeout settings to prevent failures
-network-timeout=300000
-fetch-retry-mintimeout=15000
-fetch-retry-maxtimeout=60000
-fetch-retries=3
 
 # Force npm resolution
-resolution-mode=highest
 save-exact=false

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,9 +1,11 @@
 
+export type UserRole = 'b2c' | 'b2b_user' | 'b2b_admin' | 'admin';
+
 export interface User {
   id: string;
   email: string;
   name: string;
-  role: 'b2c' | 'b2b_user' | 'b2b_admin';
+  role: UserRole;
   createdAt: string;
   organizationId?: string;
   avatar?: string;


### PR DESCRIPTION
## Summary
- add a `UserRole` union type and use it in the `User` interface
- remove custom npm configuration keys to avoid warnings

## Testing
- `npm run type-check`
- `npm run test` *(fails: Failed to resolve import "undici" from "vitest.setup.ts")*
- `npm run dev` *(started then stopped)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6839f43cf700832da934dfe68214ccf0