### PR TITLE
Fix heavy install step to preserve lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: ./bin/assert-package-manager.sh
       - name: Install with npm and heavy deps
         run: |
-          rm -rf node_modules package-lock.json || true
+          rm -rf node_modules || true
           npm cache clean --force || true
           npm install --legacy-peer-deps
           node scripts/install-heavy.js


### PR DESCRIPTION
## Summary
- avoid deleting `package-lock.json` in the heavy install step so `npm ci` runs

## Testing
- `npm test -- --help`

------
https://chatgpt.com/codex/tasks/task_e_68457eaa5b54832db2b18f5f8c032d94