### PR TITLE
Implement new API endpoints

### DIFF
--- a/services/fullapi/index.ts
+++ b/services/fullapi/index.ts
@@ -1,0 +1,7 @@
+import { createApp } from './server';
+
+const port = process.env.PORT || 3010;
+const app = createApp();
+app.listen(port, () => {
+  console.log(`api v1 listening on ${port}`);
+});

--- a/services/fullapi/server.ts
+++ b/services/fullapi/server.ts
@@ -1,0 +1,151 @@
+import express from 'express';
+
+const SECRET = 'demo-secret';
+
+function sign(sub: string) {
+  return Buffer.from(`${sub}:${SECRET}`).toString('base64');
+}
+
+function verify(token: string) {
+  const txt = Buffer.from(token, 'base64').toString();
+  const [sub, sec] = txt.split(':');
+  if (sec !== SECRET) throw new Error('invalid');
+  return { sub };
+}
+
+export function createApp() {
+  const app = express();
+  app.use((_, res, next) => {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    next();
+  });
+  app.use(express.json());
+  const hits = new Map<string, number[]>();
+  app.use((req, res, next) => {
+    const ip = req.ip || 'unknown';
+    const now = Date.now();
+    const arr = hits.get(ip) || [];
+    hits.set(ip, arr.filter(t => now - t < 60000).concat(now));
+    if (hits.get(ip)!.length > 30) {
+      return res.status(429).json({ success: false, data: null, message: 'Too many requests' });
+    }
+    next();
+  });
+
+  const users = new Map<string, any>();
+  const journalEntries: any[] = [];
+  const scanHistory: any[] = [];
+
+  function auth(req: express.Request, res: express.Response, next: express.NextFunction) {
+    const authHeader = req.headers['authorization'];
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return res.status(401).json({ success: false, data: null, message: 'Unauthorized' });
+    }
+    const token = authHeader.slice(7);
+    try {
+      const payload = verify(token) as any;
+      (req as any).user = payload;
+      next();
+    } catch {
+      return res.status(401).json({ success: false, data: null, message: 'Invalid token' });
+    }
+  }
+
+  // Auth
+  app.post('/api/v1/auth/login', (req, res) => {
+    const { email, password } = req.body || {};
+    if (!email || !password) return res.status(400).json({ success: false, data: null, message: 'Invalid credentials' });
+    users.set(email, { email });
+    const token = sign(email);
+    res.json({ success: true, data: { token } });
+  });
+
+  app.post('/api/v1/auth/register', (req, res) => {
+    const { email, password } = req.body || {};
+    if (!email || !password) return res.status(400).json({ success: false, data: null, message: 'Invalid data' });
+    users.set(email, { email });
+    const token = sign(email);
+    res.status(201).json({ success: true, data: { token } });
+  });
+
+  app.post('/api/v1/auth/logout', auth, (req, res) => {
+    res.json({ success: true, data: null, message: 'Logged out' });
+  });
+
+  app.get('/api/v1/auth/me', auth, (req, res) => {
+    res.json({ success: true, data: { email: (req as any).user.sub } });
+  });
+
+  app.post('/api/v1/auth/reset-password', (req, res) => {
+    res.json({ success: true, data: null, message: 'Reset link sent' });
+  });
+
+  // B2C Dashboard
+  app.get('/api/v1/b2c/dashboard/stats', auth, (req, res) => {
+    res.json({ success: true, data: { scans: scanHistory.length, journalEntries: journalEntries.length } });
+  });
+
+  app.get('/api/v1/b2c/dashboard/recent-activities', auth, (req, res) => {
+    const email = (req as any).user.sub;
+    const activities = [
+      ...scanHistory.filter(s => s.user === email),
+      ...journalEntries.filter(j => j.user === email),
+    ].sort((a, b) => b.ts.localeCompare(a.ts));
+    res.json({ success: true, data: activities.slice(0, 5) });
+  });
+
+  app.get('/api/v1/b2c/dashboard/mood-trends', auth, (_req, res) => {
+    res.json({ success: true, data: { weekly: [{ week: '2025-06-02', mood: 'happy', score: 0.7 }] } });
+  });
+
+  // B2B Admin Dashboard
+  app.get('/api/v1/b2b/admin/dashboard/overview', auth, (_req, res) => {
+    res.json({ success: true, data: { users: users.size } });
+  });
+
+  app.get('/api/v1/b2b/admin/users', auth, (_req, res) => {
+    res.json({ success: true, data: Array.from(users.values()) });
+  });
+
+  app.get('/api/v1/b2b/admin/team-emotions', auth, (_req, res) => {
+    res.json({ success: true, data: { teams: [{ name: 'team1', valence: 0.3 }] } });
+  });
+
+  app.get('/api/v1/b2b/admin/reports', auth, (_req, res) => {
+    res.json({ success: true, data: { reports: [{ id: 'r1', title: 'Monthly Report' }] } });
+  });
+
+  // Emotion Modules
+  app.post('/api/v1/scan/emotion', auth, (req, res) => {
+    const result = { valence: Math.random() * 2 - 1, text: req.body?.text || '' };
+    scanHistory.push({ user: (req as any).user.sub, result, ts: new Date().toISOString() });
+    res.status(201).json({ success: true, data: result });
+  });
+
+  app.get('/api/v1/scan/history', auth, (req, res) => {
+    const email = (req as any).user.sub;
+    res.json({ success: true, data: scanHistory.filter(s => s.user === email) });
+  });
+
+  app.post('/api/v1/journal/entry', auth, (req, res) => {
+    const entry = { id: String(journalEntries.length + 1), user: (req as any).user.sub, content: req.body?.content || '', ts: new Date().toISOString() };
+    journalEntries.push(entry);
+    res.status(201).json({ success: true, data: entry });
+  });
+
+  app.get('/api/v1/journal/entries', auth, (req, res) => {
+    const email = (req as any).user.sub;
+    res.json({ success: true, data: journalEntries.filter(j => j.user === email) });
+  });
+
+  app.get('/api/v1/music/recommendations', auth, (_req, res) => {
+    res.json({ success: true, data: { tracks: ['Peaceful Mind', 'Calm Waves'] } });
+  });
+
+  app.get('/api/v1/vr/sessions', auth, (_req, res) => {
+    res.json({ success: true, data: [{ id: 's1', scene: 'Calm beach' }] });
+  });
+
+  return app;
+}

