### PR TITLE
Implement basic admin API

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,3 +210,6 @@ MIT License - voir le fichier [LICENSE](LICENSE) pour plus de détails.
 ---
 
 🔥 **Powered by Bun + React + Supabase**
+
+## 🛠️ Admin Service
+Provides simple organization management endpoints. Run `node services/admin/index.ts` to start.

--- a/openapi/admin.yaml
+++ b/openapi/admin.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.0
+info:
+  title: Admin API
+  version: 1.0.0
+paths:
+  /admin/organization:
+    get:
+      summary: Get organization details
+      responses:
+        '200':
+          description: Organization info
+    put:
+      summary: Update organization
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Updated organization

--- a/services/admin/handlers/organization.ts
+++ b/services/admin/handlers/organization.ts
@@ -1,0 +1,25 @@
+import { IncomingMessage, ServerResponse } from 'http';
+
+let org = {
+  id: 'org1',
+  name: 'Demo Org',
+  subscription_plan: 'basic',
+  max_users: 50,
+  updated_at: new Date().toISOString()
+};
+
+export async function getOrganization(req: IncomingMessage, res: ServerResponse) {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify(org));
+}
+
+export async function updateOrganization(req: IncomingMessage, res: ServerResponse) {
+  let body = '';
+  for await (const chunk of req) body += chunk;
+  const data = JSON.parse(body || '{}');
+  org = { ...org, ...data, updated_at: new Date().toISOString() };
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify(org));
+}

--- a/services/admin/index.ts
+++ b/services/admin/index.ts
@@ -1,0 +1,7 @@
+import { createApp } from './server';
+
+const app = createApp();
+const port = process.env.PORT || 3010;
+app.listen(port, () => {
+  console.log(`admin api listening on ${port}`);
+});

--- a/services/admin/server.ts
+++ b/services/admin/server.ts
@@ -1,0 +1,36 @@
+import { createServer, IncomingMessage, ServerResponse } from 'http';
+import { getOrganization, updateOrganization } from './handlers/organization';
+import { parse } from 'url';
+
+function getUser(req: IncomingMessage) {
+  const auth = req.headers['authorization'];
+  if (auth && auth.startsWith('Bearer ')) {
+    const token = auth.substring(7);
+    return { sub: token, role: token.startsWith('admin:') ? 'admin' : 'user' };
+  }
+  return null;
+}
+
+export function createApp() {
+  return createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    const user = getUser(req);
+    if (!user || user.role !== 'admin') {
+      res.statusCode = 401;
+      res.end('Unauthorized');
+      return;
+    }
+
+    const { pathname } = parse(req.url || '');
+    if (req.method === 'GET' && pathname === '/admin/organization') {
+      await getOrganization(req, res);
+      return;
+    }
+    if (req.method === 'PUT' && pathname === '/admin/organization') {
+      await updateOrganization(req, res);
+      return;
+    }
+
+    res.statusCode = 404;
+    res.end('Not Found');
+  });
+}

