### PR TITLE
feat: auto journalization after Flash Glow session

### DIFF
--- a/src/modules/flash-glow/__tests__/journal.test.ts
+++ b/src/modules/flash-glow/__tests__/journal.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createFlashGlowJournalEntry } from '@/modules/flash-glow/journal';
+import { journalService } from '@/modules/journal/journalService';
+
+vi.mock('@/modules/journal/journalService', () => {
+  return {
+    journalService: {
+      saveEntry: vi.fn()
+    }
+  };
+});
+
+describe('createFlashGlowJournalEntry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('enregistre une entrée structurée avec tonalité et résumé', async () => {
+    const now = new Date();
+    const mockedEntry = {
+      id: 'entry-1',
+      content: 'mocked',
+      summary: 'Flash Glow Ultra - Gain ressenti',
+      tone: 'positive' as const,
+      ephemeral: false,
+      created_at: now,
+      duration: 95
+    };
+
+    vi.mocked(journalService.saveEntry).mockResolvedValue(mockedEntry as any);
+
+    const entry = await createFlashGlowJournalEntry({
+      label: 'gain',
+      duration: 95,
+      intensity: 82,
+      glowType: 'energy',
+      recommendation: 'Continuez sur cette lancée ✨',
+      context: 'Flash Glow Ultra'
+    });
+
+    expect(journalService.saveEntry).toHaveBeenCalledTimes(1);
+    expect(journalService.saveEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tone: 'positive',
+        summary: expect.stringContaining('Flash Glow Ultra'),
+        content: expect.stringContaining('Gain ressenti'),
+        duration: 95,
+        ephemeral: false
+      })
+    );
+
+    expect(entry).toEqual(mockedEntry);
+  });
+
+  it('retourne null si la journalisation échoue', async () => {
+    vi.mocked(journalService.saveEntry).mockRejectedValue(new Error('storage error'));
+
+    const entry = await createFlashGlowJournalEntry({
+      duration: 60,
+      intensity: 70,
+      glowType: 'calm',
+      recommendation: 'Respirez profondément.'
+    });
+
+    expect(entry).toBeNull();
+  });
+});

--- a/src/modules/flash-glow/__tests__/useFlashGlowMachine.test.ts
+++ b/src/modules/flash-glow/__tests__/useFlashGlowMachine.test.ts
@@ -1,0 +1,81 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useFlashGlowMachine } from '@/modules/flash-glow/useFlashGlowMachine';
+import { flashGlowService } from '@/modules/flash-glow/flash-glowService';
+import { createFlashGlowJournalEntry } from '@/modules/flash-glow/journal';
+import { toast } from '@/hooks/use-toast';
+
+vi.mock('@/modules/flash-glow/flash-glowService', () => ({
+  flashGlowService: {
+    startSession: vi.fn().mockResolvedValue({ sessionId: 'fg_1' }),
+    endSession: vi.fn().mockResolvedValue({ success: true, message: 'ok' }),
+    getStats: vi.fn().mockResolvedValue({ total_sessions: 3, avg_duration: 80, recent_sessions: [] }),
+    getRecommendation: vi.fn().mockReturnValue('Recommandation test'),
+    triggerHapticFeedback: vi.fn()
+  }
+}));
+
+vi.mock('@/modules/flash-glow/journal', () => ({
+  createFlashGlowJournalEntry: vi.fn().mockResolvedValue({
+    id: 'journal-1',
+    content: 'entry',
+    summary: 'Flash Glow Ultra - Gain ressenti',
+    tone: 'positive',
+    ephemeral: false,
+    created_at: new Date(),
+    duration: 90
+  })
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  toast: vi.fn()
+}));
+
+describe('useFlashGlowMachine - auto journalisation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('crée une entrée de journal et enrichit les métadonnées lors de la complétion', async () => {
+    const { result } = renderHook(() => useFlashGlowMachine());
+
+    act(() => {
+      result.current.setConfig({ duration: 1 });
+    });
+
+    await act(async () => {
+      const promise = result.current.startSession();
+      vi.runAllTimers();
+      await promise;
+    });
+
+    await act(async () => {
+      await result.current.onSessionComplete('gain');
+    });
+
+    expect(createFlashGlowJournalEntry).toHaveBeenCalledTimes(1);
+    expect(createFlashGlowJournalEntry).toHaveBeenCalledWith(expect.objectContaining({
+      label: 'gain',
+      context: 'Flash Glow Ultra',
+      recommendation: 'Recommandation test'
+    }));
+
+    expect(flashGlowService.endSession).toHaveBeenCalledWith(expect.objectContaining({
+      metadata: expect.objectContaining({
+        autoJournal: true,
+        journalEntryId: 'journal-1',
+        journalSummary: 'Flash Glow Ultra - Gain ressenti',
+        journalTone: 'positive'
+      })
+    }));
+
+    expect(toast).toHaveBeenCalledWith(expect.objectContaining({
+      description: expect.stringContaining('Votre expérience a été ajoutée automatiquement au journal')
+    }));
+  });
+});

