### PR TITLE
Finaliser la remise en état des configs tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,17 +1,12 @@
-
-import js from '@eslint/js';
 import globals from 'globals';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  {
-    ignores: ['dist', 'node_modules'],
-    linterOptions: { reportUnusedDisableDirectives: false },
-  },
   ...tseslint.configs.recommended,
   {
+    ignores: ['dist', 'node_modules', 'supabase/functions/**'],
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
       ecmaVersion: 2020,

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -95,7 +95,10 @@ const config: Config = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    require("tailwindcss-animate"),
+  ],
 } satisfies Config;
 
 export default config;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from 'vitest/config';
 import path from 'node:path';
+import 'ts-node/register';
+import 'tsconfig-paths/register';
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
Fixes TASK-ID

- charge `ts-node` et `tsconfig-paths` dans la config Vitest
- ignore les fonctions Supabase via ESLint
- note l'usage de `tailwindcss-animate` avec un disable


------
https://chatgpt.com/codex/tasks/task_e_685276d02028832dac8a1db4dcc8d1d0