### PR TITLE
feat: expose journal feed route

### DIFF
--- a/scripts/routes/ROUTES_MANIFEST.json
+++ b/scripts/routes/ROUTES_MANIFEST.json
@@ -315,6 +315,13 @@
       "layout": "marketing"
     },
     {
+      "name": "modules-journal",
+      "path": "/modules/journal",
+      "component": "JournalPage",
+      "segment": "public",
+      "layout": "app"
+    },
+    {
       "name": "onboarding",
       "path": "/onboarding",
       "component": "OnboardingPage",

--- a/src/routerV2/registry.ts
+++ b/src/routerV2/registry.ts
@@ -633,6 +633,14 @@ export const ROUTES_REGISTRY: RouteMeta[] = [
     layout: 'simple',
     component: 'ChooseModePage',
   },
+  {
+    name: 'modules-journal',
+    path: '/modules/journal',
+    segment: 'public',
+    layout: 'app',
+    component: 'JournalPage',
+    guard: false,
+  },
 
   // ═══════════════════════════════════════════════════════════
   // PARAMÈTRES & COMPTE


### PR DESCRIPTION
## Summary
- register the /modules/journal feed page in the RouterV2 registry so the journal feed is reachable
- add the new feed entry to the generated routes manifest for tooling consistency

## Testing
- npx vitest run src/__tests__/journal.snapshot.spec.tsx --environment jsdom

------
https://chatgpt.com/codex/tasks/task_e_68ca88a62620832dbcf15d9e7f9a1872