### PR TITLE
feat: persist adaptive audio favorites

### DIFF
--- a/src/__tests__/__snapshots__/audio.player.snapshot.spec.tsx.snap
+++ b/src/__tests__/__snapshots__/audio.player.snapshot.spec.tsx.snap
@@ -7,17 +7,29 @@ exports[`AudioPlayer > renders and exposes volume slider 1`] = `
     style="display: grid; gap: 8px;"
   >
     <div
-      style="display: flex; gap: 8px; align-items: center;"
+      style="display: grid; gap: 6px;"
     >
-      <button
-        aria-pressed="false"
-        data-ui="primary-cta"
-      >
-        Lecture
-      </button>
       <strong>
         Test
       </strong>
+      <div
+        style="display: flex; flex-wrap: wrap; gap: 8px; align-items: center;"
+      >
+        <button
+          aria-pressed="false"
+          data-ui="primary-cta"
+          type="button"
+        >
+          Lecture
+        </button>
+        <button
+          aria-pressed="true"
+          data-ui="favorite-toggle"
+          type="button"
+        >
+          Retirer des favoris
+        </button>
+      </div>
     </div>
     <label
       style="display: flex; gap: 8px; align-items: center;"
@@ -32,6 +44,11 @@ exports[`AudioPlayer > renders and exposes volume slider 1`] = `
         value="0.8"
       />
     </label>
