### PR TITLE
feat: log breath constellation sessions

### DIFF
--- a/src/__tests__/__snapshots__/breath-constellation.snapshot.spec.tsx.snap
+++ b/src/__tests__/__snapshots__/breath-constellation.snapshot.spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`BreathConstellationPage > rend la page et le CTA Démarrer 1`] = `
   >
     <div
       class="relative overflow-hidden rounded-2xl p-6 mb-8 bg-gradient-to-r from-primary/10 via-primary/5 to-background"
-      style="opacity: 0; transform: translateY(-20px);"
+      style="opacity: 0; transform: translateY(-20px) translateZ(0);"
     >
       <div
         class="absolute inset-0 bg-gradient-to-r from-blue-50/50 via-purple-50/30 to-pink-50/20 dark:from-blue-900/10 dark:via-purple-900/5 dark:to-pink-900/5"


### PR DESCRIPTION
## Summary
- track the start of each Breath Constellation run and record duration, cycles and completion metadata when it ends
- auto-log completed sessions and capture partial stops with the updated stop handler
- update the snapshot to reflect the rendering changes

## Testing
- npx vitest run src/__tests__/breath-constellation.snapshot.spec.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ca8880c964832dab11b25d2a3f1d40