### PR TITLE
feat: add breath constellation module

### DIFF
--- a/docs/STRUCTURE_REPORT.md
+++ b/docs/STRUCTURE_REPORT.md
@@ -83,3 +83,10 @@
 - Schéma `EmotionScanData` (tous champs optionnels).
 - Event `recordEvent` à la soumission (si P6 présent).
 - Historique : clé `emotion_scan_history_v1` (localStorage, 12 points).
+
+## Module — Breath Constellation
+- Route `/modules/breath-constellation`, composant `BreathConstellationPage`.
+- DS : ConstellationCanvas, hooks useRaf, useBreathPattern.
+- Schéma `BreathConstellationPrefs` (tous optionnels).
+- Event `recordEvent` à la fin de session.
+- Notes perf & reduced motion.

--- a/e2e/breath-constellation.smoke.spec.ts
+++ b/e2e/breath-constellation.smoke.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "@playwright/test";
+
+test("breath constellation smoke", async ({ page }) => {
+  await page.goto("/modules/breath-constellation");
+  await expect(page).toHaveURL(/\/modules\/breath-constellation/);
+  await page.getByRole("button", { name: /Démarrer/i }).click();
+  await page.waitForTimeout(800);
+  await page.getByRole("button", { name: /Pause/i }).click();
+  await expect(page.getByText(/Cycle/i)).toBeVisible();
+});

--- a/src/COMPONENTS.reg.ts
+++ b/src/COMPONENTS.reg.ts
@@ -25,3 +25,5 @@ export { usePrefetchOnHover } from "@/hooks/usePrefetchOnHover";
 export { Input } from "./components/ui/input.tsx";
 export { Textarea } from "./components/ui/textarea.tsx";
 export { FeedbackForm } from "@/ui/FeedbackForm";
+export { useRaf } from "@/ui/hooks/useRaf";
+export { ConstellationCanvas } from "@/ui/ConstellationCanvas";

--- a/src/SCHEMA.ts
+++ b/src/SCHEMA.ts
@@ -9,7 +9,15 @@ export const AdaptiveMusicPrefs = z.object({}).optional();
 export type AdaptiveMusicPrefs = z.infer<typeof AdaptiveMusicPrefs>;
 export const BossGritPrefs = z.object({}).optional();
 export type BossGritPrefs = z.infer<typeof BossGritPrefs>;
-export const BreathConstellationPrefs = z.object({}).optional();
+export const BreathConstellationPrefs = z.object({
+  pattern: z
+    .enum(["coherence-5-5", "4-7-8", "box-4-4-4-4", "triangle-4-6-8"])
+    .optional(),
+  cycles: z.number().int().min(4).max(16).optional(),
+  density: z.number().min(0.3).max(1).optional(),
+  soundCues: z.boolean().optional(),
+  haptics: z.boolean().optional(),
+});
 export type BreathConstellationPrefs = z.infer<typeof BreathConstellationPrefs>;
 export const BubbleBeatPrefs = z.object({}).optional();
 export type BubbleBeatPrefs = z.infer<typeof BubbleBeatPrefs>;

--- a/src/__tests__/__snapshots__/breath-constellation.snapshot.spec.tsx.snap
+++ b/src/__tests__/__snapshots__/breath-constellation.snapshot.spec.tsx.snap
@@ -1,19 +1,261 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`BreathConstellation Page > rend la page 1`] = `
+exports[`BreathConstellationPage > rend la page et le CTA Démarrer 1`] = `
 <div>
   <main
-    class="p-4 space-y-4"
+    aria-label="Breath Constellation"
   >
