### PR TITLE
fix vitest esbuild resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "tsc": "tsc --noEmit",
-    "test": "vitest run --silent",
+    "test": "node scripts/run-tests.mjs",
     "test:ui": "vitest run src/pages/settings/SilkPage.test.tsx",
     "test:edge": "vitest --environment edge-runtime --no-browser-env-check",
     "test:db": "echo 'DB tests exécutés dans le pipeline back-end'",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,0 +1,18 @@
+import { createRequire } from 'module';
+import { spawnSync } from 'child_process';
+
+const require = createRequire(import.meta.url);
+// Point esbuild to the binary that matches the version bundled with vite.
+process.env.ESBUILD_BINARY_PATH = require.resolve('esbuild/bin/esbuild', {
+  paths: [require.resolve('vite')],
+});
+
+// Spawn vitest directly using Node's executable to avoid PATH resolution
+// issues when this script is executed outside of an npm lifecycle hook.
+const vitestBin = require.resolve('vitest/vitest.mjs');
+const result = spawnSync(process.execPath, [vitestBin, 'run', '--silent'], {
+  stdio: 'inherit',
+  env: process.env,
+});
+
+process.exit(result.status ?? 1);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,21 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import path from 'path';
+import { createRequire } from 'module';
+
+// Ensure esbuild binary version matches the JS API used by vite/vitest.
+// When the repository has multiple versions of esbuild installed (one
+// hoisted at the project root and another inside vite's node_modules),
+// vitest may load the JS API for one version while executing the binary of
+// another. This mismatch causes the tests to crash before running. By
+// resolving the binary relative to vite and pointing `ESBUILD_BINARY_PATH`
+// to it, we guarantee that the JS and binary versions stay in sync.
+const require = createRequire(import.meta.url);
+if (!process.env.ESBUILD_BINARY_PATH) {
+  process.env.ESBUILD_BINARY_PATH = require.resolve('esbuild/bin/esbuild', {
+    paths: [require.resolve('vite')],
+  });
+}
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## Summary
- ensure vitest uses matching esbuild binary by setting `ESBUILD_BINARY_PATH`
- add helper script to run vitest with correct binary

## Testing
- `npm test` *(fails: vitest produced no output and appeared to hang)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a04bc3e8832d9cf4ca3fb2698405