### PR TITLE
Implement dev services runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "build:dev": "vite build --mode development",
     "type-check": "tsc --noEmit",
     "back:audit": "node --loader ts-node/esm scripts/full-back-audit.ts",
+    "dev:services": "node --loader ts-node/esm scripts/dev-services.ts",
     "dev:api": "node --loader ts-node/esm services/journal/index.ts",
     "test:api": "vitest run --config vitest.api.config.ts",
     "db:migrate": "supabase db push",
@@ -36,8 +37,8 @@
     "db:test:setup": "node --loader ts-node/esm scripts/test-db-setup.ts",
     "install:npm": "npm install --legacy-peer-deps",
     "clean:install": "rm -rf node_modules package-lock.json && npm install --legacy-peer-deps",
-    "front:ci-install": "npm ci --prefer-offline --audit=false --omit=dev && npm run build"
-    ,"ci:verify-assets": "bash ci/verify-assets.sh"
+    "front:ci-install": "npm ci --prefer-offline --audit=false --omit=dev && npm run build",
+    "ci:verify-assets": "bash ci/verify-assets.sh"
   },
   "dependencies": {
     "@axe-core/playwright": "^4.10.2",

--- a/scripts/dev-services.ts
+++ b/scripts/dev-services.ts
@@ -1,0 +1,42 @@
+import { spawn } from 'child_process';
+
+const services = [
+  'account',
+  'journal',
+  'breath',
+  'gam',
+  'scan',
+  'vr',
+  'admin',
+  'privacy'
+] as const;
+
+const ports: Record<(typeof services)[number], number> = {
+  account: 3009,
+  journal: 3001,
+  breath: 3003,
+  gam: 3005,
+  scan: 3002,
+  vr: 3004,
+  admin: 3010,
+  privacy: 3011
+};
+
+const children: ReturnType<typeof spawn>[] = [];
+
+function start(service: (typeof services)[number]) {
+  const port = ports[service];
+  const child = spawn('node', ['--loader', 'ts-node/esm', `services/${service}/index.ts`], {
+    stdio: 'inherit',
+    env: { ...process.env, PORT: String(port) }
+  });
+  children.push(child);
+  console.log(`Started ${service} on ${port}`);
+}
+
+for (const s of services) start(s);
+
+process.on('SIGINT', () => {
+  for (const c of children) c.kill('SIGINT');
+  process.exit();
+});


### PR DESCRIPTION
## Summary
- add a small script to launch all backend services at once
- expose `npm run dev:services` in package.json

## Testing
- `npm test` *(fails: TypeError in GlowBreathPage.test.tsx etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685b4d500a9c832d94eee4963188bf2e