### PR TITLE
Fix duplicate KPI labels & framer-motion crash

### DIFF
--- a/src/components/glow/GlowKpiCard.tsx
+++ b/src/components/glow/GlowKpiCard.tsx
@@ -37,14 +37,23 @@ export const GlowKpiCard: React.FC<GlowKpiCardProps> = ({
 }) => {
   const IconComponent = iconMap[icon];
   const displayTitle = titleMap[icon];
-  
+  const slugify = (text: string) =>
+    text
+      .normalize('NFD')
+      .replace(/\p{Diacritic}/gu, '')
+      .replace(/\s+/g, '-')
+      .toLowerCase();
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ delay: index * 0.05, duration: 0.6 }}
     >
-      <Card className="bg-gradient-to-br from-white/80 to-white/60 backdrop-blur-sm border-white/20 shadow-lg">
+      <Card
+        data-testid={`kpi-card-${slugify(displayTitle)}`}
+        className="bg-gradient-to-br from-white/80 to-white/60 backdrop-blur-sm border-white/20 shadow-lg"
+      >
         <CardContent className="p-6">
           <div className="flex items-center justify-between mb-4">
             <div className="p-2 rounded-full bg-gradient-to-r from-purple-100 to-pink-100">

--- a/src/components/glow/__tests__/GlowBreathPage.test.tsx
+++ b/src/components/glow/__tests__/GlowBreathPage.test.tsx
@@ -39,10 +39,10 @@ describe('GlowBreathPage', () => {
     expect(screen.getByText(/mon souffle/i)).toBeInTheDocument();
     
     await waitFor(() => {
-      expect(screen.getByText(/décompression/i)).toBeVisible();
-      expect(screen.getByText(/breathe sync/i)).toBeVisible();
-      expect(screen.getByText(/move/i)).toBeVisible();
-      expect(screen.getByText(/zen drop/i)).toBeVisible();
+      expect(screen.getByTestId('kpi-card-decompression')).toBeVisible();
+      expect(screen.getByTestId('kpi-card-breathe-sync')).toBeVisible();
+      expect(screen.getByTestId('kpi-card-move')).toBeVisible();
+      expect(screen.getByTestId('kpi-card-zen-drop')).toBeVisible();
     });
   });
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -9,3 +9,9 @@ const env = loadEnv('test', process.cwd(), '');
   env: { ...process.env, ...env },
 };
 
+// Framer-motion injects DOM-specific styles that JSDOM can't handle.
+// Provide minimal mocks so components render in tests without crashing.
+vi.mock('framer-motion', () => ({
+  motion: { div: 'div', span: 'span', section: 'section' }
+}));
+


### PR DESCRIPTION
## Summary
- identify KPI cards with `data-testid` attributes
- mock `framer-motion` for Vitest
- update GlowBreathPage tests to use new testids

## Testing
- `npm run test` *(fails: Invariant violation from esbuild)*

------
https://chatgpt.com/codex/tasks/task_e_684bf116acf4832dba45bb2bca6c5860