-    <div>
-      BreathConstellation
+    <div
+      class="relative overflow-hidden rounded-2xl p-6 mb-8 bg-gradient-to-r from-primary/10 via-primary/5 to-background"
+      style="opacity: 0; transform: translateY(-20px);"
+    >
+      <div
+        class="absolute inset-0 bg-gradient-to-r from-blue-50/50 via-purple-50/30 to-pink-50/20 dark:from-blue-900/10 dark:via-purple-900/5 dark:to-pink-900/5"
+      />
+      <div
+        class="relative z-10"
+      >
+        <div
+          class="flex items-center justify-between mb-4"
+        >
+          <div
+            class="flex items-center gap-4"
+          >
+            <button
+              class="inline-flex items-center justify-center whitespace-nowrap font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed focus-enhanced border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground hover:shadow-md active:scale-95 h-8 px-3 text-xs rounded-full"
+              type="button"
+            >
+              <svg
+                class="lucide lucide-arrow-left h-4 w-4"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m12 19-7-7 7-7"
+                />
+                <path
+                  d="M19 12H5"
+                />
+              </svg>
+            </button>
+            <div
+              class="flex items-center gap-3"
+            >
+              <div>
+                <div
+                  class="flex items-center gap-3 mb-1"
+                >
+                  <h1
+                    class="text-2xl font-bold bg-gradient-to-r from-foreground to-foreground/80 bg-clip-text"
+                  >
+                    Breath Constellation
+                  </h1>
+                </div>
+                <p
+                  class="text-muted-foreground"
+                >
+                  Respiration guidée par une constellation vivante
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="flex items-center gap-2"
+        >
+          <button
+            class="inline-flex items-center justify-center whitespace-nowrap font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed focus-enhanced hover:bg-accent hover:text-accent-foreground active:scale-95 h-8 rounded-md px-3 text-xs"
+            type="button"
+          >
+            <svg
+              class="lucide lucide-heart h-3 w-3 mr-1"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z"
+              />
+            </svg>
+            Favoris
+          </button>
+          <button
+            class="inline-flex items-center justify-center whitespace-nowrap font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed focus-enhanced hover:bg-accent hover:text-accent-foreground active:scale-95 h-8 rounded-md px-3 text-xs"
+            type="button"
+          >
+            <svg
+              class="lucide lucide-share2 h-3 w-3 mr-1"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle
+                cx="18"
+                cy="5"
+                r="3"
+              />
+              <circle
+                cx="6"
+                cy="12"
+                r="3"
+              />
+              <circle
+                cx="18"
+                cy="19"
+                r="3"
+              />
+              <line
+                x1="8.59"
+                x2="15.42"
+                y1="13.51"
+                y2="17.49"
+              />
+              <line
+                x1="15.41"
+                x2="8.59"
+                y1="6.51"
+                y2="10.49"
+              />
+            </svg>
+            Partager
+          </button>
+          <button
+            class="inline-flex items-center justify-center whitespace-nowrap font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed focus-enhanced hover:bg-accent hover:text-accent-foreground active:scale-95 h-8 rounded-md px-3 text-xs"
+            type="button"
+          >
+            <svg
+              class="lucide lucide-star h-3 w-3 mr-1"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <polygon
+                points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"
+              />
+            </svg>
+            Noter
+          </button>
+        </div>
+      </div>
     </div>
