### PR TITLE
feat(router): unify app entrypoint on RouterV2

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { RouterProvider } from 'react-router-dom';
 import { RootProvider } from '@/providers';
-import { simpleRouter as routerV2 } from './routerV2/simple-router';
+import { routerV2 } from '@/routerV2';
 
 function App() {
   return (

--- a/src/routerV2/index.tsx
+++ b/src/routerV2/index.tsx
@@ -13,7 +13,7 @@ declare global {
 import React, { lazy, Suspense } from 'react';
 import { createBrowserRouter, Navigate, Outlet } from 'react-router-dom';
 import { ROUTES_REGISTRY } from './registry';
-import { ROUTE_ALIASES, findRedirectFor } from './aliases';
+import { ROUTE_ALIASES } from './aliases';
 import { RouteGuard } from './guards';
 import LoadingAnimation from '@/components/ui/loading-animation';
 import EnhancedShell from '@/components/layout/EnhancedShell';
@@ -360,6 +360,8 @@ function createRouteElement(routeMeta: typeof ROUTES_REGISTRY[0]) {
 
 // Export des routes helpers et du router
 export { routes } from './routes';
+export { ROUTE_ALIASES } from './aliases';
+export type { RouteAlias } from './aliases';
 export const routerV2 = createBrowserRouter([
   // Routes principales du registry
   ...ROUTES_REGISTRY.map(route => ({


### PR DESCRIPTION
## Summary
- switch App.tsx to consume the unified routerV2 entrypoint instead of the temporary simple router
- re-export RouterV2 route aliases to expose compatibility redirects from the main router module

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68ca87d07280832dba3aae154c6318d5