### PR TITLE
feat: add Recharts dashboards for Scores V2

### DIFF
--- a/src/__tests__/__snapshots__/scores.v2.snapshot.spec.tsx.snap
+++ b/src/__tests__/__snapshots__/scores.v2.snapshot.spec.tsx.snap
@@ -2,25 +2,614 @@
 
 exports[`ScoresV2Panel > rend un panneau scores 1`] = `
 <div>
-  <section aria-label="Scores V2">
-    <div>
-      <h1>Scores</h1>
-      <p>Progression, streaks et badges</p>
+  <section
+    aria-label="Scores V2"
+    class="space-y-8"
+  >
+    <div
+      class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between"
+    >
+      <div
+        class="space-y-1"
+      >
+        <h1
+          class="text-3xl font-semibold tracking-tight"
+        >
+          Scores
+        </h1>
+        <p
+          class="text-muted-foreground"
+        >
+          Progression, streaks et badges
+        </p>
+      </div>
+      <div
+        class="flex flex-wrap items-center gap-3 text-sm"
+      >
+        <div
+          aria-label="Niveau 3"
+          class="inline-flex items-center rounded-md border text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80 px-3 py-1"
+        >
+          Niveau 
+          3
+        </div>
+        <div
+          aria-label="7 jours de suite"
+          class="flex items-center gap-1 text-muted-foreground"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-flame h-4 w-4 text-orange-500"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z"
+            />
+          </svg>
+          <span>
+            7
+             j de suite
+          </span>
+        </div>
+        <div
+          class="flex items-center gap-1 text-muted-foreground"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-calendar-range h-4 w-4"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <rect
+              height="18"
+              rx="2"
+              width="18"
+              x="3"
+              y="4"
+            />
+            <path
+              d="M16 2v4"
+            />
+            <path
+              d="M3 10h18"
+            />
+            <path
+              d="M8 2v4"
+            />
+            <path
+              d="M17 14h-6"
+            />
+            <path
+              d="M13 18H7"
+            />
+            <path
+              d="M7 14h.01"
+            />
+            <path
+              d="M17 18h.01"
+            />
+          </svg>
+          <span>
+            S13
+            : 
+            13
+             séances
+          </span>
+        </div>
+        <button
+          class="inline-flex items-center justify-center whitespace-nowrap font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed focus-enhanced border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground hover:shadow-md active:scale-95 h-8 rounded-md px-3 text-xs ml-auto md:ml-0"
+          data-ui="refresh"
+          type="button"
+        >
+          <svg
+            class="lucide lucide-refresh-ccw mr-2 h-4 w-4"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"
+            />
+            <path
+              d="M3 3v5h5"
+            />
+            <path
+              d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16"
+            />
+            <path
+              d="M16 16h5v5"
+            />
+          </svg>
+          Actualiser
+        </button>
+      </div>
     </div>
-    <div>
-      <div style="display: flex; gap: 12px; align-items: center;">
-        <span aria-label="Niveau 1" style="padding: 2px 8px; border-radius: 999px; background: var(--card);">Niveau 1</span>
-        <span>Streak: 0 j</span>
-        <span>Total: 0</span>
+    <div
+      class="grid gap-6 lg:grid-cols-3"
+    >
+      <div
+        class="rounded-xl border bg-card text-card-foreground shadow lg:col-span-2"
+      >
+        <div
+          class="flex flex-col space-y-1.5 p-6 pb-0"
+        >
+          <h3
+            class="font-semibold leading-none tracking-tight"
+          >
+            Évolution de l'humeur
+          </h3>
+          <p
+            class="text-sm text-muted-foreground"
+          >
+            10 derniers jours, corrélation énergie & activités
+          </p>
+        </div>
+        <div
+          class="p-6 pt-0 space-y-6"
+        >
+          <div
+            class="grid gap-4 sm:grid-cols-3"
+          >
+            <div>
+              <p
+                class="text-xs uppercase text-muted-foreground"
+              >
+                Humeur moyenne
+              </p>
+              <p
+                class="text-2xl font-semibold"
+              >
+                7.6
+                /10
+              </p>
+            </div>
+            <div>
+              <p
+                class="text-xs uppercase text-muted-foreground"
+              >
+                Variation
+              </p>
+              <p
+                class="text-2xl font-semibold text-emerald-600"
+              >
+                +
+                2.4
+              </p>
+            </div>
+            <div>
+              <p
+                class="text-xs uppercase text-muted-foreground"
+              >
+                Pic émotionnel
+              </p>
+              <p
+                class="text-2xl font-semibold"
+              >
+                26 mars
+              </p>
+            </div>
+          </div>
+          <div
+            class="h-[280px] w-full"
+          >
+            <div
+              class="recharts-responsive-container"
+              style="width: 100%; height: 100%; min-width: 0;"
+            />
+          </div>
+        </div>
       </div>
-      <div aria-label="Progression" style="background: var(--card); border-radius: 8px; overflow: hidden;">
-        <div style="width: 0%; height: 8px; background: var(--accent);"></div>
+      <div
+        class="rounded-xl border bg-card text-card-foreground shadow"
+      >
+        <div
+          class="flex flex-col space-y-1.5 p-6 pb-0"
+        >
+          <h3
+            class="font-semibold leading-none tracking-tight"
+          >
+            Progression & Badges
+          </h3>
+          <p
+            class="text-sm text-muted-foreground"
+          >
+            Cap sur le niveau suivant
+          </p>
+        </div>
+        <div
+          class="p-6 pt-0 space-y-6"
+        >
+          <div
+            class="space-y-2"
+          >
+            <div
+              class="flex items-center justify-between text-sm"
+            >
+              <span>
+                Expérience
+              </span>
+              <span>
+                1860
+                 / 
+                2200
+              </span>
+            </div>
+            <div
+              aria-label="Progression vers le niveau suivant"
+              aria-valuemax="100"
+              aria-valuemin="0"
+              class="relative h-2 w-full overflow-hidden rounded-full bg-primary/20"
+              data-max="100"
+              data-state="indeterminate"
+              role="progressbar"
+            >
+              <div
+                class="h-full w-full flex-1 bg-primary transition-all"
+                data-max="100"
+                data-state="indeterminate"
+                style="transform: translateX(-15%);"
+              />
+            </div>
+            <p
+              class="text-xs text-muted-foreground"
+            >
+              Encore 
+              340
+               pts avant le niveau 4.
+            </p>
+          </div>
+          <div
+            class="space-y-3"
+          >
+            <div
+              class="flex items-start gap-3 rounded-lg border p-3"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-sparkles h-4 w-4 text-primary"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"
+                />
+                <path
+                  d="M5 3v4"
+                />
+                <path
+                  d="M19 17v4"
+                />
+                <path
+                  d="M3 5h4"
+                />
+                <path
+                  d="M17 19h4"
+                />
+              </svg>
+              <div>
+                <p
+                  class="font-medium"
+                >
+                  Badge Sérénité
+                </p>
+                <p
+                  class="text-xs text-muted-foreground"
+                >
+                  3 séances de respiration consécutives
+                </p>
+              </div>
+            </div>
+            <div
+              class="flex items-start gap-3 rounded-lg border p-3"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-trending-up h-4 w-4 text-emerald-500"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <polyline
+                  points="22 7 13.5 15.5 8.5 10.5 2 17"
+                />
+                <polyline
+                  points="16 7 22 7 22 13"
+                />
+              </svg>
+              <div>
+                <p
+                  class="font-medium"
+                >
+                  Boost hebdo
+                </p>
+                <p
+                  class="text-xs text-muted-foreground"
+                >
+                  13
+                   séances réalisées cette semaine
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
-      <svg width="200" height="48" role="img" aria-label="Sparkline vide"></svg>
-      <div>
-        <strong>Badges :</strong> —
+    </div>
+    <div
+      class="grid gap-6 lg:grid-cols-3"
+    >
+      <div
+        class="rounded-xl border bg-card text-card-foreground shadow lg:col-span-2"
+      >
+        <div
+          class="flex flex-col space-y-1.5 p-6 pb-0"
+        >
+          <h3
+            class="font-semibold leading-none tracking-tight"
+          >
+            Séances par semaine
+          </h3>
+          <p
+            class="text-sm text-muted-foreground"
+          >
+            Répartition guidée, respiration, VR et journal
+          </p>
+        </div>
+        <div
+          class="p-6 pt-0 space-y-6"
+        >
+          <div
+            class="grid gap-4 sm:grid-cols-3"
+          >
+            <div>
+              <p
+                class="text-xs uppercase text-muted-foreground"
+              >
+                Moyenne
+              </p>
+              <p
+                class="text-2xl font-semibold"
+              >
+                8.8
+                 séances
+              </p>
+            </div>
+            <div>
+              <p
+                class="text-xs uppercase text-muted-foreground"
+              >
+                Semaine max
+              </p>
+              <p
+                class="text-2xl font-semibold"
+              >
+                S13
+              </p>
+            </div>
+            <div>
+              <p
+                class="text-xs uppercase text-muted-foreground"
+              >
+                Guidées
+              </p>
+              <p
+                class="text-2xl font-semibold"
+              >
+                5
+              </p>
+            </div>
+          </div>
+          <div
+            class="h-[280px] w-full"
+          >
+            <div
+              class="recharts-responsive-container"
+              style="width: 100%; height: 100%; min-width: 0;"
+            />
+          </div>
+        </div>
       </div>
-      <button data-ui="refresh">Actualiser</button>
+      <div
+        class="rounded-xl border bg-card text-card-foreground shadow"
+      >
+        <div
+          class="flex flex-col space-y-1.5 p-6 pb-0"
+        >
+          <h3
+            class="font-semibold leading-none tracking-tight"
+          >
+            Focus de la semaine
+          </h3>
+          <p
+            class="text-sm text-muted-foreground"
+          >
+            Moments les plus vibrants
+          </p>
+        </div>
+        <div
+          class="p-6 pt-0 space-y-4"
+        >
+          <div
+            class="rounded-lg border bg-muted/40 p-4"
+          >
+            <p
+              class="text-sm text-muted-foreground"
+            >
+              Créneau le plus intense
+            </p>
+            <p
+              class="text-lg font-semibold"
+            >
+              Jeu
+               — 
+              Matin
+            </p>
+            <p
+              class="text-sm text-muted-foreground"
+            >
+              3
+               séances, vibe 
+              euphorique
+            </p>
+          </div>
+          <div
+            class="space-y-3 text-sm"
+          >
+            <div
+              class="flex items-center justify-between"
+            >
+              <span>
+                Pic d'énergie
+              </span>
+              <span>
+                26 mars
+              </span>
+            </div>
+            <div
+              class="flex items-center justify-between"
+            >
+              <span>
+                Sessions VR cumulées
+              </span>
+              <span>
+                10
+              </span>
+            </div>
+            <div
+              class="flex items-center justify-between"
+            >
+              <span>
+                Respirations guidées
+              </span>
+              <span>
+                13
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="rounded-xl border bg-card text-card-foreground shadow"
+    >
+      <div
+        class="flex flex-col space-y-1.5 p-6 pb-0"
+      >
+        <h3
+          class="font-semibold leading-none tracking-tight"
+        >
+          Heatmap Vibes
+        </h3>
+        <p
+          class="text-sm text-muted-foreground"
+        >
+          Intensité émotionnelle par moment clé de la journée
+        </p>
+      </div>
+      <div
+        class="p-6 pt-0 space-y-6"
+      >
+        <div
+          class="h-[320px] w-full"
+        >
+          <div
+            class="recharts-responsive-container"
+            style="width: 100%; height: 100%; min-width: 0;"
+          />
+        </div>
+        <div
+          class="flex flex-wrap items-center gap-3 text-xs text-muted-foreground"
+        >
+          <div
+            class="flex items-center gap-2"
+          >
+            <span
+              class="h-3 w-6 rounded-full"
+              style="background-color: rgba(124, 58, 237, 0.95);"
+            />
+            <span>
+              Intense
+            </span>
+          </div>
+          <div
+            class="flex items-center gap-2"
+          >
+            <span
+              class="h-3 w-6 rounded-full"
+              style="background-color: rgba(139, 92, 246, 0.85);"
+            />
+            <span>
+              Élevé
+            </span>
+          </div>
+          <div
+            class="flex items-center gap-2"
+          >
+            <span
+              class="h-3 w-6 rounded-full"
+              style="background-color: rgba(167, 139, 250, 0.75);"
+            />
+            <span>
+              Modéré
+            </span>
+          </div>
+          <div
+            class="flex items-center gap-2"
+          >
+            <span
+              class="h-3 w-6 rounded-full"
+              style="background-color: rgba(229, 231, 235, 0.45);"
+            />
+            <span>
+              Calme
+            </span>
+          </div>
+          <div
+            class="flex items-center gap-2"
+          >
+            <span
+              class="h-3 w-6 rounded-full"
+              style="background-color: rgba(229, 231, 235, 0.45);"
+            />
+            <span>
+              Repos
+            </span>
+          </div>
+        </div>
+      </div>
     </div>
   </section>
 </div>

--- a/src/app/modules/scores/ScoresV2Panel.tsx
+++ b/src/app/modules/scores/ScoresV2Panel.tsx
@@ -1,0 +1,443 @@
+import React, { useMemo } from "react";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+  BarChart,
+  Bar,
+  Cell,
+  ScatterChart,
+  Scatter,
+} from "recharts";
+import type { TooltipProps } from "recharts";
+import type { ValueType, NameType } from "recharts/types/component/DefaultTooltipContent";
+import { Flame, RefreshCcw, Sparkles, TrendingUp, CalendarRange } from "lucide-react";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { cn } from "@/lib/utils";
+
+interface MoodTrendPoint {
+  date: string;
+  mood: number;
+  energy: number;
+  annotation: string;
+}
+
+interface WeeklySessionsPoint {
+  week: string;
+  guided: number;
+  breathwork: number;
+  vr: number;
+  journaling: number;
+}
+
+interface HeatmapPoint {
+  day: string;
+  slot: string;
+  intensity: number;
+  dominantMood: string;
+  sessions: number;
+}
+
+const MOOD_TREND_DATA: MoodTrendPoint[] = [
+  { date: "2024-03-17", mood: 6.2, energy: 6.0, annotation: "Respiration 4-7-8" },
+  { date: "2024-03-18", mood: 6.8, energy: 6.3, annotation: "Séance VR focus" },
+  { date: "2024-03-19", mood: 7.1, energy: 6.9, annotation: "Coaching empathique" },
+  { date: "2024-03-20", mood: 7.4, energy: 7.3, annotation: "Routine complète" },
+  { date: "2024-03-21", mood: 7.2, energy: 7.0, annotation: "Journal guidé" },
+  { date: "2024-03-22", mood: 7.9, energy: 7.6, annotation: "Session immersive" },
+  { date: "2024-03-23", mood: 8.2, energy: 7.8, annotation: "Mix musique + respiration" },
+  { date: "2024-03-24", mood: 8.4, energy: 8.2, annotation: "Weekend ressourçant" },
+  { date: "2024-03-25", mood: 8.1, energy: 8.0, annotation: "Check-in matinal" },
+  { date: "2024-03-26", mood: 8.6, energy: 8.4, annotation: "Routine + appel coach" },
+];
+
+const WEEKLY_SESSIONS_DATA: WeeklySessionsPoint[] = [
+  { week: "S08", guided: 2, breathwork: 1, vr: 0, journaling: 1 },
+  { week: "S09", guided: 3, breathwork: 2, vr: 1, journaling: 1 },
+  { week: "S10", guided: 3, breathwork: 2, vr: 2, journaling: 1 },
+  { week: "S11", guided: 4, breathwork: 2, vr: 2, journaling: 2 },
+  { week: "S12", guided: 4, breathwork: 3, vr: 2, journaling: 2 },
+  { week: "S13", guided: 5, breathwork: 3, vr: 3, journaling: 2 },
+];
+
+const HEATMAP_DATA: HeatmapPoint[] = [
+  { day: "Lun", slot: "Matin", intensity: 75, dominantMood: "Apaisé", sessions: 2 },
+  { day: "Lun", slot: "Midi", intensity: 48, dominantMood: "Concentré", sessions: 1 },
+  { day: "Lun", slot: "Après-midi", intensity: 62, dominantMood: "Créatif", sessions: 1 },
+  { day: "Lun", slot: "Soir", intensity: 40, dominantMood: "Repos", sessions: 1 },
+  { day: "Mar", slot: "Matin", intensity: 80, dominantMood: "Positif", sessions: 2 },
+  { day: "Mar", slot: "Midi", intensity: 55, dominantMood: "Motivé", sessions: 1 },
+  { day: "Mar", slot: "Après-midi", intensity: 68, dominantMood: "Focus", sessions: 2 },
+  { day: "Mar", slot: "Soir", intensity: 35, dominantMood: "Calme", sessions: 1 },
+  { day: "Mer", slot: "Matin", intensity: 72, dominantMood: "Positif", sessions: 2 },
+  { day: "Mer", slot: "Midi", intensity: 58, dominantMood: "Engagé", sessions: 1 },
+  { day: "Mer", slot: "Après-midi", intensity: 66, dominantMood: "Concentré", sessions: 1 },
+  { day: "Mer", slot: "Soir", intensity: 44, dominantMood: "Déconnexion", sessions: 1 },
+  { day: "Jeu", slot: "Matin", intensity: 84, dominantMood: "Euphorique", sessions: 3 },
+  { day: "Jeu", slot: "Midi", intensity: 62, dominantMood: "Créatif", sessions: 1 },
+  { day: "Jeu", slot: "Après-midi", intensity: 70, dominantMood: "Confiant", sessions: 2 },
+  { day: "Jeu", slot: "Soir", intensity: 50, dominantMood: "Serein", sessions: 1 },
+  { day: "Ven", slot: "Matin", intensity: 77, dominantMood: "Motivé", sessions: 2 },
+  { day: "Ven", slot: "Midi", intensity: 60, dominantMood: "Concentré", sessions: 1 },
+  { day: "Ven", slot: "Après-midi", intensity: 73, dominantMood: "Inspiré", sessions: 2 },
+  { day: "Ven", slot: "Soir", intensity: 52, dominantMood: "Calme", sessions: 1 },
+  { day: "Sam", slot: "Matin", intensity: 68, dominantMood: "Détendu", sessions: 1 },
+  { day: "Sam", slot: "Midi", intensity: 54, dominantMood: "Curieux", sessions: 1 },
+  { day: "Sam", slot: "Après-midi", intensity: 76, dominantMood: "Enthousiaste", sessions: 2 },
+  { day: "Sam", slot: "Soir", intensity: 64, dominantMood: "Serein", sessions: 2 },
+  { day: "Dim", slot: "Matin", intensity: 70, dominantMood: "Positif", sessions: 1 },
+  { day: "Dim", slot: "Midi", intensity: 46, dominantMood: "Paisible", sessions: 1 },
+  { day: "Dim", slot: "Après-midi", intensity: 58, dominantMood: "Réflexif", sessions: 1 },
+  { day: "Dim", slot: "Soir", intensity: 49, dominantMood: "Repos", sessions: 1 },
+];
+
+const moodLineColor = "#6366f1";
+const energyLineColor = "#f97316";
+const gridColor = "rgba(148, 163, 184, 0.25)";
+const axisColor = "rgba(100, 116, 139, 0.85)";
+const sessionPalette = {
+  guided: "#818cf8",
+  breathwork: "#34d399",
+  vr: "#fbbf24",
+  journaling: "#f472b6",
+};
+
+const getHeatmapColor = (intensity: number) => {
+  if (intensity >= 80) return "rgba(124, 58, 237, 0.95)";
+  if (intensity >= 65) return "rgba(139, 92, 246, 0.85)";
+  if (intensity >= 50) return "rgba(167, 139, 250, 0.75)";
+  if (intensity >= 35) return "rgba(196, 181, 253, 0.6)";
+  return "rgba(229, 231, 235, 0.45)";
+};
+
+const ensureResizeObserver = () => {
+  if (typeof window !== "undefined" && typeof (window as Record<string, unknown>).ResizeObserver === "undefined") {
+    (window as Record<string, unknown>).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+};
+
+const formatDate = (date: string) => {
+  return new Date(date).toLocaleDateString("fr-FR", {
+    month: "short",
+    day: "numeric",
+  });
+};
+
+const MoodTooltip = ({ active, payload, label }: TooltipProps<ValueType, NameType>) => {
+  if (!active || !payload || payload.length === 0) return null;
+
+  const data = payload[0]?.payload as MoodTrendPoint | undefined;
+  if (!data) return null;
+
+  return (
+    <div className="rounded-lg border bg-background p-3 text-sm shadow-md">
+      <p className="font-medium">{formatDate(label ?? data.date)}</p>
+      <p className="text-primary">Humeur: {data.mood.toFixed(1)}/10</p>
+      <p className="text-orange-500">Énergie: {data.energy.toFixed(1)}/10</p>
+      <p className="mt-1 text-muted-foreground">{data.annotation}</p>
+    </div>
+  );
+};
+
+const HeatmapTooltip = ({ active, payload }: TooltipProps<ValueType, NameType>) => {
+  if (!active || !payload || payload.length === 0) return null;
+
+  const data = payload[0]?.payload as HeatmapPoint | undefined;
+  if (!data) return null;
+
+  return (
+    <div className="rounded-lg border bg-background p-3 text-sm shadow-md">
+      <p className="font-medium">{data.day} — {data.slot}</p>
+      <p>Sessions: {data.sessions}</p>
+      <p className="text-muted-foreground">Vibe dominante: {data.dominantMood}</p>
+    </div>
+  );
+};
+
+const HeatmapCell = ({ cx, cy, fill }: { cx?: number; cy?: number; fill?: string }) => {
+  if (typeof cx !== "number" || typeof cy !== "number") {
+    return null;
+  }
+
+  const size = 40;
+  return (
+    <rect
+      x={cx - size / 2}
+      y={cy - size / 2}
+      width={size}
+      height={size}
+      rx={12}
+      fill={fill}
+      className="transition-transform duration-200 ease-out"
+    />
+  );
+};
+
+const ScoresV2Panel: React.FC = () => {
+  ensureResizeObserver();
+  const level = 3;
+  const currentExperience = 1860;
+  const nextLevelExperience = 2200;
+  const streak = 7;
+
+  const levelProgress = Math.min(100, Math.round((currentExperience / nextLevelExperience) * 100));
+
+  const moodAverage = useMemo(() => {
+    const total = MOOD_TREND_DATA.reduce((acc, point) => acc + point.mood, 0);
+    return total / MOOD_TREND_DATA.length;
+  }, []);
+
+  const moodVariation = useMemo(() => {
+    const first = MOOD_TREND_DATA[0];
+    const last = MOOD_TREND_DATA[MOOD_TREND_DATA.length - 1];
+    return last.mood - first.mood;
+  }, []);
+
+  const bestMoodDay = useMemo(() => {
+    return MOOD_TREND_DATA.reduce((best, current) => (current.mood > best.mood ? current : best));
+  }, []);
+
+  const weeklySessions = useMemo(() => {
+    return WEEKLY_SESSIONS_DATA.map((entry) => ({
+      ...entry,
+      total: entry.guided + entry.breathwork + entry.vr + entry.journaling,
+    }));
+  }, []);
+
+  const sessionsAverage = useMemo(() => {
+    const total = weeklySessions.reduce((acc, week) => acc + week.total, 0);
+    return total / weeklySessions.length;
+  }, [weeklySessions]);
+
+  const lastWeek = weeklySessions[weeklySessions.length - 1];
+
+  const mostIntenseSlot = useMemo(() => {
+    return HEATMAP_DATA.reduce((best, current) => (current.intensity > best.intensity ? current : best));
+  }, []);
+
+  return (
+    <section aria-label="Scores V2" className="space-y-8">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="space-y-1">
+          <h1 className="text-3xl font-semibold tracking-tight">Scores</h1>
+          <p className="text-muted-foreground">Progression, streaks et badges</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3 text-sm">
+          <Badge variant="secondary" className="px-3 py-1" aria-label={`Niveau ${level}`}>
+            Niveau {level}
+          </Badge>
+          <div className="flex items-center gap-1 text-muted-foreground" aria-label={`${streak} jours de suite`}>
+            <Flame className="h-4 w-4 text-orange-500" aria-hidden="true" />
+            <span>{streak} j de suite</span>
+          </div>
+          <div className="flex items-center gap-1 text-muted-foreground">
+            <CalendarRange className="h-4 w-4" aria-hidden="true" />
+            <span>{lastWeek.week}: {lastWeek.total} séances</span>
+          </div>
+          <Button variant="outline" size="sm" className="ml-auto md:ml-0" data-ui="refresh">
+            <RefreshCcw className="mr-2 h-4 w-4" />
+            Actualiser
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <Card className="lg:col-span-2">
+          <CardHeader className="pb-0">
+            <CardTitle>Évolution de l'humeur</CardTitle>
+            <CardDescription>10 derniers jours, corrélation énergie & activités</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="grid gap-4 sm:grid-cols-3">
+              <div>
+                <p className="text-xs uppercase text-muted-foreground">Humeur moyenne</p>
+                <p className="text-2xl font-semibold">{moodAverage.toFixed(1)}/10</p>
+              </div>
+              <div>
+                <p className="text-xs uppercase text-muted-foreground">Variation</p>
+                <p className={cn("text-2xl font-semibold", moodVariation >= 0 ? "text-emerald-600" : "text-red-500")}
+                >
+                  {moodVariation >= 0 ? "+" : ""}{moodVariation.toFixed(1)}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs uppercase text-muted-foreground">Pic émotionnel</p>
+                <p className="text-2xl font-semibold">{formatDate(bestMoodDay.date)}</p>
+              </div>
+            </div>
+            <div className="h-[280px] w-full">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={MOOD_TREND_DATA} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+                  <CartesianGrid stroke={gridColor} strokeDasharray="3 3" />
+                  <XAxis dataKey="date" stroke={axisColor} tickFormatter={formatDate} />
+                  <YAxis stroke={axisColor} domain={[5, 10]} tickCount={6} />
+                  <Tooltip content={<MoodTooltip />} cursor={{ stroke: "rgba(99, 102, 241, 0.35)" }} />
+                  <Legend />
+                  <Line type="monotone" dataKey="mood" name="Humeur" stroke={moodLineColor} strokeWidth={2} dot={false} activeDot={{ r: 6 }} />
+                  <Line type="monotone" dataKey="energy" name="Énergie" stroke={energyLineColor} strokeWidth={2} dot={false} activeDot={{ r: 6 }} />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-0">
+            <CardTitle>Progression & Badges</CardTitle>
+            <CardDescription>Cap sur le niveau suivant</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="space-y-2">
+              <div className="flex items-center justify-between text-sm">
+                <span>Expérience</span>
+                <span>{currentExperience} / {nextLevelExperience}</span>
+              </div>
+              <Progress value={levelProgress} aria-label="Progression vers le niveau suivant" />
+              <p className="text-xs text-muted-foreground">Encore {nextLevelExperience - currentExperience} pts avant le niveau 4.</p>
+            </div>
+            <div className="space-y-3">
+              <div className="flex items-start gap-3 rounded-lg border p-3">
+                <Sparkles className="h-4 w-4 text-primary" aria-hidden="true" />
+                <div>
+                  <p className="font-medium">Badge Sérénité</p>
+                  <p className="text-xs text-muted-foreground">3 séances de respiration consécutives</p>
+                </div>
+              </div>
+              <div className="flex items-start gap-3 rounded-lg border p-3">
+                <TrendingUp className="h-4 w-4 text-emerald-500" aria-hidden="true" />
+                <div>
+                  <p className="font-medium">Boost hebdo</p>
+                  <p className="text-xs text-muted-foreground">{lastWeek.total} séances réalisées cette semaine</p>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <Card className="lg:col-span-2">
+          <CardHeader className="pb-0">
+            <CardTitle>Séances par semaine</CardTitle>
+            <CardDescription>Répartition guidée, respiration, VR et journal</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="grid gap-4 sm:grid-cols-3">
+              <div>
+                <p className="text-xs uppercase text-muted-foreground">Moyenne</p>
+                <p className="text-2xl font-semibold">{sessionsAverage.toFixed(1)} séances</p>
+              </div>
+              <div>
+                <p className="text-xs uppercase text-muted-foreground">Semaine max</p>
+                <p className="text-2xl font-semibold">{lastWeek.week}</p>
+              </div>
+              <div>
+                <p className="text-xs uppercase text-muted-foreground">Guidées</p>
+                <p className="text-2xl font-semibold">{lastWeek.guided}</p>
+              </div>
+            </div>
+            <div className="h-[280px] w-full">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={weeklySessions} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+                  <CartesianGrid stroke={gridColor} strokeDasharray="3 3" />
+                  <XAxis dataKey="week" stroke={axisColor} />
+                  <YAxis stroke={axisColor} allowDecimals={false} />
+                  <Tooltip
+                    cursor={{ fill: "rgba(129, 140, 248, 0.1)" }}
+                    contentStyle={{ borderRadius: "0.75rem", borderColor: "rgba(148,163,184,0.4)", boxShadow: "0 10px 30px rgba(15, 23, 42, 0.15)" }}
+                  />
+                  <Legend />
+                  <Bar dataKey="guided" stackId="sessions" name="Guidées" fill={sessionPalette.guided} radius={[4, 4, 0, 0]} />
+                  <Bar dataKey="breathwork" stackId="sessions" name="Respiration" fill={sessionPalette.breathwork} radius={[4, 4, 0, 0]} />
+                  <Bar dataKey="vr" stackId="sessions" name="VR" fill={sessionPalette.vr} radius={[4, 4, 0, 0]} />
+                  <Bar dataKey="journaling" stackId="sessions" name="Journal" fill={sessionPalette.journaling} radius={[4, 4, 0, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-0">
+            <CardTitle>Focus de la semaine</CardTitle>
+            <CardDescription>Moments les plus vibrants</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="rounded-lg border bg-muted/40 p-4">
+              <p className="text-sm text-muted-foreground">Créneau le plus intense</p>
+              <p className="text-lg font-semibold">{mostIntenseSlot.day} — {mostIntenseSlot.slot}</p>
+              <p className="text-sm text-muted-foreground">{mostIntenseSlot.sessions} séances, vibe {mostIntenseSlot.dominantMood.toLowerCase()}</p>
+            </div>
+            <div className="space-y-3 text-sm">
+              <div className="flex items-center justify-between">
+                <span>Pic d'énergie</span>
+                <span>{formatDate(bestMoodDay.date)}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span>Sessions VR cumulées</span>
+                <span>{weeklySessions.reduce((acc, week) => acc + week.vr, 0)}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span>Respirations guidées</span>
+                <span>{weeklySessions.reduce((acc, week) => acc + week.breathwork, 0)}</span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-0">
+          <CardTitle>Heatmap Vibes</CardTitle>
+          <CardDescription>Intensité émotionnelle par moment clé de la journée</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="h-[320px] w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <ScatterChart margin={{ top: 20, right: 20, bottom: 10, left: 20 }}>
+                <CartesianGrid stroke={gridColor} strokeDasharray="3 3" />
+                <XAxis type="category" dataKey="slot" stroke={axisColor} allowDuplicatedCategory={false} />
+                <YAxis type="category" dataKey="day" stroke={axisColor} width={60} />
+                <Tooltip content={<HeatmapTooltip />} cursor={{ stroke: "rgba(148, 163, 184, 0.4)", strokeWidth: 1 }} />
+                <Scatter data={HEATMAP_DATA} shape={(props) => <HeatmapCell {...props} />}>
+                  {HEATMAP_DATA.map((entry) => (
+                    <Cell key={`${entry.day}-${entry.slot}`} fill={getHeatmapColor(entry.intensity)} />
+                  ))}
+                </Scatter>
+              </ScatterChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+            {[
+              { label: "Intense", value: 85 },
+              { label: "Élevé", value: 65 },
+              { label: "Modéré", value: 50 },
+              { label: "Calme", value: 30 },
+              { label: "Repos", value: 10 },
+            ].map(({ label, value }) => (
+              <div key={label} className="flex items-center gap-2">
+                <span className="h-3 w-6 rounded-full" style={{ backgroundColor: getHeatmapColor(value) }} />
+                <span>{label}</span>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </section>
+  );
+};
+
+export default ScoresV2Panel;


### PR DESCRIPTION
## Summary
- build the Scores V2 panel with Recharts charts covering mood trend, weekly sessions, and heatmap vibes
- surface derived stats, badges, and a ResizeObserver fallback so charts render in tests
- refresh the Scores V2 snapshot for the richer layout

## Testing
- npx vitest run src/__tests__/scores.v2.snapshot.spec.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ca88e84ae4832d823b9d86317af5eb