-    <p>
-      Bienvenue dans le module BreathConstellation.
-    </p>
-    <button>
-      Commencer
-    </button>
+    <div
+      class="rounded-xl border bg-card text-card-foreground shadow"
+    >
+      <section
+        style="display: grid; gap: 12px;"
+      >
+        <div
+          style="display: grid; gap: 8px;"
+        >
+          <label>
+            Pattern
+            <select>
+              <option
+                value="coherence-5-5"
+              >
+                Cohérence (5-5)
+              </option>
+              <option
+                value="4-7-8"
+              >
+                4-7-8
+              </option>
+              <option
+                value="box-4-4-4-4"
+              >
+                Box (4-4-4-4)
+              </option>
+              <option
+                value="triangle-4-6-8"
+              >
+                Triangle (4-6-8)
+              </option>
+            </select>
+          </label>
+          <label>
+            Cycles : 
+            8
+            <input
+              max="16"
+              min="4"
+              step="1"
+              type="range"
+              value="8"
+            />
+          </label>
+          <label>
+            Densité : 
+            80
+            %
+            <input
+              max="1"
+              min="0.3"
+              step="0.05"
+              type="range"
+              value="0.8"
+            />
+          </label>
+        </div>
+        <div
+          style="width: 100%; height: 300px; border-radius: 12px; overflow: hidden;"
+        >
+          <canvas
+            aria-label="Constellation respiratoire"
+            height="0"
+            style="width: 100%; height: 100%; display: block;"
+            width="0"
+          />
+        </div>
+        <div
+          style="display: flex; gap: 8px;"
+        >
+          <button
+            class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed focus-enhanced bg-primary text-primary-foreground shadow hover:bg-primary/90 hover:shadow-md active:scale-95 h-9 px-4 py-2"
+            data-ui="primary-cta"
+            type="button"
+          >
+            Démarrer
+          </button>
+          <button
+            class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed focus-enhanced bg-primary text-primary-foreground shadow hover:bg-primary/90 hover:shadow-md active:scale-95 h-9 px-4 py-2"
+            type="button"
+          >
+            Arrêter
+          </button>
+        </div>
+        <small>
+          Cycle 
+          0
+           / 
+          8
+        </small>
+      </section>
+    </div>
   </main>
 </div>
 `;

--- a/src/__tests__/breath-constellation.snapshot.spec.tsx
+++ b/src/__tests__/breath-constellation.snapshot.spec.tsx
@@ -1,14 +1,38 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
-vi.mock("@/COMPONENTS.reg", () => ({
-  PageHeader: ({ title }: any) => <div>{title}</div>,
-  Button: ({ children }: any) => <button>{children}</button>,
-}));
-import Page from "@/app/modules/breath-constellation/page";
+import BreathConstellationPage from "@/modules/breath-constellation/BreathConstellationPage";
 
-describe("BreathConstellation Page", () => {
-  it("rend la page", () => {
-    const { container } = render(<Page />);
+// mock canvas context for jsdom
+Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+  value: () => ({
+    scale: () => {},
+    clearRect: () => {},
+    beginPath: () => {},
+    arc: () => {},
+    fill: () => {},
+    moveTo: () => {},
+    lineTo: () => {},
+    stroke: () => {},
+    save: () => {},
+    restore: () => {},
+    fillStyle: "",
+    globalAlpha: 1,
+    lineWidth: 1,
+    strokeStyle: "",
+  }),
+});
+
+class RO {
+  observe() {}
+  disconnect() {}
+}
+(globalThis as any).ResizeObserver = RO;
+
+describe("BreathConstellationPage", () => {
+  it("rend la page et le CTA Démarrer", () => {
+    const { container, getByText } = render(<BreathConstellationPage />);
+    expect(getByText(/Breath Constellation/i)).toBeTruthy();
+    expect(getByText(/Démarrer/i)).toBeTruthy();
     expect(container).toMatchSnapshot();
   });
 });

--- a/src/modules/breath-constellation/BreathConstellationPage.tsx
+++ b/src/modules/breath-constellation/BreathConstellationPage.tsx
@@ -1,0 +1,108 @@
+"use client";
+import React from "react";
+import { PageHeader, Card, Button } from "@/COMPONENTS.reg";
+import { ConstellationCanvas } from "@/COMPONENTS.reg";
+import { useBreathPattern, Pattern } from "@/ui/hooks/useBreathPattern";
+import { useSound } from "@/COMPONENTS.reg"; // si P5 dispo
+import { ff } from "@/lib/flags/ff";
+import { recordEvent } from "@/lib/scores/events"; // si P6 dispo
+
+const PATTERNS: Record<string, Pattern> = {
+  "coherence-5-5": [
+    { phase: "inhale", sec: 5 },
+    { phase: "exhale", sec: 5 },
+  ],
+  "4-7-8": [
+    { phase: "inhale", sec: 4 },
+    { phase: "hold", sec: 7 },
+    { phase: "exhale", sec: 8 },
+  ],
+  "box-4-4-4-4": [
+    { phase: "inhale", sec: 4 },
+    { phase: "hold", sec: 4 },
+    { phase: "exhale", sec: 4 },
+    { phase: "hold2", sec: 4 },
+  ],
+  "triangle-4-6-8": [
+    { phase: "inhale", sec: 4 },
+    { phase: "hold", sec: 6 },
+    { phase: "exhale", sec: 8 },
+  ],
+};
+
+export default function BreathConstellationPage() {
+  const [patternKey, setPatternKey] = React.useState<keyof typeof PATTERNS>("coherence-5-5");
+  const [cycles, setCycles] = React.useState(8);
+  const [density, setDensity] = React.useState(0.8); // 0..1
+  const reduced = typeof window !== "undefined" && window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+
+  const bp = useBreathPattern(PATTERNS[patternKey], cycles);
+  const useNewAudio = ff?.("new-audio-engine") ?? false;
+  const cue = useNewAudio ? useSound?.("/audio/tick.mp3") ?? null : null;
+
+  const lastPhase = React.useRef<string>("");
+  React.useEffect(() => {
+    const p = bp.current.phase;
+    if (p !== lastPhase.current) {
+      lastPhase.current = p;
+      if (cue?.play) cue.play().catch(() => {});
+      if ("vibrate" in navigator && !reduced) navigator.vibrate?.(6);
+    }
+  }, [bp.current.phase, cue, reduced]);
+
+  React.useEffect(() => {
+    if (!bp.running && bp.cycle >= cycles && cycles > 0) {
+      const dur = PATTERNS[patternKey].reduce((s, p) => s + p.sec, 0) * cycles;
+      recordEvent?.({
+        module: "breath-constellation",
+        startedAt: new Date(Date.now() - dur * 1000).toISOString(),
+        endedAt: new Date().toISOString(),
+        durationSec: dur,
+        score: Math.min(10, Math.round(cycles * 1.2)),
+        meta: { pattern: patternKey, density },
+      });
+    }
+  }, [bp.running, bp.cycle, cycles, density, patternKey]);
+
+  return (
+    <main aria-label="Breath Constellation">
+      <PageHeader title="Breath Constellation" subtitle="Respiration guidée par une constellation vivante" />
+      <Card>
+        <section style={{ display: "grid", gap: 12 }}>
+          <div style={{ display: "grid", gap: 8 }}>
+            <label>
+              Pattern
+              <select value={patternKey} onChange={(e) => setPatternKey(e.target.value as any)}>
+                <option value="coherence-5-5">Cohérence (5-5)</option>
+                <option value="4-7-8">4-7-8</option>
+                <option value="box-4-4-4-4">Box (4-4-4-4)</option>
+                <option value="triangle-4-6-8">Triangle (4-6-8)</option>
+              </select>
+            </label>
+
+            <label>
+              Cycles : {cycles}
+              <input type="range" min={4} max={16} step={1} value={cycles} onChange={(e) => setCycles(parseInt(e.target.value, 10))} />
+            </label>
+
+            <label>
+              Densité : {Math.round(density * 100)}%
+              <input type="range" min={0.3} max={1} step={0.05} value={density} onChange={(e) => setDensity(parseFloat(e.target.value))} />
+            </label>
+          </div>
+
+          <ConstellationCanvas phase={bp.current.phase} phaseProgress={bp.phaseProgress} reduced={!!reduced} density={density} />
+
+          <div style={{ display: "flex", gap: 8 }}>
+            <Button onClick={bp.toggle} data-ui="primary-cta">{bp.running ? "Pause" : "Démarrer"}</Button>
+            {!bp.running && bp.cycle > 0 && bp.cycle < cycles && <Button onClick={bp.start}>Reprendre</Button>}
+            <Button onClick={bp.stop}>Arrêter</Button>
+          </div>
+
+          <small>Cycle {Math.min(bp.cycle, cycles)} / {cycles}</small>
+        </section>
+      </Card>
+    </main>
+  );
+}
+

--- a/src/pages/modules/index.ts
+++ b/src/pages/modules/index.ts
@@ -14,3 +14,4 @@ export { default as StorySynthPage } from './StorySynthPage';
 export { default as VRBreathPage } from '../VRBreathPage';
 export { default as MusicPage } from '../B2CMusicEnhanced';
 export { default as EmotionScanPage } from '@/modules/emotion-scan/EmotionScanPage';
+export { default as BreathConstellationPage } from "@/modules/breath-constellation/BreathConstellationPage";

--- a/src/ui/ConstellationCanvas.tsx
+++ b/src/ui/ConstellationCanvas.tsx
@@ -1,0 +1,137 @@
+"use client";
+import React, { useEffect, useRef } from "react";
+import { useRaf } from "@/COMPONENTS.reg";
+
+type Props = {
+  phase: "inhale" | "exhale" | "hold" | "hold2";
+  phaseProgress: number; // 0..1
+  reduced?: boolean;
+  density?: number; // 0..1
+};
+
+type Star = { x: number; y: number; vx: number; vy: number; r: number };
+
+export function ConstellationCanvas({ phase, phaseProgress, reduced = false, density = 0.8 }: Props) {
+  const ref = useRef<HTMLCanvasElement | null>(null);
+  const starsRef = useRef<Star[]>([]);
+  const tRef = useRef(0);
+
+  // init étoiles
+  useEffect(() => {
+    const cvs = ref.current;
+    if (!cvs) return;
+    const ctx = cvs.getContext("2d");
+    if (!ctx) return;
+    const resize = () => {
+      const dpr = Math.max(1, window.devicePixelRatio || 1);
+      const rect = cvs.getBoundingClientRect();
+      cvs.width = Math.round(rect.width * dpr);
+      cvs.height = Math.round(rect.height * dpr);
+      ctx.scale(dpr, dpr);
+      // régénérer les étoiles selon la densité et la taille
+      const area = rect.width * rect.height;
+      const count = Math.max(12, Math.min(220, Math.round((area / 4500) * density)));
+      starsRef.current = new Array(count).fill(0).map(() => ({
+        x: Math.random() * rect.width,
+        y: Math.random() * rect.height,
+        vx: (Math.random() - 0.5) * 0.2,
+        vy: (Math.random() - 0.5) * 0.2,
+        r: 0.8 + Math.random() * 1.8,
+      }));
+    };
+    resize();
+    const ro = new ResizeObserver(resize);
+    ro.observe(cvs);
+    return () => ro.disconnect();
+  }, [density]);
+
+  // rendu
+  useRaf(
+    (t) => {
+      const cvs = ref.current;
+      if (!cvs) return;
+      const ctx = cvs.getContext("2d");
+      if (!ctx) return;
+      const w = cvs.clientWidth,
+        h = cvs.clientHeight;
+      ctx.clearRect(0, 0, w, h);
+
+      // facteur respiratoire : zoom / lueur / lien
+      let breathe = 1;
+      if (!reduced) {
+        breathe =
+          phase === "inhale"
+            ? 0.9 + 0.2 * phaseProgress
+            : phase === "exhale"
+            ? 1.1 - 0.2 * phaseProgress
+            : 1.0;
+      }
+
+      // déplacement lent
+      const stars = starsRef.current;
+      if (!reduced) {
+        for (const s of stars) {
+          s.x += s.vx * (0.5 + 0.5 * breathe);
+          s.y += s.vy * (0.5 + 0.5 * breathe);
+          if (s.x < 0) s.x += w;
+          else if (s.x > w) s.x -= w;
+          if (s.y < 0) s.y += h;
+          else if (s.y > h) s.y -= h;
+        }
+      }
+
+      // dessiner
+      ctx.save();
+      ctx.globalAlpha = 0.9;
+      for (const s of stars) {
+        ctx.beginPath();
+        ctx.arc(s.x, s.y, s.r * breathe, 0, Math.PI * 2);
+        ctx.fillStyle = "rgba(255,255,255,0.85)";
+        ctx.fill();
+      }
+
+      // relier les proches (distance modulée par la respiration)
+      const linkDist = 60 * breathe;
+      ctx.lineWidth = 0.6;
+      ctx.strokeStyle = "rgba(255,255,255,0.25)";
+      for (let i = 0; i < stars.length; i++) {
+        for (let j = i + 1; j < stars.length; j++) {
+          const a = stars[i],
+            b = stars[j];
+          const dx = a.x - b.x,
+            dy = a.y - b.y;
+          const d2 = dx * dx + dy * dy;
+          if (d2 < linkDist * linkDist) {
+            ctx.globalAlpha = Math.max(0.05, 0.35 - (Math.sqrt(d2) / linkDist) * 0.35);
+            ctx.beginPath();
+            ctx.moveTo(a.x, a.y);
+            ctx.lineTo(b.x, b.y);
+            ctx.stroke();
+          }
+        }
+      }
+      ctx.restore();
+      tRef.current = t;
+    },
+    true
+  );
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: 300,
+        borderRadius: 12,
+        overflow: "hidden",
+        background: "linear-gradient(180deg, #0c0f1a, #161b2b)",
+      }}
+    >
+      <canvas
+        ref={ref}
+        style={{ width: "100%", height: "100%", display: "block" }}
+        aria-label="Constellation respiratoire"
+      />
+    </div>
+  );
+}
+

--- a/src/ui/hooks/useBreathPattern.ts
+++ b/src/ui/hooks/useBreathPattern.ts
@@ -1,0 +1,70 @@
+"use client";
+import React from "react";
+import { useRaf } from "./useRaf";
+
+export type Phase = "inhale" | "exhale" | "hold" | "hold2";
+export type Pattern = Array<{ phase: Phase; sec: number }>;
+
+export function useBreathPattern(pattern: Pattern, _cycles: number) {
+  const [running, setRunning] = React.useState(false);
+  const [phaseIndex, setPhaseIndex] = React.useState(0);
+  const [cycle, setCycle] = React.useState(0);
+  const [phaseStart, setPhaseStart] = React.useState(0);
+  const tick = React.useRef(0);
+
+  const current = React.useRef({ phase: pattern[0]?.phase || "inhale" });
+
+  useRaf(() => {
+    if (!running) return;
+    tick.current++;
+    const now = performance.now();
+    const elapsed = (now - phaseStart) / 1000;
+    const cur = pattern[phaseIndex];
+    if (elapsed >= cur.sec) {
+      let nextIndex = phaseIndex + 1;
+      if (nextIndex >= pattern.length) {
+        nextIndex = 0;
+        setCycle(c => c + 1);
+      }
+      setPhaseIndex(nextIndex);
+      setPhaseStart(now);
+      current.current = { phase: pattern[nextIndex].phase };
+    } else {
+      current.current = { phase: cur.phase };
+    }
+  }, running);
+
+  const phaseProgress = running
+    ? Math.min(1, (performance.now() - phaseStart) / (pattern[phaseIndex].sec * 1000))
+    : 0;
+
+  const start = React.useCallback(() => {
+    setCycle(0);
+    setPhaseIndex(0);
+    setPhaseStart(performance.now());
+    setRunning(true);
+    current.current = { phase: pattern[0].phase };
+  }, [pattern]);
+
+  const stop = React.useCallback(() => {
+    setRunning(false);
+    setCycle(0);
+    setPhaseIndex(0);
+  }, []);
+
+  const toggle = React.useCallback(() => {
+    if (running) setRunning(false);
+    else start();
+  }, [running, start]);
+
+  return {
+    current: current.current,
+    phaseProgress,
+    running,
+    cycle,
+    start,
+    stop,
+    toggle,
+  };
+}
+

--- a/src/ui/hooks/useRaf.ts
+++ b/src/ui/hooks/useRaf.ts
@@ -1,0 +1,18 @@
+"use client";
+import { useEffect, useRef } from "react";
+
+export function useRaf(cb: (t: number) => void, enabled = true) {
+  const ref = useRef<((t: number) => void) | null>(null);
+  ref.current = cb;
+  useEffect(() => {
+    if (!enabled) return;
+    let raf = 0;
+    const loop = (t: number) => {
+      ref.current?.(t);
+      raf = requestAnimationFrame(loop);
+    };
+    raf = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(raf);
+  }, [enabled]);
+}
+


### PR DESCRIPTION
## Summary
- implement BreathConstellation module with configurable breathing patterns and animated starfield
- expose ConstellationCanvas and useRaf utilities
- define BreathConstellationPrefs schema and document module

## Testing
- `npx vitest src/__tests__/breath-constellation.snapshot.spec.tsx -u`
- `npm run ci:guard` *(fails: TypeError: Cannot read properties of null (reading 'playRecommendedTrack') etc.)*
- `npx playwright test e2e/breath-constellation.smoke.spec.ts` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68c67a10d708832d926193ea1ed2fc8f