### PR TITLE
refactor: enable role-based playwright setup

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -25,7 +25,27 @@ The resulting cookies and tokens are stored in JSON files under
 npx playwright test --global-setup tests/e2e/_setup/global-setup.ts
 ```
 
+The setup script will reset and seed the database before logging in with the
+different roles (B2C, B2B user and admin).
+
 ## data-testid conventions
 
 Selectors used in the tests rely on `data-testid` attributes. When adding new UI
 interactions, please expose stable identifiers using this attribute.
+
+Common selectors are centralized in `tests/e2e/_selectors.ts` to avoid
+duplication.
+
+## Useful commands
+
+```bash
+# End-to-end tests
+npm run e2e
+
+# Unit and integration tests
+npm test
+
+# Reset and seed the database for tests
+npm run test:db:reset
+npm run test:db:seed
+```

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   },
   projects: [
     { name: 'b2c-chromium', use: { ...devices['Desktop Chrome'], storageState: 'tests/e2e/_setup/state-b2c.json' } },
-    { name: 'b2b-user-chromium', use: { ...devices['Desktop Chrome'], storageState: 'tests/e2e/_setup/state-b2b_user.json' } },
-    { name: 'b2b-admin-chromium', use: { ...devices['Desktop Chrome'], storageState: 'tests/e2e/_setup/state-b2b_admin.json' } },
+    { name: 'b2b_user-chromium', use: { ...devices['Desktop Chrome'], storageState: 'tests/e2e/_setup/state-b2b_user.json' } },
+    { name: 'b2b_admin-chromium', use: { ...devices['Desktop Chrome'], storageState: 'tests/e2e/_setup/state-b2b_admin.json' } },
   ],
 });

--- a/tests/e2e/_setup/assert-db.ts
+++ b/tests/e2e/_setup/assert-db.ts
@@ -1,0 +1,22 @@
+import { request } from '@playwright/test';
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000';
+const TEST_DB_SECRET = process.env.TEST_DB_SECRET || '';
+
+/**
+ * Fetch a journal entry from the database using a test-only endpoint.
+ * The endpoint must be protected and available only in test environments.
+ */
+export async function readJournalEntry(id: string) {
+  const ctx = await request.newContext({
+    baseURL: BASE_URL,
+    extraHTTPHeaders: { 'x-test-secret': TEST_DB_SECRET },
+  });
+  const res = await ctx.get(`/api/test/db/read-journal?id=${id}`);
+  if (res.status() !== 200) {
+    throw new Error(`DB read failed for journal ${id}: ${res.status()}`);
+  }
+  const data = await res.json();
+  await ctx.dispose();
+  return data;
+}

--- a/tests/e2e/_setup/login-api.ts
+++ b/tests/e2e/_setup/login-api.ts
@@ -1,23 +1,28 @@
 import { request } from '@playwright/test';
 
-const BASE_URL = process.env.PW_BASE_URL ?? 'http://localhost:3000';
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000';
 
 type Role = 'b2c' | 'b2b_user' | 'b2b_admin';
 
+function credsFor(role: Role) {
+  const email = process.env[`PW_${role.toUpperCase()}_EMAIL`];
+  const password = process.env[`PW_${role.toUpperCase()}_PASSWORD`];
+  if (!email || !password) {
+    throw new Error(`Missing credentials for ${role}`);
+  }
+  return { email, password };
+}
+
 /**
  * Perform a real login via the HTTP API and persist the resulting storage state.
- * The credentials for each role are expected to be provided via environment variables
- * (PW_B2C_EMAIL, PW_B2C_PASSWORD, etc.).
+ * Credentials are provided via env vars (PW_B2C_EMAIL, PW_B2C_PASSWORD, ...).
  */
 export async function loginAndSaveState(role: Role, file: string) {
-  const context = await request.newContext({ baseURL: BASE_URL });
-  await context.post('/api/test-auth/login', {
-    data: {
-      role,
-      email: process.env[`PW_${role.toUpperCase()}_EMAIL`],
-      password: process.env[`PW_${role.toUpperCase()}_PASSWORD`],
-    },
-  });
-  await context.storageState({ path: file });
-  await context.dispose();
+  const ctx = await request.newContext({ baseURL: BASE_URL });
+  const res = await ctx.post('/api/auth/login', { data: credsFor(role) });
+  if (res.status() !== 200) {
+    throw new Error(`Login failed for ${role}: ${res.status()}`);
+  }
+  await ctx.storageState({ path: file });
+  await ctx.dispose();
 }

--- a/tests/e2e/b2c-smoke.spec.ts
+++ b/tests/e2e/b2c-smoke.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { SELECTORS } from './_selectors';
+import { readJournalEntry } from './_setup/assert-db';
 
 test('B2C — dashboard → journal (création) → scan', async ({ page }) => {
   await page.goto('/b2c/dashboard');
@@ -7,8 +8,16 @@ test('B2C — dashboard → journal (création) → scan', async ({ page }) => {
 
   await page.getByRole('link', { name: /Journal/i }).click();
   await page.locator(SELECTORS.journalInput).fill('Je me sens détendu.');
-  await page.locator(SELECTORS.submitJournal).click();
+  const [journalRes] = await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/api/journal') && r.request().method() === 'POST'),
+    page.locator(SELECTORS.submitJournal).click(),
+  ]);
   await expect(page.locator(SELECTORS.toastSuccess)).toBeVisible();
+
+  const created = await journalRes.json();
+  const dbEntry = await readJournalEntry(created.id);
+  expect(dbEntry.id).toBe(created.id);
+  expect(dbEntry.content).toContain('Je me sens détendu');
 
   await page.getByRole('link', { name: /Scan/i }).click();
   await expect(page.locator(SELECTORS.scanRoot)).toBeVisible();


### PR DESCRIPTION
## Summary
- align Playwright projects to use dedicated storage states per role
- perform real login via API in global setup and add helper to read DB entries
- document test workflow and useful commands

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6c5a81a48832da9ce635529c68716