### PR TITLE
Add notifications-send edge function

### DIFF
--- a/supabase/functions/notifications-send/index.ts
+++ b/supabase/functions/notifications-send/index.ts
@@ -1,0 +1,56 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { authorizeRole } from '../_shared/auth.ts';
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+const supabase = createClient(supabaseUrl, serviceKey);
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const { user, status } = await authorizeRole(req, ['b2b_admin', 'admin']);
+  if (!user) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const { template, userId, variables } = await req.json();
+    if (!template || !userId) {
+      return new Response(JSON.stringify({ error: 'template and userId required' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { data, error } = await supabase.rpc('create_notification_from_template', {
+      template_name: template,
+      target_user_id: userId,
+      template_variables: variables || {},
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    return new Response(JSON.stringify({ success: true, id: data }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('notifications-send error:', error);
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- implement notifications-send edge function to create notifications from templates

## Testing
- `npm test` *(fails: 55 failed)*

------
https://chatgpt.com/codex/tasks/task_e_685b0ab88000832d87406e219d907fd5