### PR TITLE
feat: add emotion scan module

### DIFF
--- a/docs/STRUCTURE_REPORT.md
+++ b/docs/STRUCTURE_REPORT.md
@@ -76,3 +76,10 @@
 - Présence de NavBar, Footer, error.tsx, not-found.tsx.
 - Raccourci Cmd/Ctrl + K pour la Command Palette.
 - Règles a11y appliquées ; comportements de prefetch.
+
+## Module — Emotion Scan
+- Route ajoutée `/modules/emotion-scan`.
+- Composant `EmotionScanPage`.
+- Schéma `EmotionScanData` (tous champs optionnels).
+- Event `recordEvent` à la soumission (si P6 présent).
+- Historique : clé `emotion_scan_history_v1` (localStorage, 12 points).

--- a/e2e/emotion-scan.smoke.spec.ts
+++ b/e2e/emotion-scan.smoke.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "@playwright/test";
+
+test("emotion scan smoke", async ({ page }) => {
+  await page.goto("/modules/emotion-scan");
+  await expect(page).toHaveURL(/\/modules\/emotion-scan/);
+
+  // Remplir 3-4 lignes au hasard (on coche la valeur 4)
+  await page.locator('input[name="active"][id="active-4"]').check();
+  await page.locator('input[name="determined"][id="determined-4"]').check();
+  await page.locator('input[name="upset"][id="upset-2"]').check();
+  await page.locator('input[name="nervous"][id="nervous-2"]').check();
+
+  // Soumettre (toléré même si pas 10/10 remplis)
+  await page.locator('[data-ui="primary-cta"]').click();
+  await expect(page.getByText(/Résultat/)).toBeVisible();
+});

--- a/src/SCHEMA.ts
+++ b/src/SCHEMA.ts
@@ -77,3 +77,23 @@ export const Feedback = z.object({
   message: z.string().optional(),
 });
 export type Feedback = z.infer<typeof Feedback>;
+
+export const EmotionScanData = z.object({
+  // clés I-PANAS-SF — toutes optionnelles pour compat ascendante
+  active: z.number().int().min(1).max(5).optional(),
+  determined: z.number().int().min(1).max(5).optional(),
+  attentive: z.number().int().min(1).max(5).optional(),
+  inspired: z.number().int().min(1).max(5).optional(),
+  alert: z.number().int().min(1).max(5).optional(),
+  upset: z.number().int().min(1).max(5).optional(),
+  hostile: z.number().int().min(1).max(5).optional(),
+  ashamed: z.number().int().min(1).max(5).optional(),
+  nervous: z.number().int().min(1).max(5).optional(),
+  afraid: z.number().int().min(1).max(5).optional(),
+  // scores dérivés (facultatifs)
+  pa: z.number().optional(),
+  na: z.number().optional(),
+  balance: z.number().optional()
+}).optional();
+
+export type EmotionScanData = z.infer<typeof EmotionScanData>;

--- a/src/__tests__/__snapshots__/emotion-scan.snapshot.spec.tsx.snap
+++ b/src/__tests__/__snapshots__/emotion-scan.snapshot.spec.tsx.snap
@@ -17,3 +17,796 @@ exports[`EmotionScan Page > rend la page 1`] = `
   </main>
 </div>
 `;
