### PR TITLE
feat: enable sentry telemetry and surface platform health badge

### DIFF
--- a/src/components/ui/CriticalErrorBoundary.tsx
+++ b/src/components/ui/CriticalErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { AlertTriangle, RefreshCw, Home, Bug } from 'lucide-react';
+import * as Sentry from '@sentry/react';
 
 interface Props {
   children: ReactNode;
@@ -89,9 +90,8 @@ export class CriticalErrorBoundary extends Component<Props, State> {
 
   private reportError(error: Error, errorInfo: ErrorInfo, context?: string) {
     try {
-      // Si Sentry est configuré
-      if (typeof window !== 'undefined' && (window as any).Sentry) {
-        (window as any).Sentry.captureException(error, {
+      if (Sentry.getCurrentHub().getClient()) {
+        Sentry.captureException(error, {
           contexts: {
             react: {
               componentStack: errorInfo.componentStack
@@ -100,7 +100,7 @@ export class CriticalErrorBoundary extends Component<Props, State> {
           tags: {
             errorBoundary: context || 'CriticalErrorBoundary',
             feature: 'error-boundary',
-            errorType: error.message.includes('reading \'add\'') ? 'reading_add' : 'unknown'
+            errorType: error.message.includes("reading 'add'") ? 'reading_add' : 'unknown'
           },
           extra: {
             errorInfo,

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -5,10 +5,10 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { routes } from '@/routerV2';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTheme } from '@/components/theme-provider';
-import { 
-  Loader2, 
-  Menu, 
-  X, 
+import {
+  Loader2,
+  Menu,
+  X,
   Heart, 
   Bell, 
   Settings, 
@@ -35,6 +35,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';
 import { Link } from 'react-router-dom';
+import HealthCheckBadge from '@/components/HealthCheckBadge';
 
 // Enhanced layout component with premium sidebar and navigation
 const AppLayout: React.FC = () => {
@@ -270,14 +271,14 @@ const AppLayout: React.FC = () => {
         {/* Mobile Header */}
         <header className="lg:hidden sticky top-0 z-40 bg-background/95 backdrop-blur-md border-b">
           <div className="flex items-center justify-between p-4">
-            <Button 
-              variant="ghost" 
+            <Button
+              variant="ghost"
               size="sm"
               onClick={() => setSidebarOpen(true)}
             >
               <Menu className="w-5 h-5" />
             </Button>
-            
+
             <Link to="/app/home" className="flex items-center space-x-2">
               <div className="w-8 h-8 bg-gradient-to-br from-primary to-primary/70 rounded-lg flex items-center justify-center">
                 <Heart className="w-4 h-4 text-white" />
@@ -286,6 +287,7 @@ const AppLayout: React.FC = () => {
             </Link>
 
             <div className="flex items-center space-x-2">
+              <HealthCheckBadge />
               <Button variant="ghost" size="sm" className="relative">
                 <Bell className="w-5 h-5" />
                 {notifications > 0 && (
@@ -324,6 +326,9 @@ const AppLayout: React.FC = () => {
 
         {/* Page Content */}
         <main className="min-h-screen" role="main">
+          <div className="hidden lg:flex justify-end px-6 py-4 border-b bg-background/80 backdrop-blur-md">
+            <HealthCheckBadge />
+          </div>
           <AnimatePresence mode="wait">
             <motion.div
               key={location.pathname}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import './index.css';
 import './styles/accessibility.css';
 import './theme/theme.css';
 import { ThemeProvider, I18nProvider } from '@/COMPONENTS.reg';
+import { initializeSentry, monitorDOMErrors } from '@/lib/sentry-config';
 
 // Configuration de l'attribut lang pour l'accessibilité
 document.documentElement.lang = 'fr';
@@ -28,6 +29,11 @@ const addAccessibilityMeta = () => {
 };
 
 addAccessibilityMeta();
+
+if (typeof window !== 'undefined') {
+  initializeSentry();
+  monitorDOMErrors();
+}
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,13 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SENTRY_DSN?: string;
+  readonly VITE_SENTRY_ENVIRONMENT?: string;
+  readonly VITE_SENTRY_TRACES_SAMPLE_RATE?: string;
+  readonly VITE_SENTRY_REPLAYS_SESSION_SAMPLE_RATE?: string;
+  readonly VITE_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- initialize Sentry on the client with routing-safe guards and expose helpers for targeted error capture
- update the critical error boundary to rely on the initialized Sentry client instead of window checks
- surface the real-time HealthCheckBadge in the application layout for mobile and desktop users

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca89014c48832db232e164b96fef29