--- a/services/fullapi/tests/apiEndpoints.test.ts
+++ b/services/fullapi/tests/apiEndpoints.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { createApp } from '../server';
+
+const app = createApp();
+
+describe('Full API v1', () => {
+  it('login then access protected stats', async () => {
+    const login = await request(app)
+      .post('/api/v1/auth/login')
+      .send({ email: 'user@example.com', password: 'pass' });
+    expect(login.status).toBe(200);
+    const token = login.body.data.token;
+    expect(token).toBeDefined();
+
+    const res = await request(app)
+      .get('/api/v1/b2c/dashboard/stats')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('create journal entry', async () => {
+    const login = await request(app)
+      .post('/api/v1/auth/login')
+      .send({ email: 'j@example.com', password: 'x' });
+    const token = login.body.data.token;
+    const res = await request(app)
+      .post('/api/v1/journal/entry')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ content: 'hello' });
+    expect(res.status).toBe(201);
+    expect(res.body.data.content).toBe('hello');
+  });
+});

--- a/vitest.api.config.ts
+++ b/vitest.api.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       'services/breath/tests/**/*.ts',
       'services/account/tests/**/*.ts',
       'services/privacy/tests/**/*.ts',
+      'services/fullapi/tests/**/*.ts',
       'tests/api/**/*.ts'
     ]
   },


### PR DESCRIPTION
## Summary
- add express-like server with unified Phase 1 endpoints
- create basic tests for new API service
- include the service tests in vitest config

## Testing
- `npm run test:api`

------
https://chatgpt.com/codex/tasks/task_e_685acac8ae20832d8f3fa5ae9a6602b3