--- a/src/modules/flash-glow/journal.ts
+++ b/src/modules/flash-glow/journal.ts
@@ -1,0 +1,112 @@
+import type { FlashGlowSession } from './flash-glowService';
+import { journalService } from '@/modules/journal/journalService';
+import type { JournalEntry } from '@/modules/journal/journalService';
+
+export type FlashGlowJournalLabel = FlashGlowSession['label'];
+
+interface CreateFlashGlowJournalEntryParams {
+  label?: FlashGlowJournalLabel;
+  duration: number;
+  intensity: number;
+  glowType?: string;
+  recommendation?: string;
+  context?: string;
+}
+
+const LABEL_CONFIG: Record<FlashGlowJournalLabel, { title: string; tone: 'positive' | 'neutral' | 'negative'; reflection: string }> = {
+  gain: {
+    title: 'Gain ressenti',
+    tone: 'positive',
+    reflection: 'Cette session a apporté une montée d\'énergie palpable. Conservez cette sensation en identifiant ce qui a le plus contribué à votre regain.'
+  },
+  'léger': {
+    title: 'Effet léger',
+    tone: 'neutral',
+    reflection: 'Les changements subtils s\'accumulent. Notez les signaux, même légers, qui indiquent une évolution positive.'
+  },
+  incertain: {
+    title: 'Incertain',
+    tone: 'neutral',
+    reflection: 'Chaque session est une exploration. Identifiez ce qui pourrait soutenir davantage votre prochaine immersion.'
+  }
+};
+
+const DEFAULT_LABEL_INFO = {
+  title: 'Exploration',
+  tone: 'neutral' as const,
+  reflection: 'Prenez un instant pour noter ce que cette session vous inspire, même si les sensations sont diffuses.'
+};
+
+const GLOW_TYPE_LABELS: Record<string, string> = {
+  energy: 'Énergie',
+  calm: 'Calme',
+  creativity: 'Créativité',
+  confidence: 'Confiance',
+  love: 'Amour',
+  doux: 'Velours doux',
+  standard: 'Velours standard',
+  tonique: 'Velours tonique'
+};
+
+const formatGlowType = (glowType?: string): string => {
+  if (!glowType) return 'Standard';
+  const mapped = GLOW_TYPE_LABELS[glowType];
+  if (mapped) return mapped;
+  const normalized = glowType.replace(/[-_]/g, ' ');
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+};
+
+/**
+ * Crée une entrée de journal automatique pour Flash Glow.
+ * Retourne l'entrée enregistrée ou null si la journalisation n'a pas abouti.
+ */
+export async function createFlashGlowJournalEntry({
+  label,
+  duration,
+  intensity,
+  glowType,
+  recommendation,
+  context
+}: CreateFlashGlowJournalEntryParams): Promise<JournalEntry | null> {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const safeDuration = Math.max(1, Math.round(duration));
+  const safeIntensity = Math.max(0, Math.min(100, Math.round(intensity)));
+  const labelInfo = label ? LABEL_CONFIG[label] : DEFAULT_LABEL_INFO;
+  const friendlyGlowType = formatGlowType(glowType);
+  const sectionTitle = context ?? 'Flash Glow';
+
+  const summary = `${sectionTitle} - ${labelInfo.title}`;
+  const contentLines = [
+    `✨ ${sectionTitle}`,
+    `Ressenti : ${labelInfo.title}`,
+    `Mode : ${friendlyGlowType}`,
+    `Intensité : ${safeIntensity}%`,
+    `Durée : ${safeDuration}s`
+  ];
+
+  if (recommendation) {
+    contentLines.push('', recommendation.trim());
+  }
+
+  if (labelInfo.reflection) {
+    contentLines.push('', labelInfo.reflection);
+  }
+
+  try {
+    const entry = await journalService.saveEntry({
+      content: contentLines.join('\n'),
+      summary,
+      tone: labelInfo.tone,
+      ephemeral: false,
+      duration: safeDuration
+    });
+
+    return entry;
+  } catch (error) {
+    console.error('Flash Glow auto journalisation échouée:', error);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared helper to generate Flash Glow journal entries with contextual copy
- hook auto journal creation into the Flash Glow state machine and enrich session metadata
- cover the new flow with focused vitest suites for the helper and the hook

## Testing
- npx vitest run src/modules/flash-glow/__tests__/journal.test.ts --reporter verbose
- npx vitest run src/modules/flash-glow/__tests__/useFlashGlowMachine.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68ca88570d70832d9482d076ed46930f