### PR TITLE
Add env stub for tests

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,5 @@
+VITE_SUPABASE_URL=http://localhost:54321
+VITE_SUPABASE_ANON_KEY=dummy_anon_key
+VITE_APP_NAME=EmotionsCare
+VITE_APP_VERSION=0.0.0-test
+VITE_ENVIRONMENT=test

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ env
 .env
 .env.*
 !.env.example
+!.env.test
 *.local
 
 # Editor directories and files

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ npm run dev
 npm run build
 
 # Exécuter les tests
+# Les variables de `.env.test` sont chargées automatiquement
 npm test
 
 # Vérifier les types TypeScript

--- a/tests/utils/env.ts
+++ b/tests/utils/env.ts
@@ -1,0 +1,3 @@
+export const getEnv = (key: string): string | undefined => {
+  return (globalThis as any).importMetaEnv?.[key] || process.env[key];
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,6 @@
 
 import { defineConfig } from 'vitest/config';
-import react from '@vitejs/plugin-react';
+import react from '@vitejs/plugin-react-swc';
 import path from 'path';
 
 export default defineConfig({

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,4 +1,5 @@
 import { fetch, Headers, Request, Response } from 'undici';
+import { loadEnv } from 'vite';
 
 if (!globalThis.fetch) {
   // Polyfill fetch and related classes for headless environments
@@ -11,4 +12,12 @@ if (!globalThis.fetch) {
   // @ts-ignore
   globalThis.Response = Response as any;
 }
+
+// Charge les variables d'environnement de `.env.test`
+const env = loadEnv('test', process.cwd(), '');
+(globalThis as any).importMetaEnv = env;
+(globalThis as any).process = {
+  ...process,
+  env: { ...process.env, ...env },
+};
 


### PR DESCRIPTION
## Summary
- add `.env.test` for Vitest
- ignore `.env.test` in .gitignore exceptions
- load `.env.test` vars in `vitest.setup.ts`
- update test config to use React SWC plugin
- document `.env.test` usage in README
- expose `getEnv` helper for tests

## Testing
- `npm run test` *(fails: Failed to resolve import "undici")*

------
https://chatgpt.com/codex/tasks/task_e_684aee64cbac832db70c12b94fc6bf77