### PR TITLE
ci(front): bump Node to 20 (fix glob@11 EBADENGINE)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  NODE_VERSION: "18"
+  NODE_VERSION: "20"
   BUN_DISABLED: "true"
   USE_NPM_ONLY: "true"
   PACKAGE_MANAGER: "npm"
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          node-version: 20
+          cache: npm
       - name: Remove Bun completely
         run: |
           sudo rm -rf ~/.bun ~/.cache/bun /usr/local/bin/bun || true
@@ -50,10 +50,10 @@ jobs:
         ports: ['5432:5432']
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          node-version: 20
+          cache: npm
       - name: Remove Bun completely
         run: |
           sudo rm -rf ~/.bun ~/.cache/bun /usr/local/bin/bun || true


### PR DESCRIPTION
## Summary
- update CI to use Node 20 runners

## Testing
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684363686fec832da5658decc5a8b732