--- a/services/admin/tests/organization.test.ts
+++ b/services/admin/tests/organization.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createApp } from '../server';
+
+let server: any;
+let url: string;
+
+beforeEach(async () => {
+  await new Promise<void>(resolve => {
+    server = createApp().listen(0, () => {
+      const { port } = server.address();
+      url = `http://localhost:${port}`;
+      resolve();
+    });
+  });
+});
+
+afterEach(() => {
+  server.close();
+});
+
+describe('admin organization endpoints', () => {
+  it('GET returns organization info', async () => {
+    const res = await fetch(url + '/admin/organization', {
+      headers: { Authorization: 'Bearer admin:org1' }
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toHaveProperty('id');
+  });
+
+  it('PUT updates organization name', async () => {
+    const res = await fetch(url + '/admin/organization', {
+      method: 'PUT',
+      headers: { Authorization: 'Bearer admin:org1', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Updated Org' })
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.name).toBe('Updated Org');
+  });
+});

--- a/supabase/migrations/20250701_b2b_core.sql
+++ b/supabase/migrations/20250701_b2b_core.sql
@@ -1,0 +1,103 @@
+-- B2B core schema for organizations, teams, achievements
+
+-- Organizations table
+CREATE TABLE IF NOT EXISTS public.organizations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name varchar(255) NOT NULL,
+  domain varchar(255) UNIQUE,
+  subscription_plan varchar(50) DEFAULT 'basic',
+  max_users integer DEFAULT 50,
+  settings jsonb DEFAULT '{}',
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+-- Extend profiles with organization fields
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS organization_id uuid REFERENCES organizations(id),
+  ADD COLUMN IF NOT EXISTS department varchar(100),
+  ADD COLUMN IF NOT EXISTS position varchar(100),
+  ADD COLUMN IF NOT EXISTS manager_id uuid REFERENCES profiles(id),
+  ADD COLUMN IF NOT EXISTS onboarding_completed boolean DEFAULT false;
+
+-- Teams table
+CREATE TABLE IF NOT EXISTS public.teams (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid REFERENCES organizations(id) NOT NULL,
+  name varchar(255) NOT NULL,
+  description text,
+  admin_id uuid REFERENCES profiles(id) NOT NULL,
+  member_count integer DEFAULT 0,
+  settings jsonb DEFAULT '{}',
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+-- Team members association
+CREATE TABLE IF NOT EXISTS public.team_members (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  team_id uuid REFERENCES teams(id) ON DELETE CASCADE,
+  user_id uuid REFERENCES profiles(id) ON DELETE CASCADE,
+  role varchar(50) DEFAULT 'member',
+  joined_at timestamptz DEFAULT now(),
+  UNIQUE(team_id, user_id)
+);
+
+-- Achievements
+CREATE TABLE IF NOT EXISTS public.achievements (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name varchar(255) NOT NULL,
+  description text,
+  icon varchar(100),
+  points integer DEFAULT 0,
+  category varchar(50),
+  criteria jsonb NOT NULL,
+  is_active boolean DEFAULT true,
+  created_at timestamptz DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.user_achievements (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid REFERENCES profiles(id) NOT NULL,
+  achievement_id uuid REFERENCES achievements(id) NOT NULL,
+  unlocked_at timestamptz DEFAULT now(),
+  progress jsonb DEFAULT '{}',
+  UNIQUE(user_id, achievement_id)
+);
+
+-- Audit logs
+CREATE TABLE IF NOT EXISTS public.audit_logs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid REFERENCES profiles(id),
+  organization_id uuid REFERENCES organizations(id),
+  action varchar(100) NOT NULL,
+  resource_type varchar(100),
+  resource_id uuid,
+  details jsonb,
+  ip_address inet,
+  user_agent text,
+  created_at timestamptz DEFAULT now()
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_user_achievements_user_id
+  ON public.user_achievements(user_id);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_user_id_created_at
+  ON public.audit_logs(user_id, created_at DESC);
+
+-- Trigger to update updated_at
+CREATE OR REPLACE FUNCTION public.update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_organizations_updated_at
+  BEFORE UPDATE ON public.organizations
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+CREATE TRIGGER trg_teams_updated_at
+  BEFORE UPDATE ON public.teams
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();

--- a/vitest.api.config.ts
+++ b/vitest.api.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       'services/gam/tests/**/*.ts',
       'services/vr/tests/**/*.ts',
       'services/breath/tests/**/*.ts',
+      'services/admin/tests/**/*.ts',
       'services/account/tests/**/*.ts',
       'services/privacy/tests/**/*.ts',
       'services/fullapi/tests/**/*.ts',


### PR DESCRIPTION
## Summary
- add B2B database schema for organizations, teams and audit logs
- introduce admin service with simple organization endpoints
- cover admin service with vitest
- document admin service in README
- include admin tests in vitest configuration

## Testing
- `npm run test:api`
- `npm run lint` *(fails: Parsing error in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_685ad794f7b4832dab99c8082f6c2e95