### PR TITLE
feat(flash-glow): add guard rails and flash glow module

### DIFF
--- a/docs/STRUCTURE_REPORT.md
+++ b/docs/STRUCTURE_REPORT.md
@@ -1,0 +1,33 @@
+# Structure Report
+
+## État initial
+- Aucune route Next.js détectée.
+- Aucun export de `COMPONENTS.reg.ts`.
+- Aucun fichier dans `src/app`.
+
+## État après complétion
+### Modules existants
+- `flash-glow` → composant `FlashGlowPage` route `/modules/flash-glow`
+
+### Manques/ébauches
+- Aucun module supplémentaire identifié.
+
+### Doublons détectés (à ignorer)
+- Aucun doublon détecté.
+
+### Points d'attention
+- La structure est désormais verrouillable via les scripts de snapshot et vérification.
+
+## Fichiers créés
+- `src/ROUTES.reg.ts` : registre central des routes.
+- `src/COMPONENTS.reg.ts` : registre des composants UI.
+- `src/SCHEMA.ts` : schéma Zod pour les préférences Flash Glow.
+- `src/app/modules/flash-glow/page.tsx` : page du module Flash Glow.
+- `src/__tests__/flash-glow.snapshot.spec.tsx` : test snapshot du module.
+- `e2e/smoke.routes.spec.ts` : test Playwright des routes.
+- `scripts/lock-structure.ts` : génération du snapshot de structure.
+- `scripts/verify-structure.ts` : vérification de l'intégrité de la structure.
+- `docs/STRUCTURE_REPORT.md` : ce rapport.
+
+## TODO restants
+- Ajouter et compléter d'autres modules.

