### PR TITLE
Stop using Bun in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  NODE_VERSION: "20"
+  NODE_VERSION: "18"
 
 jobs:
   front:
@@ -17,15 +17,10 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-      - name: Disable Bun
-        run: |
-          if command -v bun; then
-            echo "🧹 Removing Bun binary"
-            sudo rm -f "$(which bun)"
-          fi
-          rm -rf ~/.bun ~/.cache/bun || true
-      - name: Assert no Bun
-        run: ./bin/assert-no-bun.sh
+      - name: bun-slayer
+        run: rm -rf ~/.bun ~/.cache/bun || true
+      - name: Assert package manager
+        run: ./bin/assert-package-manager.sh
       - run: npm run front:ci-install
       - run: npm run test -- --environment=jsdom
 
@@ -46,15 +41,10 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-      - name: Disable Bun
-        run: |
-          if command -v bun; then
-            echo "🧹 Removing Bun binary"
-            sudo rm -f "$(which bun)"
-          fi
-          rm -rf ~/.bun ~/.cache/bun || true
-      - name: Assert no Bun
-        run: ./bin/assert-no-bun.sh
+      - name: bun-slayer
+        run: rm -rf ~/.bun ~/.cache/bun || true
+      - name: Assert package manager
+        run: ./bin/assert-package-manager.sh
       - run: npm ci --prefer-offline --audit=false
       - run: npm run flyway:migrate
       - run: npm run db:migrate

--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ EmotionsCare est un produit développé par [Votre Entreprise], avec une équipe
 [![CI](https://github.com/your-username/emotions-care/actions/workflows/ci.yml/badge.svg?branch=feat/dashboard-widgets)](https://github.com/your-username/emotions-care/actions/workflows/ci.yml)
 
 Les contributions sont les bienvenues ! Veillez à installer les dépendances avec `npm ci`, à lancer `npm run lint` et `npm test` avant de proposer une pull request.
+Bun est interdit pour l'instant. Utilisez npm version 10 ou superieure.
 
 ## Licence
 

--- a/bin/assert-no-bun.sh
+++ b/bin/assert-no-bun.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-if command -v bun > /dev/null; then
-  echo "❌  Bun still present – aborting pipeline"
-  exit 1
-fi

--- a/bin/assert-package-manager.sh
+++ b/bin/assert-package-manager.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Fail if bun is installed
+if command -v bun > /dev/null; then
+  echo "❌ Bun détecté — build annulé"
+  exit 1
+fi
+
+# Ensure npm is available
+if ! command -v npm > /dev/null; then
+  echo "❌ npm introuvable"
+  exit 1
+fi
+
+exit 0

--- a/ci/docker/node-npm-only.Dockerfile
+++ b/ci/docker/node-npm-only.Dockerfile
@@ -1,0 +1,11 @@
+FROM node:18-alpine
+
+# Remove Bun if present
+RUN apk del --no-cache bun && rm -f /usr/local/bin/bun || true
+
+# Disable Yarn/Bun auto via Corepack
+ENV COREPACK_ENABLE=0
+
+WORKDIR /app
+
+CMD ["node"]

--- a/ci/test/pm-detection.spec.sh
+++ b/ci/test/pm-detection.spec.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(dirname "$SCRIPT_DIR")/.."
+"$ROOT/bin/assert-package-manager.sh"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -9,8 +9,13 @@ export PUPPETEER_SKIP_DOWNLOAD=1
 export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 export NODE_OPTIONS=--max-old-space-size=4096
 
-# Install dependencies with bun, skipping heavy binaries
-SKIP_HEAVY=true bun install
+# Optionally clean bun caches (skip if SKIP_BUN_CLEAN=true)
+if [ "${SKIP_BUN_CLEAN:-false}" != "true" ]; then
+  rm -rf ~/.bun ~/.cache/bun || true
+fi
+
+# Install dependencies with npm
+npm ci --prefer-offline --audit=false
 
 # Ensure vitest is installed before running tests
 if ! npx --no-install vitest --version >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- add a minimal Dockerfile without Bun
- assert package manager presence
- wipe Bun caches in CI and setup script
- update CI workflow to use Node 18 and run the assertion
- document the npm 10 requirement
- shell test for package manager detection

## Testing
- `npm test` *(fails: Cannot find package '@vitejs/plugin-react')*
- `ci/test/pm-detection.spec.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a311e5fd0832d859aa0dad3fbee53