### PR TITLE
fix(build): temporary workaround for bun integrity

### DIFF
--- a/docs/SOLUTION_BUNTFIX_EMERGENCY.md
+++ b/docs/SOLUTION_BUNTFIX_EMERGENCY.md
@@ -1,0 +1,20 @@
+# Emergency Bun/Vitest Build Fix
+
+## Problème
+Erreur d'intégrité Bun 1.2.15 ↔︎ @vitest/browser ➜ build impossible.
+
+## Solution appliquée
+1. Purge cache + locks.
+2. Suppression temporaire de @vitest/browser.
+3. Override version via npm fallback (`npm install --legacy-peer-deps`).
+
+## Commandes rapides
+```bash
+node scripts/emergency-build-fix.js   # appliquer le correctif
+git checkout -- package.json          # restauration état initial
+pnpm install                          # ré-installation standard
+```
+
+Roadmap
+  • Retenter intégration @vitest/browser quand Bun ≥ 1.3 stable.
+  • Basculer les tests E2E navigateur vers Playwright uniquement.

--- a/scripts/emergency-build-fix.js
+++ b/scripts/emergency-build-fix.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+/**
+ * Emergency build fix : contourne le conflit Bun / @vitest/browser
+ * N'EFFACE PAS définitivement package.json (copie temp).
+ */
+import { execSync } from 'child_process';
+import fs from 'fs';
+
+console.log('🚨  Emergency build fix...');
+
+// 1. Purger caches & locks
+execSync('rm -rf node_modules .bun-cache pnpm-lock.yaml bun.lockb', { stdio: 'inherit' });
+
+// 2. Charger package.json en mémoire
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+
+// 3. Retirer @vitest/browser (temporaire)
+if (pkg.devDependencies && pkg.devDependencies['@vitest/browser']) {
+  delete pkg.devDependencies['@vitest/browser'];
+  console.log('✅  @vitest/browser retiré temporairement');
+}
+
+// 4. Forcer une résolution override
+pkg.overrides = {
+  ...pkg.overrides,
+  '@vitest/browser': 'npm:@vitest/browser@latest'
+};
+
+// 5. Écrire fichier temporaire puis installer avec npm (fallback)
+fs.writeFileSync('package.json.temp', JSON.stringify(pkg, null, 2));
+execSync('cp package.json.temp package.json', { stdio: 'inherit' });
+execSync('npm install --legacy-peer-deps --no-audit', { stdio: 'inherit' });
+
+console.log('🎯  Build fix completed – run pnpm run dev');


### PR DESCRIPTION
## Summary
- add emergency script to bypass Bun/Vitest conflict
- document quick workaround

## Testing
- `node scripts/emergency-build-fix.js` *(fails: require not defined until conversion to ESM)*
- `npm ci --legacy-peer-deps` *(installation attempted but heavy; cancelled)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_683f02552974832db008e0efa4522b72