### PR TITLE
feat: add mood presets management for mood mixer

### DIFF
--- a/public/routes-manifest.json
+++ b/public/routes-manifest.json
@@ -27,6 +27,7 @@
     
     { "path": "/boss-level-grit", "auth": "authenticated", "module": "resilience", "component": "BossLevelGritPage", "status": "created" },
     { "path": "/mood-mixer", "auth": "authenticated", "module": "resilience", "component": "MoodMixerPage", "status": "created" },
+    { "path": "/mood-presets", "auth": "authenticated", "module": "resilience", "component": "MoodPresetsAdminPage", "status": "created" },
     { "path": "/bounce-back-battle", "auth": "authenticated", "module": "resilience", "component": "BounceBackBattlePage", "status": "created" },
     { "path": "/story-synth-lab", "auth": "authenticated", "module": "resilience", "component": "StorySynthLabPage", "status": "created" },
     { "path": "/breathwork", "auth": "authenticated", "module": "resilience", "component": "BreathworkPage", "status": "created" },
@@ -66,9 +67,9 @@
     { "path": "/health-check-badge", "auth": "b2b_admin", "role": "b2b_admin", "module": "platform", "component": "PlatformStatusPage", "status": "created" }
   ],
   "meta": {
-    "totalRoutes": 52,
+    "totalRoutes": 53,
     "activeRoutes": 25,
-    "createdRoutes": 27,
+    "createdRoutes": 28,
     "lastUpdated": "2025-01-23T12:00:00.000Z",
     "version": "2.0.0",
     "backendIntegration": "completed",

--- a/src/components/mood-mixer/PresetSelector.tsx
+++ b/src/components/mood-mixer/PresetSelector.tsx
@@ -1,19 +1,22 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { LucideIconType } from '@/types/common';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { motion } from 'framer-motion';
-import { 
-  Zap, 
-  Heart, 
-  Music, 
-  Focus, 
-  Coffee, 
-  Moon, 
-  Sun, 
-  Headphones 
+import {
+  Zap,
+  Heart,
+  Music,
+  Focus,
+  Coffee,
+  Moon,
+  Sun,
+  Headphones,
+  Sparkles,
 } from 'lucide-react';
+import { moodPresetsService } from '@/services/moodPresetsService';
+import { MoodPresetRecord } from '@/types/mood-mixer';
 
 interface BlendState {
   joy: number;
@@ -22,7 +25,7 @@ interface BlendState {
   focus: number;
 }
 
-interface MoodPreset {
+interface MoodPresetCard {
   id: string;
   name: string;
   description: string;
@@ -37,91 +40,174 @@ interface PresetSelectorProps {
   currentBlend: BlendState;
 }
 
-const presets: MoodPreset[] = [
+const ICON_MAP: Record<string, LucideIconType> = {
+  sun: Sun,
+  focus: Focus,
+  music: Music,
+  heart: Heart,
+  zap: Zap,
+  moon: Moon,
+  headphones: Headphones,
+  coffee: Coffee,
+  sparkles: Sparkles,
+};
+
+interface PresetSeed {
+  slug: string;
+  name: string;
+  description: string;
+  icon: keyof typeof ICON_MAP;
+  gradient: string;
+  blend: BlendState;
+  tags: string[];
+}
+
+const resolveIcon = (iconName?: string | null): LucideIconType => {
+  if (!iconName) return Sparkles;
+  const key = iconName.toLowerCase();
+  return ICON_MAP[key] ?? Sparkles;
+};
+
+const mapRecordToCard = (record: MoodPresetRecord): MoodPresetCard => ({
+  id: record.id || record.slug,
+  name: record.name,
+  description: record.description ?? 'Ambiance personnalisée générée',
+  icon: resolveIcon(record.icon),
+  gradient: record.gradient ?? 'from-purple-500 to-pink-500',
+  blend: record.blend,
+  tags: record.tags.length ? record.tags : ['Mood Mixer'],
+});
+
+const DEFAULT_PRESETS: PresetSeed[] = [
   {
-    id: 'morning-boost',
+    slug: 'morning-boost',
     name: 'Réveil Énergique',
     description: 'Commencez la journée avec dynamisme',
-    icon: Sun,
+    icon: 'sun',
     gradient: 'from-orange-400 to-yellow-500',
     blend: { joy: 0.8, calm: 0.3, energy: 0.9, focus: 0.6 },
-    tags: ['Matin', 'Énergie', 'Motivation']
+    tags: ['Matin', 'Énergie', 'Motivation'],
   },
   {
-    id: 'deep-focus',
+    slug: 'deep-focus',
     name: 'Focus Intense',
     description: 'Concentration maximale pour le travail',
-    icon: Focus,
+    icon: 'focus',
     gradient: 'from-green-500 to-emerald-600',
     blend: { joy: 0.4, calm: 0.7, energy: 0.5, focus: 0.95 },
-    tags: ['Travail', 'Concentration', 'Productivité']
+    tags: ['Travail', 'Concentration', 'Productivité'],
   },
   {
-    id: 'creative-flow',
+    slug: 'creative-flow',
     name: 'Flow Créatif',
     description: 'Libérez votre créativité',
-    icon: Music,
+    icon: 'music',
     gradient: 'from-purple-500 to-pink-500',
     blend: { joy: 0.7, calm: 0.6, energy: 0.7, focus: 0.8 },
-    tags: ['Créativité', 'Inspiration', 'Art']
+    tags: ['Créativité', 'Inspiration', 'Art'],
   },
   {
-    id: 'zen-meditation',
+    slug: 'zen-meditation',
     name: 'Méditation Zen',
     description: 'Paix intérieure et relaxation profonde',
-    icon: Heart,
+    icon: 'heart',
     gradient: 'from-blue-400 to-cyan-500',
     blend: { joy: 0.6, calm: 0.95, energy: 0.2, focus: 0.4 },
-    tags: ['Méditation', 'Calme', 'Relaxation']
+    tags: ['Méditation', 'Calme', 'Relaxation'],
   },
   {
-    id: 'workout-power',
+    slug: 'workout-power',
     name: 'Puissance Sport',
-    description: 'Énergie explosive pour l\'entraînement',
-    icon: Zap,
+    description: "Énergie explosive pour l'entraînement",
+    icon: 'zap',
     gradient: 'from-red-500 to-orange-600',
     blend: { joy: 0.6, calm: 0.2, energy: 1.0, focus: 0.7 },
-    tags: ['Sport', 'Énergie', 'Motivation']
+    tags: ['Sport', 'Énergie', 'Motivation'],
   },
   {
-    id: 'evening-wind',
+    slug: 'evening-wind',
     name: 'Détente Soir',
     description: 'Transition douce vers la relaxation',
-    icon: Moon,
+    icon: 'moon',
     gradient: 'from-indigo-500 to-purple-600',
     blend: { joy: 0.5, calm: 0.8, energy: 0.3, focus: 0.3 },
-    tags: ['Soir', 'Détente', 'Relaxation']
+    tags: ['Soir', 'Détente', 'Relaxation'],
   },
   {
-    id: 'study-session',
+    slug: 'study-session',
     name: 'Session Étude',
     description: 'Concentration soutenue pour apprendre',
-    icon: Headphones,
+    icon: 'headphones',
     gradient: 'from-teal-500 to-blue-600',
     blend: { joy: 0.4, calm: 0.6, energy: 0.4, focus: 0.9 },
-    tags: ['Étude', 'Apprentissage', 'Focus']
+    tags: ['Étude', 'Apprentissage', 'Focus'],
   },
   {
-    id: 'coffee-break',
+    slug: 'coffee-break',
     name: 'Pause Café',
     description: 'Moment de détente et ressourcement',
-    icon: Coffee,
+    icon: 'coffee',
     gradient: 'from-amber-500 to-orange-500',
     blend: { joy: 0.7, calm: 0.5, energy: 0.6, focus: 0.5 },
-    tags: ['Pause', 'Social', 'Ressourcement']
-  }
+    tags: ['Pause', 'Social', 'Ressourcement'],
+  },
 ];
 
-const PresetSelector: React.FC<PresetSelectorProps> = ({ 
-  onPresetSelect, 
-  currentBlend 
+const DEFAULT_PRESET_CARDS: MoodPresetCard[] = DEFAULT_PRESETS.map((preset) => ({
+  id: preset.slug,
+  name: preset.name,
+  description: preset.description,
+  icon: ICON_MAP[preset.icon] ?? Sparkles,
+  gradient: preset.gradient,
+  blend: preset.blend,
+  tags: preset.tags,
+}));
+
+const PresetSelector: React.FC<PresetSelectorProps> = ({
+  onPresetSelect,
+  currentBlend,
 }) => {
-  
+  const [presets, setPresets] = useState<MoodPresetCard[]>(DEFAULT_PRESET_CARDS);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchPresets = async () => {
+      try {
+        const data = await moodPresetsService.listPresets();
+        if (!isMounted) return;
+        if (data.length > 0) {
+          setPresets(data.map(mapRecordToCard));
+        } else {
+          setPresets(DEFAULT_PRESET_CARDS);
+        }
+      } catch (error) {
+        console.error('Unable to load mood presets', error);
+        if (isMounted) {
+          setPresets(DEFAULT_PRESET_CARDS);
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    fetchPresets();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
   const isCurrentPreset = (presetBlend: BlendState) => {
-    return Math.abs(presetBlend.joy - currentBlend.joy) < 0.1 &&
-           Math.abs(presetBlend.calm - currentBlend.calm) < 0.1 &&
-           Math.abs(presetBlend.energy - currentBlend.energy) < 0.1 &&
-           Math.abs(presetBlend.focus - currentBlend.focus) < 0.1;
+    return (
+      Math.abs(presetBlend.joy - currentBlend.joy) < 0.1 &&
+      Math.abs(presetBlend.calm - currentBlend.calm) < 0.1 &&
+      Math.abs(presetBlend.energy - currentBlend.energy) < 0.1 &&
+      Math.abs(presetBlend.focus - currentBlend.focus) < 0.1
+    );
   };
 
   return (
@@ -137,7 +223,7 @@ const PresetSelector: React.FC<PresetSelectorProps> = ({
         {presets.map((preset, index) => {
           const IconComponent = preset.icon;
           const isCurrent = isCurrentPreset(preset.blend);
-          
+
           return (
             <motion.div
               key={preset.id}
@@ -147,7 +233,7 @@ const PresetSelector: React.FC<PresetSelectorProps> = ({
               whileHover={{ scale: 1.02 }}
               whileTap={{ scale: 0.98 }}
             >
-              <Card 
+              <Card
                 className={`cursor-pointer transition-all duration-200 hover:shadow-lg ${
                   isCurrent ? 'ring-2 ring-primary border-primary' : ''
                 }`}
@@ -155,18 +241,20 @@ const PresetSelector: React.FC<PresetSelectorProps> = ({
               >
                 <CardHeader className="pb-3">
                   <div className="text-center space-y-2">
-                    <div className={`w-12 h-12 mx-auto rounded-full bg-gradient-to-r ${preset.gradient} flex items-center justify-center`}>
+                    <div
+                      className={`w-12 h-12 mx-auto rounded-full bg-gradient-to-r ${preset.gradient} flex items-center justify-center`}
+                    >
                       <IconComponent className="h-6 w-6 text-white" />
                     </div>
                     <CardTitle className="text-lg">{preset.name}</CardTitle>
                   </div>
                 </CardHeader>
-                
+
                 <CardContent className="space-y-4">
                   <p className="text-sm text-muted-foreground text-center">
                     {preset.description}
                   </p>
-                  
+
                   {/* Blend Preview */}
                   <div className="space-y-2">
                     <div className="grid grid-cols-2 gap-1 text-xs">
@@ -188,7 +276,7 @@ const PresetSelector: React.FC<PresetSelectorProps> = ({
                       </div>
                     </div>
                   </div>
-                  
+
                   {/* Tags */}
                   <div className="flex flex-wrap gap-1 justify-center">
                     {preset.tags.slice(0, 2).map((tag, idx) => (
@@ -197,13 +285,14 @@ const PresetSelector: React.FC<PresetSelectorProps> = ({
                       </Badge>
                     ))}
                   </div>
-                  
-                  <Button 
-                    size="sm" 
+
+                  <Button
+                    size="sm"
                     className="w-full"
-                    variant={isCurrent ? "default" : "outline"}
+                    variant={isCurrent ? 'default' : 'outline'}
+                    disabled={isLoading}
                   >
-                    {isCurrent ? 'Sélectionné' : 'Appliquer'}
+                    {isLoading ? 'Chargement…' : isCurrent ? 'Sélectionné' : 'Appliquer'}
                   </Button>
                 </CardContent>
               </Card>

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -5613,6 +5613,54 @@ export type Database = {
           },
         ]
       }
+      mood_presets: {
+        Row: {
+          calm: number
+          created_at: string
+          description: string | null
+          energy: number
+          focus: number
+          gradient: string | null
+          icon: string | null
+          id: string
+          joy: number
+          name: string
+          slug: string
+          tags: string[]
+          updated_at: string
+        }
+        Insert: {
+          calm?: number
+          created_at?: string
+          description?: string | null
+          energy?: number
+          focus?: number
+          gradient?: string | null
+          icon?: string | null
+          id?: string
+          joy?: number
+          name: string
+          slug: string
+          tags?: string[]
+          updated_at?: string
+        }
+        Update: {
+          calm?: number
+          created_at?: string
+          description?: string | null
+          energy?: number
+          focus?: number
+          gradient?: string | null
+          icon?: string | null
+          id?: string
+          joy?: number
+          name?: string
+          slug?: string
+          tags?: string[]
+          updated_at?: string
+        }
+        Relationships: []
+      }
       music_skip_logs: {
         Row: {
           id: string

--- a/src/pages/MoodPresetsAdminPage.tsx
+++ b/src/pages/MoodPresetsAdminPage.tsx
@@ -1,0 +1,383 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { moodPresetsService, MoodPresetPayload } from '@/services/moodPresetsService';
+import { MoodPresetRecord } from '@/types/mood-mixer';
+import { toast } from 'sonner';
+import { Loader2, Plus, RefreshCw, Save, Trash2 } from 'lucide-react';
+
+interface MoodPresetFormState {
+  slug: string;
+  name: string;
+  description: string;
+  icon: string;
+  gradient: string;
+  tags: string;
+  joy: number;
+  calm: number;
+  energy: number;
+  focus: number;
+}
+
+const INITIAL_FORM_STATE: MoodPresetFormState = {
+  slug: '',
+  name: '',
+  description: '',
+  icon: '',
+  gradient: '',
+  tags: '',
+  joy: 50,
+  calm: 50,
+  energy: 50,
+  focus: 50,
+};
+
+const toPercent = (value: number) => Math.round(Math.min(Math.max(value, 0), 1) * 100);
+const toRatio = (value: number) => Math.min(Math.max(value / 100, 0), 1);
+
+const MoodPresetsAdminPage: React.FC = () => {
+  const [presets, setPresets] = useState<MoodPresetRecord[]>([]);
+  const [formState, setFormState] = useState<MoodPresetFormState>(INITIAL_FORM_STATE);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const existingSlugs = useMemo(() => new Set(presets.map((preset) => preset.slug)), [presets]);
+
+  const loadPresets = async () => {
+    setIsLoading(true);
+    try {
+      const data = await moodPresetsService.listPresets();
+      setPresets(data);
+    } catch (error) {
+      console.error('Failed to load mood presets', error);
+      toast.error('Impossible de charger les presets Mood Mixer.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadPresets();
+  }, []);
+
+  const resetForm = () => {
+    setFormState(INITIAL_FORM_STATE);
+    setEditingId(null);
+  };
+
+  const handleEdit = (preset: MoodPresetRecord) => {
+    setEditingId(preset.id);
+    setFormState({
+      slug: preset.slug,
+      name: preset.name,
+      description: preset.description ?? '',
+      icon: preset.icon ?? '',
+      gradient: preset.gradient ?? '',
+      tags: preset.tags.join(', '),
+      joy: toPercent(preset.blend.joy),
+      calm: toPercent(preset.blend.calm),
+      energy: toPercent(preset.blend.energy),
+      focus: toPercent(preset.blend.focus),
+    });
+  };
+
+  const parseTags = (value: string): string[] =>
+    value
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter((tag) => tag.length > 0);
+
+  const buildPayload = (): MoodPresetPayload | null => {
+    if (!formState.slug.trim()) {
+      toast.error('Le slug est obligatoire.');
+      return null;
+    }
+    if (!formState.name.trim()) {
+      toast.error('Le nom est obligatoire.');
+      return null;
+    }
+
+    const slug = formState.slug.trim();
+    if (!editingId && existingSlugs.has(slug)) {
+      toast.error('Ce slug existe déjà.');
+      return null;
+    }
+
+    return {
+      slug,
+      name: formState.name.trim(),
+      description: formState.description.trim() || null,
+      icon: formState.icon.trim() || null,
+      gradient: formState.gradient.trim() || null,
+      tags: parseTags(formState.tags),
+      blend: {
+        joy: toRatio(formState.joy),
+        calm: toRatio(formState.calm),
+        energy: toRatio(formState.energy),
+        focus: toRatio(formState.focus),
+      },
+    };
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const payload = buildPayload();
+    if (!payload) return;
+
+    setIsSubmitting(true);
+    try {
+      if (editingId) {
+        await moodPresetsService.updatePreset(editingId, payload);
+        toast.success('Preset mis à jour avec succès.');
+      } else {
+        await moodPresetsService.createPreset(payload);
+        toast.success('Preset créé avec succès.');
+      }
+      await loadPresets();
+      resetForm();
+    } catch (error) {
+      console.error('Failed to save mood preset', error);
+      toast.error('Erreur lors de la sauvegarde du preset.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDelete = async (preset: MoodPresetRecord) => {
+    if (!window.confirm(`Supprimer le preset "${preset.name}" ?`)) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await moodPresetsService.deletePreset(preset.id);
+      toast.success('Preset supprimé.');
+      await loadPresets();
+      if (editingId === preset.id) {
+        resetForm();
+      }
+    } catch (error) {
+      console.error('Failed to delete mood preset', error);
+      toast.error('Erreur lors de la suppression du preset.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="max-w-6xl mx-auto py-10 px-4 space-y-8">
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <div>
+          <h1 className="text-3xl font-bold">Gestion des Mood Presets</h1>
+          <p className="text-muted-foreground">
+            Créez, modifiez et supprimez les ambiances proposées dans le Mood Mixer.
+          </p>
+        </div>
+        <Button variant="outline" onClick={loadPresets} disabled={isLoading || isSubmitting}>
+          <RefreshCw className={`mr-2 h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
+          Actualiser
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{editingId ? 'Modifier un preset' : 'Créer un nouveau preset'}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form className="grid gap-6 md:grid-cols-2" onSubmit={handleSubmit}>
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="slug">Slug</Label>
+                <Input
+                  id="slug"
+                  value={formState.slug}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, slug: event.target.value }))}
+                  placeholder="morning-boost"
+                  disabled={Boolean(editingId)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="name">Nom</Label>
+                <Input
+                  id="name"
+                  value={formState.name}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, name: event.target.value }))}
+                  placeholder="Réveil Énergique"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="description">Description</Label>
+                <Textarea
+                  id="description"
+                  value={formState.description}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, description: event.target.value }))}
+                  placeholder="Commencez la journée avec dynamisme"
+                  rows={4}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="tags">Tags (séparés par des virgules)</Label>
+                <Input
+                  id="tags"
+                  value={formState.tags}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, tags: event.target.value }))}
+                  placeholder="Matin, Énergie, Motivation"
+                />
+              </div>
+            </div>
+
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="icon">Icône (Lucide)</Label>
+                <Input
+                  id="icon"
+                  value={formState.icon}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, icon: event.target.value }))}
+                  placeholder="sun"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="gradient">Gradient Tailwind</Label>
+                <Input
+                  id="gradient"
+                  value={formState.gradient}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, gradient: event.target.value }))}
+                  placeholder="from-orange-400 to-yellow-500"
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                {(['joy', 'calm', 'energy', 'focus'] as Array<keyof Pick<MoodPresetFormState, 'joy' | 'calm' | 'energy' | 'focus'>>).map((field) => (
+                  <div key={field} className="space-y-2">
+                    <Label htmlFor={field} className="capitalize">
+                      {field === 'joy' ? 'Joie' : field === 'calm' ? 'Calme' : field === 'energy' ? 'Énergie' : 'Focus'}
+                    </Label>
+                    <Input
+                      id={field}
+                      type="number"
+                      min={0}
+                      max={100}
+                      value={formState[field]}
+                      onChange={(event) =>
+                        setFormState((prev) => ({ ...prev, [field]: Number(event.target.value) }))
+                      }
+                    />
+                  </div>
+                ))}
+              </div>
+              <div className="flex items-center gap-2">
+                <Button type="submit" disabled={isSubmitting}>
+                  {isSubmitting ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Sauvegarde…
+                    </>
+                  ) : (
+                    <>
+                      <Save className="mr-2 h-4 w-4" />
+                      {editingId ? 'Mettre à jour' : 'Créer'}
+                    </>
+                  )}
+                </Button>
+                <Button type="button" variant="outline" onClick={resetForm} disabled={isSubmitting}>
+                  <Plus className="mr-2 h-4 w-4" />
+                  Nouveau
+                </Button>
+              </div>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Presets existants</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Chargement des presets…
+            </div>
+          ) : presets.length === 0 ? (
+            <div className="text-muted-foreground text-sm">Aucun preset enregistré pour le moment.</div>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2">
+              {presets.map((preset) => (
+                <Card key={preset.id} className="border-border">
+                  <CardHeader>
+                    <div className="flex items-start justify-between gap-2">
+                      <div>
+                        <CardTitle className="text-lg">{preset.name}</CardTitle>
+                        <p className="text-xs text-muted-foreground">Slug : {preset.slug}</p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => handleEdit(preset)}
+                          disabled={isSubmitting}
+                        >
+                          Modifier
+                        </Button>
+                        <Button
+                          variant="destructive"
+                          size="sm"
+                          onClick={() => handleDelete(preset)}
+                          disabled={isSubmitting}
+                        >
+                          <Trash2 className="mr-2 h-4 w-4" />
+                          Supprimer
+                        </Button>
+                      </div>
+                    </div>
+                  </CardHeader>
+                  <CardContent className="space-y-3 text-sm">
+                    <p>{preset.description ?? 'Aucune description fournie.'}</p>
+                    <div className="flex flex-wrap gap-2">
+                      {preset.tags.map((tag) => (
+                        <Badge key={`${preset.id}-${tag}`} variant="outline">
+                          {tag}
+                        </Badge>
+                      ))}
+                      {preset.tags.length === 0 && (
+                        <span className="text-xs text-muted-foreground">Aucun tag</span>
+                      )}
+                    </div>
+                    <div className="grid grid-cols-2 gap-2 text-xs">
+                      <div className="flex justify-between">
+                        <span>Joie</span>
+                        <span>{toPercent(preset.blend.joy)}%</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span>Calme</span>
+                        <span>{toPercent(preset.blend.calm)}%</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span>Énergie</span>
+                        <span>{toPercent(preset.blend.energy)}%</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span>Focus</span>
+                        <span>{toPercent(preset.blend.focus)}%</span>
+                      </div>
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      Mis à jour le {new Date(preset.updatedAt).toLocaleString('fr-FR')}
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default MoodPresetsAdminPage;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -103,6 +103,7 @@ export { default as ExportPage } from './ExportPage';
 export { default as NavigationPage } from './NavigationPage';
 export { default as LeaderboardPage } from './LeaderboardPage';
 export { default as HeatmapPage } from './HeatmapPage';
+export { default as MoodPresetsAdminPage } from './MoodPresetsAdminPage';
 export { default as GamificationPage } from './GamificationPage';
 export { default as ChooseModePage } from './ChooseModePage';
 export { default as AdminFlagsPage } from "@/modules/admin/AdminFlagsPage";

--- a/src/routerV2/index.tsx
+++ b/src/routerV2/index.tsx
@@ -85,6 +85,7 @@ const B2CAmbitionArcadePage = lazy(() => import('@/pages/B2CAmbitionArcadePage')
 const B2CBossLevelGritPage = lazy(() => import('@/pages/B2CBossLevelGritPage'));
 const B2CBounceBackBattlePage = lazy(() => import('@/pages/B2CBounceBackBattlePage'));
 const B2CMoodMixerPage = lazy(() => import('@/pages/B2CMoodMixerPage'));
+const MoodPresetsAdminPage = lazy(() => import('@/pages/MoodPresetsAdminPage'));
 const B2CSocialCoconPage = lazy(() => import('@/pages/B2CSocialCoconPage'));
 const B2CStorySynthLabPage = lazy(() => import('@/pages/B2CStorySynthLabPage'));
 const B2CCommunautePage = lazy(() => import('@/pages/B2CCommunautePage'));
@@ -224,6 +225,7 @@ const componentMap: Record<string, React.LazyExoticComponent<React.ComponentType
   B2CBossLevelGritPage,
   B2CBounceBackBattlePage,
   B2CMoodMixerPage,
+  MoodPresetsAdminPage,
   B2CSocialCoconPage,
   B2CStorySynthLabPage,
   B2CCommunautePage,

--- a/src/routerV2/registry.ts
+++ b/src/routerV2/registry.ts
@@ -377,6 +377,15 @@ export const ROUTES_REGISTRY: RouteMeta[] = [
     aliases: ['/mood-mixer'],
   },
   {
+    name: 'mood-presets-admin',
+    path: '/app/mood-presets',
+    segment: 'consumer',
+    role: 'consumer',
+    layout: 'app',
+    component: 'MoodPresetsAdminPage',
+    guard: true,
+  },
+  {
     name: 'ambition-arcade',
     path: '/app/ambition-arcade',
     segment: 'consumer',

--- a/src/routerV2/simple-router.tsx
+++ b/src/routerV2/simple-router.tsx
@@ -29,6 +29,7 @@ const B2CScreenSilkBreakPage = lazy(() => import('@/pages/B2CScreenSilkBreakPage
 const B2CARFiltersPage = lazy(() => import('@/pages/B2CARFiltersPage'));
 const B2CStorySynthLabPage = lazy(() => import('@/pages/B2CStorySynthLabPage'));
 const B2CBubbleBeatPage = lazy(() => import('@/pages/B2CBubbleBeatPage'));
+const MoodPresetsAdminPage = lazy(() => import('@/pages/MoodPresetsAdminPage'));
 const LeaderboardPage = lazy(() => import('@/pages/LeaderboardPage'));
 const B2CActivitePage = lazy(() => import('@/pages/B2CActivitePage'));
 const PrivacyPage = lazy(() => import('@/pages/LegalPrivacyPage'));
@@ -151,6 +152,14 @@ export const simpleRouter = createBrowserRouter([
     element: (
       <SecureWrapper>
         <B2CMoodMixerPage />
+      </SecureWrapper>
+    ),
+  },
+  {
+    path: '/app/mood-presets',
+    element: (
+      <SecureWrapper>
+        <MoodPresetsAdminPage />
       </SecureWrapper>
     ),
   },

--- a/src/services/moodPresetsService.ts
+++ b/src/services/moodPresetsService.ts
@@ -1,0 +1,148 @@
+import { supabase } from '@/integrations/supabase/client';
+import { Database } from '@/integrations/supabase/types';
+import { MoodPresetBlend, MoodPresetRecord } from '@/types/mood-mixer';
+
+export type MoodPresetRow = Database['public']['Tables']['mood_presets']['Row'];
+export type MoodPresetInsert = Database['public']['Tables']['mood_presets']['Insert'];
+export type MoodPresetUpdate = Database['public']['Tables']['mood_presets']['Update'];
+
+export interface MoodPresetPayload {
+  slug: string;
+  name: string;
+  description?: string | null;
+  icon?: string | null;
+  gradient?: string | null;
+  tags?: string[];
+  blend: MoodPresetBlend;
+}
+
+const toRecord = (row: MoodPresetRow): MoodPresetRecord => ({
+  id: row.id,
+  slug: row.slug,
+  name: row.name,
+  description: row.description,
+  icon: row.icon,
+  gradient: row.gradient,
+  tags: row.tags ?? [],
+  blend: {
+    joy: Number(row.joy),
+    calm: Number(row.calm),
+    energy: Number(row.energy),
+    focus: Number(row.focus),
+  },
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+});
+
+const toInsert = (payload: MoodPresetPayload): MoodPresetInsert => ({
+  slug: payload.slug,
+  name: payload.name,
+  description: payload.description ?? null,
+  icon: payload.icon ?? null,
+  gradient: payload.gradient ?? null,
+  tags: payload.tags ?? [],
+  joy: payload.blend.joy,
+  calm: payload.blend.calm,
+  energy: payload.blend.energy,
+  focus: payload.blend.focus,
+});
+
+const toUpdate = (payload: Partial<MoodPresetPayload>): MoodPresetUpdate => {
+  const update: MoodPresetUpdate = {
+    updated_at: new Date().toISOString(),
+  };
+
+  if (typeof payload.slug !== 'undefined') update.slug = payload.slug;
+  if (typeof payload.name !== 'undefined') update.name = payload.name;
+  if (typeof payload.description !== 'undefined') update.description = payload.description;
+  if (typeof payload.icon !== 'undefined') update.icon = payload.icon;
+  if (typeof payload.gradient !== 'undefined') update.gradient = payload.gradient;
+  if (typeof payload.tags !== 'undefined') update.tags = payload.tags;
+
+  if (payload.blend) {
+    if (typeof payload.blend.joy !== 'undefined') update.joy = payload.blend.joy;
+    if (typeof payload.blend.calm !== 'undefined') update.calm = payload.blend.calm;
+    if (typeof payload.blend.energy !== 'undefined') update.energy = payload.blend.energy;
+    if (typeof payload.blend.focus !== 'undefined') update.focus = payload.blend.focus;
+  }
+
+  return update;
+};
+
+export const moodPresetsService = {
+  async listPresets(): Promise<MoodPresetRecord[]> {
+    const { data, error } = await supabase
+      .from('mood_presets')
+      .select('*')
+      .order('name');
+
+    if (error) {
+      console.error('Error fetching mood presets:', error);
+      return [];
+    }
+
+    return (data ?? []).map(toRecord);
+  },
+
+  async getPresetById(id: string): Promise<MoodPresetRecord | null> {
+    const { data, error } = await supabase
+      .from('mood_presets')
+      .select('*')
+      .eq('id', id)
+      .single();
+
+    if (error) {
+      console.error('Error fetching mood preset:', error);
+      return null;
+    }
+
+    return data ? toRecord(data) : null;
+  },
+
+  async createPreset(payload: MoodPresetPayload): Promise<MoodPresetRecord | null> {
+    const { data, error } = await supabase
+      .from('mood_presets')
+      .insert(toInsert(payload))
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Error creating mood preset:', error);
+      throw error;
+    }
+
+    return data ? toRecord(data) : null;
+  },
+
+  async updatePreset(id: string, payload: Partial<MoodPresetPayload>): Promise<MoodPresetRecord | null> {
+    const { data, error } = await supabase
+      .from('mood_presets')
+      .update(toUpdate(payload))
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Error updating mood preset:', error);
+      throw error;
+    }
+
+    return data ? toRecord(data) : null;
+  },
+
+  async deletePreset(id: string): Promise<boolean> {
+    const { error } = await supabase
+      .from('mood_presets')
+      .delete()
+      .eq('id', id);
+
+    if (error) {
+      console.error('Error deleting mood preset:', error);
+      throw error;
+    }
+
+    return true;
+  }
+};
+
+export type MoodPresetsService = typeof moodPresetsService;

--- a/src/types/mood-mixer.ts
+++ b/src/types/mood-mixer.ts
@@ -15,6 +15,26 @@ export interface MoodProfile {
   lastUsed?: Date;
 }
 
+export interface MoodPresetBlend {
+  joy: number;
+  calm: number;
+  energy: number;
+  focus: number;
+}
+
+export interface MoodPresetRecord {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  icon: string | null;
+  gradient: string | null;
+  tags: string[];
+  blend: MoodPresetBlend;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface MoodMix {
   id: string;
   name: string;

--- a/supabase/migrations/20250701120000-3a7f4be8-9c1d-4f24-9e2a-1d2c4eb0b6e1.sql
+++ b/supabase/migrations/20250701120000-3a7f4be8-9c1d-4f24-9e2a-1d2c4eb0b6e1.sql
@@ -1,0 +1,47 @@
+-- Migration: Create mood_presets table for Mood Mixer presets management
+-- Provides CRUD-ready structure with RLS policies
+
+create table if not exists public.mood_presets (
+  id uuid primary key default gen_random_uuid(),
+  slug text not null unique,
+  name text not null,
+  description text,
+  icon text,
+  gradient text,
+  joy numeric(4,3) not null default 0.500,
+  calm numeric(4,3) not null default 0.500,
+  energy numeric(4,3) not null default 0.500,
+  focus numeric(4,3) not null default 0.500,
+  tags text[] not null default array[]::text[],
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.mood_presets
+  add constraint mood_presets_blend_range
+  check (
+    joy >= 0 and joy <= 1
+    and calm >= 0 and calm <= 1
+    and energy >= 0 and energy <= 1
+    and focus >= 0 and focus <= 1
+  );
+
+alter table public.mood_presets enable row level security;
+
+-- Policies: allow read for any authenticated user, full CRUD for authenticated roles
+create policy "Authenticated users can read mood presets"
+  on public.mood_presets
+  for select
+  using (auth.role() = 'authenticated');
+
+create policy "Authenticated users can manage mood presets"
+  on public.mood_presets
+  for all
+  using (auth.role() = 'authenticated')
+  with check (auth.role() = 'authenticated');
+
+-- Trigger to keep updated_at in sync
+create trigger set_mood_presets_updated_at
+  before update on public.mood_presets
+  for each row
+  execute function public.update_updated_at_column();


### PR DESCRIPTION
## Summary
- add Supabase migration for the new `mood_presets` table with RLS policies
- expose a typed mood presets service and admin page to manage presets
- load presets dynamically in the Mood Mixer selector and register the new route

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca883102cc832d87af7cb66f7b86f9