### PR TITLE
Add global fetch mock setup for API tests

### DIFF
--- a/src/lib/fetchJson.ts
+++ b/src/lib/fetchJson.ts
@@ -1,0 +1,12 @@
+if (!globalThis.fetch) {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  Object.assign(globalThis, require('undici'));
+}
+
+export async function fetchJson(
+  input: RequestInfo,
+  init?: RequestInit
+): Promise<Response> {
+  return globalThis.fetch(input, init);
+}
+

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -1,0 +1,33 @@
+import { vi } from 'vitest';
+
+export type FetchOptions = {
+  status?: number;
+  json?: Record<string, unknown>;
+  text?: string;
+  headers?: Record<string, string>;
+};
+
+export function mockFetchResponse(
+  data: FetchOptions | ((url: string) => FetchOptions)
+) {
+  global.fetch = vi.fn((input: RequestInfo) => {
+    const opt = typeof data === 'function' ? data(String(input)) : data;
+    const {
+      status = 200,
+      json = {},
+      text,
+      headers = { 'Content-Type': 'application/json' },
+    } = opt ?? {};
+    return Promise.resolve(
+      new Response(text ?? JSON.stringify(json), { status, headers })
+    );
+  }) as unknown as typeof fetch;
+}
+
+if (!global.fetch || !global.Response) {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  Object.assign(global, require('undici'));
+}
+if (!global.fetch) {
+  mockFetchResponse({});
+}

--- a/vitest.api.config.ts
+++ b/vitest.api.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
+    setupFiles: ['./vitest.setup.ts'],
     include: [
       'services/journal/tests/**/*.ts',
       'services/scan/tests/**/*.ts',

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,9 +1,5 @@
-import fetch, { Headers, Request, Response } from 'cross-fetch';
-
-if (!globalThis.fetch) globalThis.fetch = fetch as any;
-if (!globalThis.Headers) globalThis.Headers = Headers as any;
-if (!globalThis.Request) globalThis.Request = Request as any;
-if (!globalThis.Response) globalThis.Response = Response as any;
+import './test/setupTests';
+import { loadEnv } from 'vite';
 
 // Charge les variables d'environnement de `.env.test`
 const env = loadEnv('test', process.cwd(), '');


### PR DESCRIPTION
## Summary
- provide a helper to mock `fetch` responses in tests
- load the helper through `vitest.setup.ts`
- run setup file for api test suites
- add `fetchJson` helper with Node fallback

## Testing
- `npm run test:api`

------
https://chatgpt.com/codex/tasks/task_e_684af6c49fa8832d94b0eb4a77b2cd46