--- a/e2e/smoke.routes.spec.ts
+++ b/e2e/smoke.routes.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from "@playwright/test";
+import routes from "../src/ROUTES.reg";
+
+for (const r of Object.values(routes)) {
+  test(`smoke ${r.id}`, async ({ page }) => {
+    await page.goto(r.path);
+    await expect(page).toHaveURL(new RegExp(r.path.replace("/", "\\/")));
+    const cta = page.locator("button, a[role=button]").first();
+    if (await cta.count()) await cta.click();
+  });
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "tsc": "tsc --noEmit",
-    "test": "NODE_ENV=test vitest run --passWithNoTests",
+    "test": "vitest run --silent",
     "test:ui": "vitest run src/pages/settings/SilkPage.test.tsx",
     "test:edge": "vitest --environment edge-runtime --no-browser-env-check",
     "test:db": "echo 'DB tests exécutés dans le pipeline back-end'",
@@ -38,7 +38,13 @@
     "install:npm": "npm install --legacy-peer-deps",
     "clean:install": "rm -rf node_modules package-lock.json && npm install --legacy-peer-deps",
     "front:ci-install": "npm ci --prefer-offline --audit=false --omit=dev && npm run build",
-    "ci:verify-assets": "bash ci/verify-assets.sh"
+    "ci:verify-assets": "bash ci/verify-assets.sh",
+    "typecheck": "tsc --noEmit",
+    "struct:snapshot": "ts-node scripts/lock-structure.ts",
+    "struct:verify": "ts-node scripts/verify-structure.ts",
+    "test:quick": "npm run typecheck && npm run lint && npm run test",
+    "ci:guard": "npm run test:quick && npm run struct:verify",
+    "lovable:push": "npm run ci:guard && lovable sync"
   },
   "dependencies": {
     "@axe-core/playwright": "^4.10.2",

--- a/scripts/.structure-snapshot.json
+++ b/scripts/.structure-snapshot.json
@@ -1,0 +1,17 @@
+{
+  "routes": [
+    {
+      "id": "flash-glow",
+      "path": "/modules/flash-glow",
+      "component": "FlashGlowPage"
+    }
+  ],
+  "components": [
+    "Button",
+    "LoadingSpinner",
+    "PageHeader"
+  ],
+  "appFiles": [
+    "app/modules/flash-glow/page.tsx"
+  ]
+}

--- a/scripts/lock-structure.ts
+++ b/scripts/lock-structure.ts
@@ -1,0 +1,40 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { getRoutes } from "../src/ROUTES.reg.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function listFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listFiles(full));
+    } else {
+      files.push(path.relative(path.join(process.cwd(), "src"), full));
+    }
+  }
+  return files.sort();
+}
+
+const compSource = fs.readFileSync(path.join(process.cwd(), "src/COMPONENTS.reg.ts"), "utf8");
+const componentExports = compSource
+  .split("\n")
+  .filter((l) => l.startsWith("export {"))
+  .map((l) => l.match(/export\s+{\s*(?:default\s+as\s+)?(\w+)/)?.[1])
+  .filter(Boolean) as string[];
+
+const snapshot = {
+  routes: getRoutes(),
+  components: componentExports.sort(),
+  appFiles: listFiles(path.join(process.cwd(), "src/app")),
+};
+
+fs.writeFileSync(
+  path.join(__dirname, ".structure-snapshot.json"),
+  JSON.stringify(snapshot, null, 2)
+);
+console.log("Structure snapshot saved");

--- a/scripts/verify-structure.ts
+++ b/scripts/verify-structure.ts
@@ -1,0 +1,65 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { getRoutes } from "../src/ROUTES.reg.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const snapshotPath = path.join(__dirname, ".structure-snapshot.json");
+
+function listFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listFiles(full));
+    } else {
+      files.push(path.relative(path.join(process.cwd(), "src"), full));
+    }
+  }
+  return files.sort();
+}
+
+if (!fs.existsSync(snapshotPath)) {
+  console.error("Snapshot file not found. Run struct:snapshot first.");
+  process.exit(1);
+}
+
+const compSource = fs.readFileSync(path.join(process.cwd(), "src/COMPONENTS.reg.ts"), "utf8");
+const componentExports = compSource
+  .split("\n")
+  .filter((l) => l.startsWith("export {"))
+  .map((l) => l.match(/export\s+{\s*(?:default\s+as\s+)?(\w+)/)?.[1])
+  .filter(Boolean) as string[];
+
+const snapshot = JSON.parse(fs.readFileSync(snapshotPath, "utf8"));
+const current = {
+  routes: getRoutes(),
+  components: componentExports.sort(),
+  appFiles: listFiles(path.join(process.cwd(), "src/app")),
+};
+
+function diff<T extends { id?: string }>(prev: T[], now: T[], key: keyof T) {
+  const prevSet = new Set(prev.map((i) => i[key] as string));
+  const nowSet = new Set(now.map((i) => i[key] as string));
+  const missing: string[] = [];
+  for (const item of prevSet) {
+    if (!nowSet.has(item)) missing.push(item);
+  }
+  return missing;
+}
+
+const missingRoutes = diff(snapshot.routes, current.routes, "id");
+const missingComponents = snapshot.components.filter((c: string) => !current.components.includes(c));
+const missingFiles = snapshot.appFiles.filter((f: string) => !current.appFiles.includes(f));
+
+if (missingRoutes.length || missingComponents.length || missingFiles.length) {
+  console.error("Structure verification failed:");
+  if (missingRoutes.length) console.error("Missing routes:", missingRoutes);
+  if (missingComponents.length) console.error("Missing components:", missingComponents);
+  if (missingFiles.length) console.error("Missing app files:", missingFiles);
+  process.exit(1);
+}
+
+console.log("Structure verified");

--- a/src/COMPONENTS.reg.ts
+++ b/src/COMPONENTS.reg.ts
@@ -1,0 +1,3 @@
+export { default as PageHeader } from "./components/ui/PageHeader.tsx";
+export { LoadingSpinner } from "./components/ui/LoadingSpinner.tsx";
+export { default as Button } from "./components/ui/button.tsx";

--- a/src/ROUTES.reg.ts
+++ b/src/ROUTES.reg.ts
@@ -1,0 +1,18 @@
+export type RouteDef = { id: string; path: string; component: string };
+const routes: Record<string, RouteDef> = {
+  // ⚠️ existants : ne rien modifier
+};
+
+export function addRoute(def: RouteDef) {
+  if (routes[def.id]) throw new Error(`Route ${def.id} existe déjà`);
+  routes[def.id] = def;
+}
+
+export function getRoutes() {
+  return Object.values(routes);
+}
+
+export default routes;
+
+// Routes initiales
+addRoute({ id: "flash-glow", path: "/modules/flash-glow", component: "FlashGlowPage" });

--- a/src/SCHEMA.ts
+++ b/src/SCHEMA.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const FlashGlowPrefs = z.object({
+  intensity: z.number().min(0).max(10).optional(),
+  enabled: z.boolean().optional(),
+});
+export type FlashGlowPrefs = z.infer<typeof FlashGlowPrefs>;

--- a/src/__tests__/flash-glow.snapshot.spec.tsx
+++ b/src/__tests__/flash-glow.snapshot.spec.tsx
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import Page from "@/app/modules/flash-glow/page";
+
+describe("FlashGlowPage", () => {
+  it("rend la page", () => {
+    const { container } = render(<Page />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/app/modules/flash-glow/page.tsx
+++ b/src/app/modules/flash-glow/page.tsx
@@ -1,0 +1,11 @@
+import { PageHeader, Button } from "@/COMPONENTS.reg";
+
+export default function FlashGlowPage() {
+  return (
+    <main className="p-4 space-y-4">
+      <PageHeader title="Flash Glow" subtitle="Experience the glow" />
+      <p>Bienvenue dans le module Flash Glow.</p>
+      <Button>Commencer</Button>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add central route registry and component registry
- scaffold Flash Glow module with page and schema
- add structure snapshot/verify scripts and tests

## Testing
- `npm run struct:snapshot`
- `npm run struct:verify`
- `npm run ci:guard` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_68c497264510832d983e441b014a7413