### PR TITLE
Fix test env and supabase roles

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,6 +181,10 @@
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.19",
     "vitest": "^3.1.4"
+    ,"@playwright/test": "1.42.1"
+    ,"edge-test-kit": "^0.7.2"
+    ,"std": "*"
+    ,"std-env": "*"
   },
   "optionalDependencies": {
     "cypress": "^13.5.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,6 @@
 
 import { defineConfig, devices } from '@playwright/test';
+import path from 'node:path';
 
 export default defineConfig({
   testDir: './src/e2e',
@@ -41,5 +42,10 @@ export default defineConfig({
     command: 'npm run dev',
     url: 'http://localhost:8080',
     reuseExistingServer: !process.env.CI,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
   },
 });

--- a/supabase/functions/analyze-journal/index.ts
+++ b/supabase/functions/analyze-journal/index.ts
@@ -1,6 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
+import { authorizeRole } from '../_shared/auth.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -13,6 +14,13 @@ serve(async (req) => {
   }
 
   try {
+    const { user, status } = await authorizeRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
+    if (!user) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
     const { content } = await req.json();
 
     const openAIApiKey = Deno.env.get('OPENAI_API_KEY');

--- a/supabase/functions/coach-ai/index.ts
+++ b/supabase/functions/coach-ai/index.ts
@@ -1,6 +1,7 @@
 
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { authorizeRole } from '../_shared/auth.ts';
 
 const openAIApiKey = Deno.env.get('OPENAI_API_KEY');
 
@@ -15,6 +16,13 @@ serve(async (req) => {
   }
 
   try {
+    const { user, status } = await authorizeRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
+    if (!user) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
     const { emotionData, userProfile, requestType } = await req.json();
 
     if (!openAIApiKey) {

--- a/supabase/functions/enhanced-emotion-analyze/index.ts
+++ b/supabase/functions/enhanced-emotion-analyze/index.ts
@@ -1,6 +1,7 @@
 
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { authorizeRole } from '../_shared/auth.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -23,6 +24,13 @@ serve(async (req) => {
   }
 
   try {
+    const { user, status } = await authorizeRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
+    if (!user) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
     const body: EmotionAnalysisRequest = await req.json();
     const { type, data, options = {} } = body;
 

--- a/supabase/functions/process-emotion-gamification/index.ts
+++ b/supabase/functions/process-emotion-gamification/index.ts
@@ -1,6 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
+import { authorizeRole } from '../_shared/auth.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -13,6 +14,13 @@ serve(async (req) => {
   }
 
   try {
+    const { user, status } = await authorizeRole(req, ['b2c', 'b2b_user', 'b2b_admin', 'admin']);
+    if (!user) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
     const { userId, emotionResult } = await req.json();
 
     if (!userId || !emotionResult) {

--- a/tests/__mocks__/db.ts
+++ b/tests/__mocks__/db.ts
@@ -1,0 +1,19 @@
+export default {
+  deleteFrom: () => ({ execute: () => Promise.resolve() }),
+  insertInto: () => ({ values: () => ({ execute: () => Promise.resolve() }) }),
+  insert: () => ({ values: () => ({ execute: () => Promise.resolve() }) }),
+  selectFrom: () => ({
+    where: () => ({
+      select: () => ({
+        execute: () => Promise.resolve([]),
+        executeTakeFirst: () => Promise.resolve(undefined),
+        executeTakeFirstOrThrow: () => Promise.resolve(undefined),
+      }),
+      execute: () => Promise.resolve([]),
+      executeTakeFirst: () => Promise.resolve(undefined),
+    }),
+  }),
+  exec: () => Promise.resolve(),
+  raw: () => Promise.resolve(),
+  clear: () => Promise.resolve(),
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vitest/config';
+import path from 'node:path';
 
 export default defineConfig({
   test: {
     environment: 'node',      // évite jsdom par défaut
     setupFiles: ['./vitest.setup.ts'],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
   },
 });


### PR DESCRIPTION
## Summary
- add aliases to vitest and playwright configs
- mock DB for vitest
- include playwright and edge test tooling deps
- enforce role checks in some supabase functions

## Testing
- `npm test` *(fails: connect ECONNREFUSED and jsdom issues)*

------
https://chatgpt.com/codex/tasks/task_e_685230858f80832dac33069f6a73168e