+    <small
+      style="opacity: 0.75;"
+    >
+      Sauvegardé dans vos favoris locaux.
+    </small>
   </div>
 </div>
 `;

--- a/src/__tests__/audio.player.snapshot.spec.tsx
+++ b/src/__tests__/audio.player.snapshot.spec.tsx
@@ -1,11 +1,37 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, it, expect } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { AudioPlayer } from "@/ui/AudioPlayer";
 
 describe("AudioPlayer", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
   it("renders and exposes volume slider", () => {
-    const { container } = render(<AudioPlayer src="/audio/lofi-120.mp3" title="Test" />);
+    const { container } = render(
+      <AudioPlayer src="/audio/lofi-120.mp3" trackId="test-track" title="Test" />
+    );
     expect(screen.getByLabelText("Volume")).toBeInTheDocument();
+    const favorite = screen.getByRole("button", { name: /Ajouter aux favoris/i });
+    fireEvent.click(favorite);
+    expect(favorite).toHaveAttribute("aria-pressed", "true");
     expect(container).toMatchSnapshot();
+  });
+
+  it("restores resume button from persisted playback state", async () => {
+    window.localStorage.setItem(
+      "adaptive-music:playback:test-track",
+      JSON.stringify({ position: 42, volume: 0.4, wasPlaying: false, updatedAt: Date.now() })
+    );
+
+    render(
+      <AudioPlayer src="/audio/lofi-120.mp3" trackId="test-track" title="Test" />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Reprendre/ })).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Dernière écoute sauvegardée/)).toHaveTextContent("0:42");
   });
 });

--- a/src/modules/adaptive-music/AdaptiveMusicPage.tsx
+++ b/src/modules/adaptive-music/AdaptiveMusicPage.tsx
@@ -26,6 +26,7 @@ export default function AdaptiveMusicPage() {
           <div style={{ display: "grid", gap: 12 }}>
             <AudioPlayer
               src="/audio/lofi-120.mp3"
+              trackId="adaptive-lofi-120"
               title="Lofi 120"
               loop
               defaultVolume={0.75}

--- a/src/modules/story-synth/StorySynthPage.tsx
+++ b/src/modules/story-synth/StorySynthPage.tsx
@@ -142,6 +142,7 @@ export default function StorySynthPage() {
             {newAudio && ambient !== "aucun" && (
               <AudioPlayer
                 src={AMBIENTS[ambient]}
+                trackId={`story-ambient-${ambient}`}
                 title={`Ambiance ${ambient}`}
                 loop
                 defaultVolume={0.5}

--- a/src/ui/AudioPlayer.tsx
+++ b/src/ui/AudioPlayer.tsx
@@ -3,51 +3,387 @@ import React from "react";
 import { useSound } from "@/ui/hooks/useSound";
 import { clamp01 } from "@/lib/audio/utils";
 
+type FavoriteEntry = {
+  id: string;
+  title?: string;
+  src: string;
+  addedAt: string;
+};
+
+type PlaybackPersistedState = {
+  position: number;
+  volume: number;
+  wasPlaying: boolean;
+  updatedAt: number;
+};
+
+const FAVORITES_STORAGE_KEY = "adaptive-music:favorites";
+
+const formatTime = (totalSeconds: number) => {
+  if (!Number.isFinite(totalSeconds) || totalSeconds <= 0) return "0:00";
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = Math.floor(totalSeconds % 60);
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+};
+
 type Props = {
   src: string;
   title?: string;
+  trackId?: string;
   loop?: boolean;
   defaultVolume?: number; // 0..1
   haptics?: boolean;
 };
 
-export function AudioPlayer({ src, title, loop, defaultVolume = 0.8, haptics = false }: Props) {
-  const s = useSound(src, { loop, volume: defaultVolume });
+export function AudioPlayer({
+  src,
+  title,
+  trackId,
+  loop,
+  defaultVolume = 0.8,
+  haptics = false
+}: Props) {
+  const safeDefaultVolume = clamp01(defaultVolume);
+  const trackKey = React.useMemo(() => trackId ?? src, [trackId, src]);
+  const playbackStorageKey = React.useMemo(
+    () => `adaptive-music:playback:${trackKey}`,
+    [trackKey]
+  );
+  const defaultPlaybackState = React.useMemo<PlaybackPersistedState>(
+    () => ({
+      position: 0,
+      volume: safeDefaultVolume,
+      wasPlaying: false,
+      updatedAt: Date.now()
+    }),
+    [safeDefaultVolume]
+  );
+
+  const {
+    ready,
+    play: playSound,
+    pause: pauseSound,
+    setVolume: setSoundVolume,
+    seek,
+    getTime,
+    onEnded
+  } = useSound(src, { loop, volume: safeDefaultVolume });
+
   const [playing, setPlaying] = React.useState(false);
-  const [volume, setVolume] = React.useState(defaultVolume);
+  const [volume, setVolume] = React.useState(safeDefaultVolume);
+  const [favorites, setFavorites] = React.useState<FavoriteEntry[]>([]);
+  const [resumePosition, setResumePosition] = React.useState(0);
 
-  React.useEffect(() => { s.setVolume?.(volume); }, [volume]);
+  const playbackRef = React.useRef<PlaybackPersistedState>(defaultPlaybackState);
 
-  async function toggle() {
+  const applyHaptics = React.useCallback(() => {
+    if (!haptics) return;
+    if (typeof window === "undefined" || typeof navigator === "undefined") return;
+    const prefersReduced = window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches;
+    if (!prefersReduced && "vibrate" in navigator) {
+      try {
+        navigator.vibrate?.(10);
+      } catch (error) {
+        console.warn("Haptics unavailable", error);
+      }
+    }
+  }, [haptics]);
+
+  const persistPlayback = React.useCallback(
+    (update: Partial<PlaybackPersistedState>, options?: { skipState?: boolean }) => {
+      const nextPosition =
+        typeof update.position === "number"
+          ? Math.max(0, update.position)
+          : playbackRef.current.position;
+      const nextVolume =
+        typeof update.volume === "number"
+          ? clamp01(update.volume)
+          : playbackRef.current.volume;
+      const nextWasPlaying =
+        typeof update.wasPlaying === "boolean"
+          ? update.wasPlaying
+          : playbackRef.current.wasPlaying;
+
+      const nextState: PlaybackPersistedState = {
+        position: nextPosition,
+        volume: nextVolume,
+        wasPlaying: nextWasPlaying,
+        updatedAt: Date.now()
+      };
+
+      playbackRef.current = nextState;
+
+      if (typeof window !== "undefined") {
+        try {
+          window.localStorage.setItem(playbackStorageKey, JSON.stringify(nextState));
+        } catch (error) {
+          console.warn("Unable to persist playback state", error);
+        }
+      }
+
+      if (!options?.skipState && typeof update.position === "number") {
+        const safePosition = Math.max(0, update.position);
+        setResumePosition(prev =>
+          Math.abs(prev - safePosition) < 0.01 ? prev : safePosition
+        );
+      }
+    },
+    [playbackStorageKey]
+  );
+
+  const updateFavorites = React.useCallback(
+    (updater: (prev: FavoriteEntry[]) => FavoriteEntry[]) => {
+      setFavorites(prev => {
+        const next = updater(prev);
+        if (typeof window !== "undefined") {
+          try {
+            window.localStorage.setItem(FAVORITES_STORAGE_KEY, JSON.stringify(next));
+          } catch (error) {
+            console.warn("Unable to persist favorites", error);
+          }
+        }
+        return next;
+      });
+    },
+    []
+  );
+
+  React.useEffect(() => {
+    setPlaying(false);
+  }, [trackKey]);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") {
+      playbackRef.current = defaultPlaybackState;
+      setResumePosition(defaultPlaybackState.position);
+      setVolume(defaultPlaybackState.volume);
+      return;
+    }
+
+    try {
+      const raw = window.localStorage.getItem(playbackStorageKey);
+      if (!raw) {
+        playbackRef.current = defaultPlaybackState;
+        setResumePosition(defaultPlaybackState.position);
+        setVolume(current =>
+          Math.abs(current - defaultPlaybackState.volume) < 0.001
+            ? current
+            : defaultPlaybackState.volume
+        );
+        return;
+      }
+
+      const parsed = JSON.parse(raw);
+      const normalized: PlaybackPersistedState = {
+        position:
+          typeof parsed?.position === "number"
+            ? Math.max(0, parsed.position)
+            : defaultPlaybackState.position,
+        volume:
+          typeof parsed?.volume === "number"
+            ? clamp01(parsed.volume)
+            : defaultPlaybackState.volume,
+        wasPlaying: typeof parsed?.wasPlaying === "boolean" ? parsed.wasPlaying : false,
+        updatedAt: typeof parsed?.updatedAt === "number" ? parsed.updatedAt : Date.now()
+      };
+
+      playbackRef.current = normalized;
+      setResumePosition(normalized.position);
+      setVolume(current =>
+        Math.abs(current - normalized.volume) < 0.001 ? current : normalized.volume
+      );
+    } catch (error) {
+      console.warn("Unable to restore playback state", error);
+      playbackRef.current = defaultPlaybackState;
+      setResumePosition(defaultPlaybackState.position);
+      setVolume(defaultPlaybackState.volume);
+    }
+  }, [playbackStorageKey, defaultPlaybackState]);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    try {
+      const raw = window.localStorage.getItem(FAVORITES_STORAGE_KEY);
+      if (!raw) return;
+
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) return;
+
+      const seen = new Set<string>();
+      const entries: FavoriteEntry[] = [];
+
+      for (const entry of parsed) {
+        if (!entry || typeof entry !== "object") continue;
+        const id = typeof entry.id === "string" ? entry.id : undefined;
+        const storedSrc = typeof entry.src === "string" ? entry.src : undefined;
+        if (!id || !storedSrc || seen.has(id)) continue;
+        seen.add(id);
+        entries.push({
+          id,
+          src: storedSrc,
+          title: typeof entry.title === "string" ? entry.title : undefined,
+          addedAt:
+            typeof entry.addedAt === "string" ? entry.addedAt : new Date().toISOString()
+        });
+      }
+
+      if (entries.length) {
+        updateFavorites(() => entries.slice(-50));
+      }
+    } catch (error) {
+      console.warn("Unable to restore favorites", error);
+    }
+  }, [updateFavorites]);
+
+  React.useEffect(() => {
+    setSoundVolume?.(volume);
+  }, [setSoundVolume, volume]);
+
+  React.useEffect(() => {
+    if (Math.abs(playbackRef.current.volume - volume) < 0.001) return;
+    persistPlayback({ volume });
+  }, [volume, persistPlayback]);
+
+  React.useEffect(() => {
+    if (!onEnded) return;
+    onEnded(() => {
+      setPlaying(false);
+      persistPlayback({ wasPlaying: false, position: 0 });
+    });
+  }, [onEnded, persistPlayback]);
+
+  React.useEffect(() => {
+    if (!playing) return;
+    const interval = window.setInterval(() => {
+      const position = getTime?.() ?? 0;
+      persistPlayback({ position });
+    }, 2000);
+    return () => window.clearInterval(interval);
+  }, [playing, getTime, persistPlayback]);
+
+  React.useEffect(() => {
+    return () => {
+      const position = getTime?.() ?? 0;
+      persistPlayback({ position, wasPlaying: false }, { skipState: true });
+    };
+  }, [getTime, persistPlayback]);
+
+  const isFavorite = React.useMemo(
+    () => favorites.some(entry => entry.id === trackKey),
+    [favorites, trackKey]
+  );
+
+  const toggleFavorite = React.useCallback(() => {
+    updateFavorites(prev => {
+      const exists = prev.some(entry => entry.id === trackKey);
+      if (exists) {
+        return prev.filter(entry => entry.id !== trackKey);
+      }
+
+      const sanitized = prev.filter(entry => entry.id !== trackKey);
+      const nextEntry: FavoriteEntry = {
+        id: trackKey,
+        title,
+        src,
+        addedAt: new Date().toISOString()
+      };
+
+      const next = [...sanitized, nextEntry];
+      return next.slice(-50);
+    });
+  }, [trackKey, title, src, updateFavorites]);
+
+  const handleResume = React.useCallback(async () => {
+    if (resumePosition <= 0.01) return;
+    seek?.(resumePosition);
+    await playSound?.();
+    setPlaying(true);
+    applyHaptics();
+    persistPlayback({ wasPlaying: true, position: resumePosition });
+  }, [resumePosition, seek, playSound, applyHaptics, persistPlayback]);
+
+  const hasResume = resumePosition > 0.5 && !playing;
+
+  const onTogglePlay = React.useCallback(async () => {
     try {
       if (!playing) {
-        await s.play?.();
+        await playSound?.();
         setPlaying(true);
-        const reduced = typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-        if (haptics && !reduced && "vibrate" in navigator) navigator.vibrate?.(10);
+        applyHaptics();
+        const position = getTime?.() ?? 0;
+        persistPlayback({ wasPlaying: true, position });
       } else {
-        s.pause?.();
+        pauseSound?.();
+        const position = getTime?.() ?? 0;
         setPlaying(false);
+        persistPlayback({ wasPlaying: false, position });
       }
-    } catch {}
-  }
+    } catch (error) {
+      console.warn("Audio toggle error", error);
+    }
+  }, [playing, playSound, pauseSound, getTime, applyHaptics, persistPlayback]);
 
   return (
     <div aria-label={title ?? "Lecteur audio"} style={{ display: "grid", gap: 8 }}>
-      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-        <button onClick={toggle} aria-pressed={playing} data-ui="primary-cta">
-          {playing ? "Pause" : "Lecture"}
-        </button>
+      <div style={{ display: "grid", gap: 6 }}>
         {title && <strong>{title}</strong>}
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 8, alignItems: "center" }}>
+          <button
+            type="button"
+            onClick={onTogglePlay}
+            aria-pressed={playing}
+            data-ui="primary-cta"
+          >
+            {playing ? "Pause" : "Lecture"}
+          </button>
+          {hasResume && (
+            <button
+              type="button"
+              onClick={handleResume}
+              disabled={!ready}
+              data-ui="resume-button"
+            >
+              Reprendre ({formatTime(resumePosition)})
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={toggleFavorite}
+            aria-pressed={isFavorite}
+            data-ui="favorite-toggle"
+          >
+            {isFavorite ? "Retirer des favoris" : "Ajouter aux favoris"}
+          </button>
+        </div>
       </div>
+
       <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
         Volume
         <input
-          type="range" min={0} max={1} step={0.01} value={volume}
-          onChange={(e) => setVolume(clamp01(parseFloat(e.target.value)))}
+          type="range"
+          min={0}
+          max={1}
+          step={0.01}
+          value={volume}
+          onChange={event => setVolume(clamp01(parseFloat(event.target.value)))}
           data-ui="volume-slider"
         />
       </label>
+
+      {hasResume && (
+        <small aria-live="polite" style={{ opacity: 0.75 }}>
+          Dernière écoute sauvegardée à {formatTime(resumePosition)}.
+        </small>
+      )}
+
+      {isFavorite && (
+        <small style={{ opacity: 0.75 }}>
+          Sauvegardé dans vos favoris locaux.
+        </small>
+      )}
     </div>
   );
 }
+
+export default AudioPlayer;

--- a/src/ui/hooks/useSound.ts
+++ b/src/ui/hooks/useSound.ts
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createAudioHandle } from "@/lib/audio/engine";
 
 export function useSound(url: string, opts?: { loop?: boolean; volume?: number }) {
@@ -14,17 +14,28 @@ export function useSound(url: string, opts?: { loop?: boolean; volume?: number }
       setReady(true);
     });
     return () => { mounted = false; ref.current?.stop(); };
-  }, [url]);
+  }, [url, opts?.loop, opts?.volume]);
 
-  return {
+  const play = useCallback(() => ref.current?.play() ?? Promise.resolve(), []);
+  const pause = useCallback(() => ref.current?.pause(), []);
+  const stop = useCallback(() => ref.current?.stop(), []);
+  const setVolume = useCallback((v: number) => ref.current?.setVolume(v), []);
+  const setLoop = useCallback((l: boolean) => ref.current?.setLoop(l), []);
+  const seek = useCallback((time: number) => ref.current?.seek(time), []);
+  const getTime = useCallback(() => ref.current?.getCurrentTime() ?? 0, []);
+  const getDuration = useCallback(() => ref.current?.getDuration() ?? null, []);
+  const onEnded = useCallback((cb: () => void) => ref.current?.onEnded(cb), []);
+
+  return useMemo(() => ({
     ready,
-    play: () => ref.current?.play() ?? Promise.resolve(),
-    pause: () => ref.current?.pause(),
-    stop: () => ref.current?.stop(),
-    setVolume: (v: number) => ref.current?.setVolume(v),
-    setLoop: (l: boolean) => ref.current?.setLoop(l),
-    getTime: () => ref.current?.getCurrentTime() ?? 0,
-    getDuration: () => ref.current?.getDuration() ?? null,
-    onEnded: (cb: () => void) => ref.current?.onEnded(cb)
-  };
+    play,
+    pause,
+    stop,
+    setVolume,
+    setLoop,
+    seek,
+    getTime,
+    getDuration,
+    onEnded
+  }), [ready, play, pause, stop, setVolume, setLoop, seek, getTime, getDuration, onEnded]);
 }


### PR DESCRIPTION
## Summary
- persist adaptive audio player favorites and playback position via localStorage with resume/favorite controls in the UI
- add seek support to the audio engine and useSound hook to enable playback restoration
- wire adaptive music/story synth pages to stable track ids and cover the new behaviour with unit tests

## Testing
- npx vitest run src/__tests__/audio.player.snapshot.spec.tsx --silent

------
https://chatgpt.com/codex/tasks/task_e_68ca88d6b0bc832d954001443404cdd1