### PR TITLE
Add grit challenge function

### DIFF
--- a/supabase/functions/generate-grit-challenge/index.ts
+++ b/supabase/functions/generate-grit-challenge/index.ts
@@ -1,0 +1,60 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import "https://deno.land/x/xhr@0.1.0/mod.ts";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const { mood } = await req.json();
+    const openaiKey = Deno.env.get('OPENAI_API_KEY');
+
+    if (!openaiKey) {
+      throw new Error('OpenAI API key not configured');
+    }
+
+    const messages = [
+      {
+        role: 'system',
+        content:
+          'You are an encouraging coach creating short personalised grit challenges for users. Keep the challenge under 50 words.',
+      },
+      {
+        role: 'user',
+        content: `Mood context: ${JSON.stringify(mood)}. Generate a micro grit challenge.`,
+      },
+    ];
+
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${openaiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages,
+        max_tokens: 120,
+        temperature: 0.8,
+      }),
+    });
+
+    const data = await response.json();
+    const challenge = data.choices?.[0]?.message?.content || '';
+
+    return new Response(JSON.stringify({ challenge }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add OpenAI edge function for generating grit challenges

## Testing
- `npm test` *(fails: 51 failed, 25 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685c2bb41acc832db1fb670948ada037