+
+exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
+<div>
+  <main
+    aria-label="Emotion Scan"
+  >
+    <div>
+      Emotion Scan
+    </div>
+    <div>
+      <form>
+        <fieldset>
+          <legend>
+            Émotions positives
+          </legend>
+          <div
+            style="display: grid; grid-template-columns: 1fr auto auto auto auto auto; align-items: center; gap: 6px; padding-block: 4px;"
+          >
+            <label
+              for="active-3"
+              style="white-space: nowrap;"
+            >
+              Actif(ve)
+            </label>
+            <label
+              aria-label="Actif(ve) 1"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="active-1"
+                name="active"
+                type="radio"
+              />
+              <small>
+                1
+              </small>
+            </label>
+            <label
+              aria-label="Actif(ve) 2"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="active-2"
+                name="active"
+                type="radio"
+              />
+              <small>
+                2
+              </small>
+            </label>
+            <label
+              aria-label="Actif(ve) 3"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="active-3"
+                name="active"
+                type="radio"
+              />
+              <small>
+                3
+              </small>
+            </label>
+            <label
+              aria-label="Actif(ve) 4"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="active-4"
+                name="active"
+                type="radio"
+              />
+              <small>
+                4
+              </small>
+            </label>
+            <label
+              aria-label="Actif(ve) 5"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="active-5"
+                name="active"
+                type="radio"
+              />
+              <small>
+                5
+              </small>
+            </label>
+          </div>
+          <div
+            style="display: grid; grid-template-columns: 1fr auto auto auto auto auto; align-items: center; gap: 6px; padding-block: 4px;"
+          >
+            <label
+              for="determined-3"
+              style="white-space: nowrap;"
+            >
+              Déterminé(e)
+            </label>
+            <label
+              aria-label="Déterminé(e) 1"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="determined-1"
+                name="determined"
+                type="radio"
+              />
+              <small>
+                1
+              </small>
+            </label>
+            <label
+              aria-label="Déterminé(e) 2"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="determined-2"
+                name="determined"
+                type="radio"
+              />
+              <small>
+                2
+              </small>
+            </label>
+            <label
+              aria-label="Déterminé(e) 3"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="determined-3"
+                name="determined"
+                type="radio"
+              />
+              <small>
+                3
+              </small>
+            </label>
+            <label
+              aria-label="Déterminé(e) 4"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="determined-4"
+                name="determined"
+                type="radio"
+              />
+              <small>
+                4
+              </small>
+            </label>
+            <label
+              aria-label="Déterminé(e) 5"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="determined-5"
+                name="determined"
+                type="radio"
+              />
+              <small>
+                5
+              </small>
+            </label>
+          </div>
+          <div
+            style="display: grid; grid-template-columns: 1fr auto auto auto auto auto; align-items: center; gap: 6px; padding-block: 4px;"
+          >
+            <label
+              for="attentive-3"
+              style="white-space: nowrap;"
+            >
+              Attentif(ve)
+            </label>
+            <label
+              aria-label="Attentif(ve) 1"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="attentive-1"
+                name="attentive"
+                type="radio"
+              />
+              <small>
+                1
+              </small>
+            </label>
+            <label
+              aria-label="Attentif(ve) 2"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="attentive-2"
+                name="attentive"
+                type="radio"
+              />
+              <small>
+                2
+              </small>
+            </label>
+            <label
+              aria-label="Attentif(ve) 3"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="attentive-3"
+                name="attentive"
+                type="radio"
+              />
+              <small>
+                3
+              </small>
+            </label>
+            <label
+              aria-label="Attentif(ve) 4"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="attentive-4"
+                name="attentive"
+                type="radio"
+              />
+              <small>
+                4
+              </small>
+            </label>
+            <label
+              aria-label="Attentif(ve) 5"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="attentive-5"
+                name="attentive"
+                type="radio"
+              />
+              <small>
+                5
+              </small>
+            </label>
+          </div>
+          <div
+            style="display: grid; grid-template-columns: 1fr auto auto auto auto auto; align-items: center; gap: 6px; padding-block: 4px;"
+          >
+            <label
+              for="inspired-3"
+              style="white-space: nowrap;"
+            >
+              Inspiré(e)
+            </label>
+            <label
+              aria-label="Inspiré(e) 1"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="inspired-1"
+                name="inspired"
+                type="radio"
+              />
+              <small>
+                1
+              </small>
+            </label>
+            <label
+              aria-label="Inspiré(e) 2"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="inspired-2"
+                name="inspired"
+                type="radio"
+              />
+              <small>
+                2
+              </small>
+            </label>
+            <label
+              aria-label="Inspiré(e) 3"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="inspired-3"
+                name="inspired"
+                type="radio"
+              />
+              <small>
+                3
+              </small>
+            </label>
+            <label
+              aria-label="Inspiré(e) 4"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="inspired-4"
+                name="inspired"
+                type="radio"
+              />
+              <small>
+                4
+              </small>
+            </label>
+            <label
+              aria-label="Inspiré(e) 5"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="inspired-5"
+                name="inspired"
+                type="radio"
+              />
+              <small>
+                5
+              </small>
+            </label>
+          </div>
+          <div
+            style="display: grid; grid-template-columns: 1fr auto auto auto auto auto; align-items: center; gap: 6px; padding-block: 4px;"
+          >
+            <label
+              for="alert-3"
+              style="white-space: nowrap;"
+            >
+              Alerte
+            </label>
+            <label
+              aria-label="Alerte 1"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="alert-1"
+                name="alert"
+                type="radio"
+              />
+              <small>
+                1
+              </small>
+            </label>
+            <label
+              aria-label="Alerte 2"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="alert-2"
+                name="alert"
+                type="radio"
+              />
+              <small>
+                2
+              </small>
+            </label>
+            <label
+              aria-label="Alerte 3"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="alert-3"
+                name="alert"
+                type="radio"
+              />
+              <small>
+                3
+              </small>
+            </label>
+            <label
+              aria-label="Alerte 4"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="alert-4"
+                name="alert"
+                type="radio"
+              />
+              <small>
+                4
+              </small>
+            </label>
+            <label
+              aria-label="Alerte 5"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="alert-5"
+                name="alert"
+                type="radio"
+              />
+              <small>
+                5
+              </small>
+            </label>
+          </div>
+        </fieldset>
+        <fieldset
+          style="margin-top: 12px;"
+        >
+          <legend>
+            Émotions négatives
+          </legend>
+          <div
+            style="display: grid; grid-template-columns: 1fr auto auto auto auto auto; align-items: center; gap: 6px; padding-block: 4px;"
+          >
+            <label
+              for="upset-3"
+              style="white-space: nowrap;"
+            >
+              Contrarié(e)
+            </label>
+            <label
+              aria-label="Contrarié(e) 1"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="upset-1"
+                name="upset"
+                type="radio"
+              />
+              <small>
+                1
+              </small>
+            </label>
+            <label
+              aria-label="Contrarié(e) 2"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="upset-2"
+                name="upset"
+                type="radio"
+              />
+              <small>
+                2
+              </small>
+            </label>
+            <label
+              aria-label="Contrarié(e) 3"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="upset-3"
+                name="upset"
+                type="radio"
+              />
+              <small>
+                3
+              </small>
+            </label>
+            <label
+              aria-label="Contrarié(e) 4"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="upset-4"
+                name="upset"
+                type="radio"
+              />
+              <small>
+                4
+              </small>
+            </label>
+            <label
+              aria-label="Contrarié(e) 5"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="upset-5"
+                name="upset"
+                type="radio"
+              />
+              <small>
+                5
+              </small>
+            </label>
+          </div>
+          <div
+            style="display: grid; grid-template-columns: 1fr auto auto auto auto auto; align-items: center; gap: 6px; padding-block: 4px;"
+          >
+            <label
+              for="hostile-3"
+              style="white-space: nowrap;"
+            >
+              Hostile
+            </label>
+            <label
+              aria-label="Hostile 1"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="hostile-1"
+                name="hostile"
+                type="radio"
+              />
+              <small>
+                1
+              </small>
+            </label>
+            <label
+              aria-label="Hostile 2"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="hostile-2"
+                name="hostile"
+                type="radio"
+              />
+              <small>
+                2
+              </small>
+            </label>
+            <label
+              aria-label="Hostile 3"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="hostile-3"
+                name="hostile"
+                type="radio"
+              />
+              <small>
+                3
+              </small>
+            </label>
+            <label
+              aria-label="Hostile 4"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="hostile-4"
+                name="hostile"
+                type="radio"
+              />
+              <small>
+                4
+              </small>
+            </label>
+            <label
+              aria-label="Hostile 5"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="hostile-5"
+                name="hostile"
+                type="radio"
+              />
+              <small>
+                5
+              </small>
+            </label>
+          </div>
+          <div
+            style="display: grid; grid-template-columns: 1fr auto auto auto auto auto; align-items: center; gap: 6px; padding-block: 4px;"
+          >
+            <label
+              for="ashamed-3"
+              style="white-space: nowrap;"
+            >
+              Honteux(se)
+            </label>
+            <label
+              aria-label="Honteux(se) 1"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="ashamed-1"
+                name="ashamed"
+                type="radio"
+              />
+              <small>
+                1
+              </small>
+            </label>
+            <label
+              aria-label="Honteux(se) 2"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="ashamed-2"
+                name="ashamed"
+                type="radio"
+              />
+              <small>
+                2
+              </small>
+            </label>
+            <label
+              aria-label="Honteux(se) 3"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="ashamed-3"
+                name="ashamed"
+                type="radio"
+              />
+              <small>
+                3
+              </small>
+            </label>
+            <label
+              aria-label="Honteux(se) 4"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="ashamed-4"
+                name="ashamed"
+                type="radio"
+              />
+              <small>
+                4
+              </small>
+            </label>
+            <label
+              aria-label="Honteux(se) 5"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="ashamed-5"
+                name="ashamed"
+                type="radio"
+              />
+              <small>
+                5
+              </small>
+            </label>
+          </div>
+          <div
+            style="display: grid; grid-template-columns: 1fr auto auto auto auto auto; align-items: center; gap: 6px; padding-block: 4px;"
+          >
+            <label
+              for="nervous-3"
+              style="white-space: nowrap;"
+            >
+              Nerveux(se)
+            </label>
+            <label
+              aria-label="Nerveux(se) 1"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="nervous-1"
+                name="nervous"
+                type="radio"
+              />
+              <small>
+                1
+              </small>
+            </label>
+            <label
+              aria-label="Nerveux(se) 2"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="nervous-2"
+                name="nervous"
+                type="radio"
+              />
+              <small>
+                2
+              </small>
+            </label>
+            <label
+              aria-label="Nerveux(se) 3"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="nervous-3"
+                name="nervous"
+                type="radio"
+              />
+              <small>
+                3
+              </small>
+            </label>
+            <label
+              aria-label="Nerveux(se) 4"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="nervous-4"
+                name="nervous"
+                type="radio"
+              />
+              <small>
+                4
+              </small>
+            </label>
+            <label
+              aria-label="Nerveux(se) 5"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="nervous-5"
+                name="nervous"
+                type="radio"
+              />
+              <small>
+                5
+              </small>
+            </label>
+          </div>
+          <div
+            style="display: grid; grid-template-columns: 1fr auto auto auto auto auto; align-items: center; gap: 6px; padding-block: 4px;"
+          >
+            <label
+              for="afraid-3"
+              style="white-space: nowrap;"
+            >
+              Effrayé(e)
+            </label>
+            <label
+              aria-label="Effrayé(e) 1"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="afraid-1"
+                name="afraid"
+                type="radio"
+              />
+              <small>
+                1
+              </small>
+            </label>
+            <label
+              aria-label="Effrayé(e) 2"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="afraid-2"
+                name="afraid"
+                type="radio"
+              />
+              <small>
+                2
+              </small>
+            </label>
+            <label
+              aria-label="Effrayé(e) 3"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="afraid-3"
+                name="afraid"
+                type="radio"
+              />
+              <small>
+                3
+              </small>
+            </label>
+            <label
+              aria-label="Effrayé(e) 4"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="afraid-4"
+                name="afraid"
+                type="radio"
+              />
+              <small>
+                4
+              </small>
+            </label>
+            <label
+              aria-label="Effrayé(e) 5"
+              style="display: grid; place-items: center;"
+            >
+              <input
+                id="afraid-5"
+                name="afraid"
+                type="radio"
+              />
+              <small>
+                5
+              </small>
+            </label>
+          </div>
+        </fieldset>
+        <div
+          style="display: grid; gap: 8px; margin-top: 12px;"
+        >
+          <div>
+            progress 
+            0
+          </div>
+          <button
+            aria-disabled="true"
+            data-ui="primary-cta"
+            type="submit"
+          >
+            Calculer
+          </button>
+        </div>
+      </form>
+    </div>
+  </main>
+</div>
+`;

--- a/src/__tests__/emotion-scan.snapshot.spec.tsx
+++ b/src/__tests__/emotion-scan.snapshot.spec.tsx
@@ -2,13 +2,26 @@ import { describe, it, expect, vi } from "vitest";
 import { render } from "@testing-library/react";
 vi.mock("@/COMPONENTS.reg", () => ({
   PageHeader: ({ title }: any) => <div>{title}</div>,
-  Button: ({ children }: any) => <button>{children}</button>,
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  Card: ({ children }: any) => <div>{children}</div>,
+  ProgressBar: ({ value }: any) => <div>progress {value}</div>,
+  Sparkline: ({ values }: any) => <div>{values.join(',')}</div>
 }));
 import Page from "@/app/modules/emotion-scan/page";
+import EmotionScanPage from "@/modules/emotion-scan/EmotionScanPage";
 
 describe("EmotionScan Page", () => {
   it("rend la page", () => {
     const { container } = render(<Page />);
+    expect(container).toMatchSnapshot();
+  });
+});
+
+describe("EmotionScanPage", () => {
+  it("rend la page et le CTA Calculer", () => {
+    const { container, getByText } = render(<EmotionScanPage />);
+    expect(getByText(/Emotion Scan/i)).toBeTruthy();
+    expect(getByText(/Calculer/i)).toBeTruthy();
     expect(container).toMatchSnapshot();
   });
 });

--- a/src/modules/emotion-scan/EmotionScanPage.tsx
+++ b/src/modules/emotion-scan/EmotionScanPage.tsx
@@ -1,0 +1,140 @@
+"use client";
+import React from "react";
+import { PageHeader, Card, Button, ProgressBar, Sparkline } from "@/COMPONENTS.reg"; // ProgressBar/Sparkline ajoutés en P6
+import { recordEvent } from "@/lib/scores/events"; // si P6 non intégré, cet import peut être ignoré (no-op)
+import { z } from "zod";
+
+const POS = [
+  { id: "active", label: "Actif(ve)" },
+  { id: "determined", label: "Déterminé(e)" },
+  { id: "attentive", label: "Attentif(ve)" },
+  { id: "inspired", label: "Inspiré(e)" },
+  { id: "alert", label: "Alerte" }
+] as const;
+
+const NEG = [
+  { id: "upset", label: "Contrarié(e)" },
+  { id: "hostile", label: "Hostile" },
+  { id: "ashamed", label: "Honteux(se)" },
+  { id: "nervous", label: "Nerveux(se)" },
+  { id: "afraid", label: "Effrayé(e)" }
+] as const;
+
+type Likert = 1|2|3|4|5;
+type Resp = Record<(typeof POS[number] | typeof NEG[number])["id"], Likert | undefined>;
+
+const HISTORY_KEY = "emotion_scan_history_v1";
+
+function loadHistory(): number[] {
+  try { return JSON.parse(localStorage.getItem(HISTORY_KEY) || "[]"); } catch { return []; }
+}
+function saveHistory(vals: number[]) {
+  localStorage.setItem(HISTORY_KEY, JSON.stringify(vals.slice(-12)));
+}
+
+export default function EmotionScanPage() {
+  const [resp, setResp] = React.useState<Resp>({} as any);
+  const [submitted, setSubmitted] = React.useState(false);
+  const [history, setHistory] = React.useState<number[]>([]);
+
+  React.useEffect(() => { setHistory(loadHistory()); }, []);
+
+  const pa = POS.reduce((s, q) => s + ((resp[q.id] ?? 0) as number), 0); // 0..25
+  const na = NEG.reduce((s, q) => s + ((resp[q.id] ?? 0) as number), 0); // 0..25
+  const balance = pa - na; // -25..25
+  const completion = [...POS, ...NEG].filter(q => !!resp[q.id]).length / 10; // 0..1
+
+  function labelForBalance(b: number) {
+    if (b >= 8) return "Équilibre positif";
+    if (b >= 3) return "Plutôt positif";
+    if (b > -3) return "Neutre";
+    if (b > -8) return "Tendu";
+    return "Négatif";
+    }
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitted(true);
+    // Historique (balance normalisée 0..100)
+    const toStore = Math.round((balance + 25) * 2); // -25..25 → 0..100
+    const next = [...history, toStore].slice(-12);
+    setHistory(next);
+    saveHistory(next);
+
+    // Event pour Scores V2 (si dispo)
+    try {
+      recordEvent?.({
+        module: "emotion-scan",
+        startedAt: new Date().toISOString(),
+        endedAt: new Date().toISOString(),
+        durationSec: 60,
+        score: Math.max(0, toStore), // proxy
+        meta: { pa, na, balance }
+      });
+    } catch {}
+
+    // focus résultat
+    setTimeout(() => document.getElementById("scan-result")?.scrollIntoView({ behavior: "smooth", block: "start" }), 10);
+  }
+
+  return (
+    <main aria-label="Emotion Scan">
+      <PageHeader title="Emotion Scan" subtitle="Auto-évaluation rapide (I-PANAS-SF)" />
+      <Card>
+        <form onSubmit={onSubmit}>
+          <fieldset>
+            <legend>Émotions positives</legend>
+            {POS.map(q => (
+              <LikertRow key={q.id} id={q.id} label={q.label} value={resp[q.id]} onChange={(v)=>setResp(r => ({...r, [q.id]: v}))} />
+            ))}
+          </fieldset>
+
+          <fieldset style={{ marginTop: 12 }}>
+            <legend>Émotions négatives</legend>
+            {NEG.map(q => (
+              <LikertRow key={q.id} id={q.id} label={q.label} value={resp[q.id]} onChange={(v)=>setResp(r => ({...r, [q.id]: v}))} />
+            ))}
+          </fieldset>
+
+          <div style={{ display: "grid", gap: 8, marginTop: 12 }}>
+            <ProgressBar value={completion * 100} max={100} />
+            <Button type="submit" data-ui="primary-cta" aria-disabled={completion < 1}>Calculer</Button>
+          </div>
+        </form>
+      </Card>
+
+      {submitted && (
+        <Card id="scan-result" style={{ marginTop: 12 }}>
+          <h2>Résultat</h2>
+          <p><strong>PA</strong> (positif) : {pa} / 25</p>
+          <p><strong>NA</strong> (négatif) : {na} / 25</p>
+          <p><strong>Balance</strong> (PA - NA) : {balance} — <em>{labelForBalance(balance)}</em></p>
+          <div style={{ marginTop: 8 }}>
+            <Sparkline values={history} />
+          </div>
+        </Card>
+      )}
+    </main>
+  );
+}
+
+function LikertRow({ id, label, value, onChange }: { id: string; label: string; value?: Likert; onChange: (v: Likert)=>void }) {
+  const opts: Likert[] = [1,2,3,4,5];
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "1fr auto auto auto auto auto", alignItems: "center", gap: 6, paddingBlock: 4 }}>
+      <label htmlFor={`${id}-3`} style={{ whiteSpace: "nowrap" }}>{label}</label>
+      {opts.map(v => (
+        <label key={v} style={{ display: "grid", placeItems: "center" }} aria-label={`${label} ${v}`}>
+          <input
+            type="radio"
+            name={id}
+            id={`${id}-${v}`}
+            checked={value === v}
+            onChange={() => onChange(v)}
+          />
+          <small>{v}</small>
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/modules/index.ts
+++ b/src/pages/modules/index.ts
@@ -13,3 +13,4 @@ export { default as StorySynthPage } from './StorySynthPage';
 // Re-export refactored modules
 export { default as VRBreathPage } from '../VRBreathPage';
 export { default as MusicPage } from '../B2CMusicEnhanced';
+export { default as EmotionScanPage } from '@/modules/emotion-scan/EmotionScanPage';

--- a/src/routerV2/index.tsx
+++ b/src/routerV2/index.tsx
@@ -137,6 +137,7 @@ const BossGritPage = lazy(() => import('@/pages/modules/BossGritPage'));
 const BubbleBeatPage = lazy(() => import('@/pages/modules/BubbleBeatPage'));
 const StorySynthPage = lazy(() => import('@/pages/modules/StorySynthPage'));
 const ModulesShowcasePage = lazy(() => import('@/pages/ModulesShowcasePage'));
+const EmotionScanPage = lazy(() => import('@/modules/emotion-scan/EmotionScanPage'));
 
 // Pages DEV uniquement
 const ComprehensiveSystemAuditPage = lazy(() => import('@/pages/ComprehensiveSystemAuditPage'));
@@ -272,6 +273,7 @@ const componentMap: Record<string, React.LazyExoticComponent<React.ComponentType
   BubbleBeatPage,
   StorySynthPage,
   ModulesShowcasePage,
+  EmotionScanPage,
 
   // Dev-only pages
   ComprehensiveSystemAuditPage,


### PR DESCRIPTION
## Summary
- add EmotionScanPage module with I-PANAS-SF questionnaire
- wire router, schema and exports for emotion scan
- add tests and docs for emotion scan module

## Testing
- `npx vitest run src/__tests__/emotion-scan.snapshot.spec.tsx -u`
- `npm run ci:guard` *(fails: globalInterceptor tests, db connection, music recommendation etc.)*
- `npx playwright test e2e/emotion-scan.smoke.spec.ts --project=chromium` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68c6740d12b0832da5020ed68a00de85