### PR TITLE
feat: add schema validation to unified auth forms

### DIFF
--- a/src/lib/validations/auth.ts
+++ b/src/lib/validations/auth.ts
@@ -26,6 +26,14 @@ export const registerSchema = z.object({
   path: ["confirmPassword"],
 });
 
+export const unifiedRegisterSchema = registerSchema.extend({
+  fullName: z
+    .string()
+    .trim()
+    .min(2, 'Le nom complet doit contenir au moins 2 caractères')
+    .max(100, 'Le nom complet ne peut pas dépasser 100 caractères')
+});
+
 export const resetPasswordSchema = z.object({
   email: z
     .string()
@@ -36,3 +44,4 @@ export const resetPasswordSchema = z.object({
 export type LoginFormData = z.infer<typeof loginSchema>;
 export type RegisterFormData = z.infer<typeof registerSchema>;
 export type ResetPasswordFormData = z.infer<typeof resetPasswordSchema>;
+export type UnifiedRegisterFormData = z.infer<typeof unifiedRegisterSchema>;


### PR DESCRIPTION
## Summary
- add a dedicated unified registration schema that validates full name input
- migrate the unified login/signup page to use react-hook-form with Zod-based validation and better error handling

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68ca890b32a8832d921d1daddf3c6fd2