### PR TITLE
feat: allow journal db injection and cover journal API

### DIFF
--- a/services/api/server.ts
+++ b/services/api/server.ts
@@ -3,20 +3,62 @@ import { hash } from '../journal/lib/hash';
 import { insertVoice, insertText, listFeed } from '../journal/lib/db';
 import { createServer } from '../lib/server';
 
-export function createApp() {
+type MaybePromise<T> = T | Promise<T>;
+
+type InsertVoiceInput = Parameters<typeof insertVoice>[0];
+type InsertVoiceOutput = Awaited<ReturnType<typeof insertVoice>>;
+type InsertTextInput = Parameters<typeof insertText>[0];
+type InsertTextOutput = Awaited<ReturnType<typeof insertText>>;
+type ListFeedOutput = Awaited<ReturnType<typeof listFeed>>;
+
+type JournalDb = {
+  insertVoice: (data: InsertVoiceInput) => MaybePromise<InsertVoiceOutput>;
+  insertText: (data: InsertTextInput) => MaybePromise<InsertTextOutput>;
+  listFeed: (userHash: string) => MaybePromise<ListFeedOutput>;
+};
+
+type CreateAppOptions = {
+  journalDb?: Partial<JournalDb>;
+};
+
+const defaultJournalDb: JournalDb = {
+  insertVoice,
+  insertText,
+  listFeed,
+};
+
+export function createApp(options: CreateAppOptions = {}) {
+  const journalDb: JournalDb = {
+    insertVoice: options.journalDb?.insertVoice ?? defaultJournalDb.insertVoice,
+    insertText: options.journalDb?.insertText ?? defaultJournalDb.insertText,
+    listFeed: options.journalDb?.listFeed ?? defaultJournalDb.listFeed,
+  };
+
   return createServer({
     registerRoutes(app) {
+      const ensureUser = (req: any, reply: any) => {
+        if (!req.user) {
+          reply.code(401).send({ ok: false, error: { code: 'unauthorized', message: 'Unauthorized' } });
+          return null;
+        }
+        return req.user;
+      };
+
       const handleVoice = async (req: any, reply: any) => {
+        const user = ensureUser(req, reply);
+        if (!user) return;
         const data = VoiceSchema.parse(req.body);
-        const userHash = hash(req.user.sub);
-        const row = insertVoice({ ...data, user_hash: userHash });
+        const userHash = hash(user.sub);
+        const row = await journalDb.insertVoice({ ...data, user_hash: userHash });
         reply.code(201).send({ ok: true, data: { id: row.id, ts: row.ts } });
       };
 
       const handleText = async (req: any, reply: any) => {
+        const user = ensureUser(req, reply);
+        if (!user) return;
         const data = TextSchema.parse(req.body);
-        const userHash = hash(req.user.sub);
-        const row = insertText({ ...data, user_hash: userHash });
+        const userHash = hash(user.sub);
+        const row = await journalDb.insertText({ ...data, user_hash: userHash });
         reply.code(201).send({ ok: true, data: { id: row.id, ts: row.ts } });
       };
 
@@ -33,8 +75,10 @@ export function createApp() {
       });
 
       app.get('/api/v1/me/journal', async (req: any, reply: any) => {
-        const userHash = hash(req.user.sub);
-        const entries = listFeed(userHash);
+        const user = ensureUser(req, reply);
+        if (!user) return;
+        const userHash = hash(user.sub);
+        const entries = await journalDb.listFeed(userHash);
         reply.send({ ok: true, data: { entries, weekly: [] } });
       });
     },

--- a/services/api/tests/auth.test.ts
+++ b/services/api/tests/auth.test.ts
@@ -4,7 +4,6 @@ import { signJwt } from '../../lib/jwt';
 
 let app: any;
 let url: string;
-
 beforeAll(async () => {
   process.env.JWT_SECRETS = 'test-secret';
   process.env.HASH_PEPPER = 'pepper';
@@ -28,8 +27,8 @@ describe('auth', () => {
   });
 
   it('rejects expired token', async () => {
-    const token = await signJwt({ sub: 'u1', role: 'b2c', aud: 'test' }, { expiresIn: '1ms' });
-    await new Promise(r => setTimeout(r, 5));
+    const token = await signJwt({ sub: 'u1', role: 'b2c', aud: 'test' }, { expiresIn: '1s' });
+    await new Promise(r => setTimeout(r, 1100));
     const res = await fetch(url + '/api/v1/me/journal', {
       headers: { Authorization: `Bearer ${token}` },
     });

--- a/services/api/tests/journal.test.ts
+++ b/services/api/tests/journal.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createHash } from 'crypto';
+import * as jwt from '../../lib/jwt';
+
+const voiceBody = {
+  audio_url: 'https://storage.supabase.co/u123/cap.webm',
+  text_raw: 'hello',
+  summary_120: 'hi',
+  valence: 0.3,
+  emo_vec: [0, 0, 0, 0, 0, 0, 0, 0],
+  pitch_avg: 200,
+  crystal_meta: { form: 'gem', palette: ['#fff', '#000'], mesh_url: 'https://x.com/a.glb' },
+};
+
+const textBody = {
+  text_raw: 'text entry',
+  styled_html: '<p>text</p>',
+  preview: 'text',
+  valence: 0.1,
+  emo_vec: [0, 0, 0, 0, 0, 0, 0, 0],
+};
+
+const computeHash = () => createHash('sha256').update('user42' + 'pepper').digest('hex');
+
+describe('journal api', () => {
+  let app: any;
+  let url: string;
+  const voiceResponse = { id: 'voice-123', ts: '2024-01-01T00:00:00.000Z' };
+  const textResponse = { id: 'text-456', ts: '2024-01-02T00:00:00.000Z' };
+
+  const insertVoiceMock = vi.fn(async (data: any) => ({ ...voiceResponse, ...data }));
+  const insertTextMock = vi.fn(async (data: any) => ({ ...textResponse, ...data }));
+  const listFeedMock = vi.fn(async () => [
+    { type: 'voice', id: 'voice-123', ts: '2024-01-01T00:00:00.000Z', summary: 'summary' },
+    { type: 'text', id: 'text-456', ts: '2024-01-02T00:00:00.000Z', preview: 'preview' },
+  ]);
+
+  beforeEach(async () => {
+    process.env.JWT_SECRETS = 'test-secret';
+    process.env.HASH_PEPPER = 'pepper';
+    insertVoiceMock.mockClear();
+    insertTextMock.mockClear();
+    listFeedMock.mockClear();
+    vi.spyOn(jwt, 'verifyJwt').mockImplementation(async token => {
+      if (token === 'valid-token') {
+        return { sub: 'user42', role: 'b2c', aud: 'test' } as jwt.TokenPayload;
+      }
+      throw new Error('invalid token');
+    });
+    const serverModule = await import('../server');
+    app = serverModule.createApp({
+      journalDb: {
+        insertVoice: insertVoiceMock,
+        insertText: insertTextMock,
+        listFeed: listFeedMock,
+      },
+    });
+    app.addHook('preHandler', (req: any, _reply: any, done: any) => {
+      if (req.headers.authorization === 'Bearer valid-token') {
+        (req as any).user = { sub: 'user42', role: 'b2c', aud: 'test' };
+      }
+      done();
+    });
+    await app.listen({ port: 0 });
+    const address = app.server.address();
+    const port = typeof address === 'object' && address ? address.port : 0;
+    url = `http://127.0.0.1:${port}`;
+  });
+
+  afterEach(async () => {
+    await app.close();
+    vi.restoreAllMocks();
+  });
+
+  it('creates voice journal entry with hashed user id', async () => {
+    const res = await fetch(url + '/api/v1/journal/voice', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer valid-token', 'Content-Type': 'application/json' },
+      body: JSON.stringify(voiceBody),
+    });
+
+    expect(res.status).toBe(201);
+    expect(insertVoiceMock).toHaveBeenCalledTimes(1);
+    expect(insertVoiceMock).toHaveBeenCalledWith({ ...voiceBody, user_hash: computeHash() });
+    const data = await res.json();
+    expect(data).toEqual({ ok: true, data: voiceResponse });
+  });
+
+  it('creates text journal entry with hashed user id', async () => {
+    const res = await fetch(url + '/api/v1/journal/text', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer valid-token', 'Content-Type': 'application/json' },
+      body: JSON.stringify(textBody),
+    });
+
+    expect(res.status).toBe(201);
+    expect(insertTextMock).toHaveBeenCalledTimes(1);
+    expect(insertTextMock).toHaveBeenCalledWith({ ...textBody, user_hash: computeHash() });
+    const data = await res.json();
+    expect(data).toEqual({ ok: true, data: textResponse });
+  });
+
+  it('returns journal feed from dependency', async () => {
+    const res = await fetch(url + '/api/v1/me/journal', {
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(listFeedMock).toHaveBeenCalledTimes(1);
+    expect(listFeedMock).toHaveBeenCalledWith(computeHash());
+    const data = await res.json();
+    const entries = await listFeedMock.mock.results[0].value;
+    expect(data).toEqual({ ok: true, data: { entries, weekly: [] } });
+  });
+});

--- a/services/lib/plugins/auth.ts
+++ b/services/lib/plugins/auth.ts
@@ -20,6 +20,7 @@ export const authPlugin: FastifyPluginAsync = async app => {
       (req as any).user = await verifyJwt(token);
     } catch {
       reply.code(401).send({ ok: false, error: { code: 'unauthorized', message: 'Invalid token' } });
+      return;
     }
   });
 };

--- a/vitest.api.config.ts
+++ b/vitest.api.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from 'vitest/config';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+if (!process.env.ESBUILD_BINARY_PATH) {
+  process.env.ESBUILD_BINARY_PATH = require.resolve('esbuild/bin/esbuild', {
+    paths: [require.resolve('vite')],
+  });
+}
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['services/api/tests/**/*.test.ts'],
+    maxThreads: 1,
+    minThreads: 1,
+    sequence: { hooks: 'list', files: 'serial' },
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json'],
+      reportsDirectory: 'reports/api-tests-coverage',
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- allow passing custom journal DB functions into the API server and guard routes against missing auth
- stop the auth plugin from continuing after invalid tokens and add focused journal API tests with helper hooks
- add a Vitest config to run the API test suite in a Node environment

## Testing
- npm run test:api

------
https://chatgpt.com/codex/tasks/task_e_68ca889e7524832d8029af3ef46296fa