### PR TITLE
test: cover mood mixer store and emotion scan mappers

### DIFF
--- a/src/__tests__/emotion-scan.mappers.test.ts
+++ b/src/__tests__/emotion-scan.mappers.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getEvents: vi.fn(),
+  computeSnapshot: vi.fn(),
+}));
+
+vi.mock('@/lib/scores/events', () => ({
+  getEvents: mocks.getEvents,
+}));
+
+vi.mock('@/lib/scores/compute', () => ({
+  computeSnapshot: mocks.computeSnapshot,
+}));
+
+import { getCoachContext, loadEmotionScanHistory01 } from '@/lib/coach/context';
+
+describe('emotion scan mappers', () => {
+  beforeEach(() => {
+    mocks.getEvents.mockReset();
+    mocks.computeSnapshot.mockReset();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('normalizes stored scan history between 0 and 1', () => {
+    localStorage.setItem('emotion_scan_history_v1', JSON.stringify([0, 50, 120]));
+
+    expect(loadEmotionScanHistory01()).toEqual([0, 0.5, 1]);
+  });
+
+  it('returns an empty array when history is missing or malformed', () => {
+    expect(loadEmotionScanHistory01()).toEqual([]);
+
+    localStorage.setItem('emotion_scan_history_v1', 'not-an-array');
+    expect(loadEmotionScanHistory01()).toEqual([]);
+  });
+
+  it('builds the coach context from stored events and history', () => {
+    vi.useFakeTimers();
+    const now = new Date('2024-03-12T09:15:00Z');
+    vi.setSystemTime(now);
+
+    localStorage.setItem('emotion_scan_history_v1', JSON.stringify([40, 85]));
+
+    mocks.getEvents.mockReturnValue([
+      { module: 'mood-mixer', startedAt: '2024-03-09T12:00:00Z' },
+      { module: 'emotion-scan', startedAt: '2024-03-10T12:00:00Z' },
+      { module: 'journal', startedAt: '2024-03-11T12:00:00Z' },
+      { module: 'coach', startedAt: '2024-03-12T12:00:00Z' },
+    ]);
+
+    mocks.computeSnapshot.mockReturnValue({
+      total: 179.6,
+      streakDays: 4,
+      level: 3,
+    });
+
+    const context = getCoachContext();
+
+    expect(context.nowHour).toBe(now.getHours());
+    expect(context.streakDays).toBe(4);
+    expect(context.totalPoints).toBe(180);
+    expect(context.lastScanBalance01).toBeCloseTo(0.85, 2);
+    expect(context.recentModules).toEqual(['coach', 'journal', 'emotion-scan']);
+  });
+});

--- a/src/__tests__/mood.store.test.ts
+++ b/src/__tests__/mood.store.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useMoodStore } from '@/store/mood.store';
+
+type StoreState = ReturnType<typeof useMoodStore.getState>;
+
+const resetStoreState = () => {
+  const defaults: Partial<StoreState> = {
+    sessionId: null,
+    status: 'idle',
+    cards: [],
+    blend: { joy: 0.5, calm: 0.5, energy: 0.5, focus: 0.5 },
+    trackUrl: null,
+    wsUrl: null,
+    answers: [],
+    humeSummary: null,
+    isPlaying: false,
+    currentPromptId: null,
+  };
+
+  useMoodStore.setState(defaults);
+};
+
+describe('useMoodStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    (useMoodStore as unknown as { persist?: { clearStorage?: () => void } }).persist?.clearStorage?.();
+    resetStoreState();
+  });
+
+  it('starts a session and primes the store state', () => {
+    const { startSession } = useMoodStore.getState();
+
+    startSession('session-123', 'wss://example.test');
+
+    const state = useMoodStore.getState();
+    expect(state.sessionId).toBe('session-123');
+    expect(state.status).toBe('starting');
+    expect(state.wsUrl).toBe('wss://example.test');
+    expect(state.answers).toEqual([]);
+    expect(state.humeSummary).toBeNull();
+  });
+
+  it('transitions to ending only when the session is running', () => {
+    const { endSession, startSession, setIsPlaying } = useMoodStore.getState();
+
+    startSession('session-active');
+    useMoodStore.setState({ status: 'active' });
+    setIsPlaying(true);
+
+    endSession();
+
+    const state = useMoodStore.getState();
+    expect(state.status).toBe('ending');
+    expect(state.isPlaying).toBe(false);
+
+    useMoodStore.setState({ status: 'idle' });
+    endSession();
+    expect(useMoodStore.getState().status).toBe('idle');
+  });
+
+  it('stores selected cards and updates the emotion blend accordingly', () => {
+    const { setCards } = useMoodStore.getState();
+    useMoodStore.setState({ blend: { joy: 0, calm: 0, energy: 0, focus: 0 } });
+
+    setCards(['joy', 'focus']);
+
+    const state = useMoodStore.getState();
+    expect(state.cards).toEqual(['joy', 'focus']);
+    expect(state.blend.joy).toBeCloseTo(0.3, 5);
+    expect(state.blend.focus).toBeCloseTo(0.3, 5);
+    expect(state.blend.calm).toBe(0);
+  });
+
+  it('merges new blend values without overwriting other axes', () => {
+    const { updateBlend } = useMoodStore.getState();
+
+    updateBlend({ joy: 0.9 });
+
+    const state = useMoodStore.getState();
+    expect(state.blend.joy).toBe(0.9);
+    expect(state.blend.calm).toBeCloseTo(0.5);
+  });
+
+  it('adds answers uniquely and replaces existing entries', () => {
+    const { addAnswer } = useMoodStore.getState();
+
+    addAnswer({ id: 'q1', value: 1 });
+    addAnswer({ id: 'q1', value: 3 });
+    addAnswer({ id: 'q2', value: 2 });
+
+    const state = useMoodStore.getState();
+    expect(state.answers).toHaveLength(2);
+    expect(state.answers.find(a => a.id === 'q1')?.value).toBe(3);
+  });
+
+  it('activates playback when a track URL is provided', () => {
+    const { setTrackUrl } = useMoodStore.getState();
+
+    setTrackUrl('/audio/test.mp3');
+
+    const state = useMoodStore.getState();
+    expect(state.trackUrl).toBe('/audio/test.mp3');
+    expect(state.status).toBe('active');
+  });
+
+  it('resets transient state but keeps the current session identifier', () => {
+    const { startSession, setCards, addAnswer, setIsPlaying, reset } = useMoodStore.getState();
+
+    startSession('session-reset');
+    useMoodStore.setState({ status: 'active', blend: { joy: 0.8, calm: 0.2, energy: 0.6, focus: 0.4 } });
+    setCards(['joy']);
+    addAnswer({ id: 'q1', value: 2 });
+    setIsPlaying(true);
+
+    reset();
+
+    const state = useMoodStore.getState();
+    expect(state.sessionId).toBe('session-reset');
+    expect(state.status).toBe('idle');
+    expect(state.cards).toEqual([]);
+    expect(state.answers).toEqual([]);
+    expect(state.blend).toEqual({ joy: 0.5, calm: 0.5, energy: 0.5, focus: 0.5 });
+    expect(state.isPlaying).toBe(false);
+  });
+});

--- a/src/__tests__/scores.compute.spec.ts
+++ b/src/__tests__/scores.compute.spec.ts
@@ -1,22 +1,76 @@
-import { describe, it, expect } from "vitest";
-import { computeStreakDays, bucketByDay, computeLevel, computeSnapshot } from "@/lib/scores/compute";
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { bucketByDay, computeBadges, computeLevel, computeSnapshot, computeStreakDays } from '@/lib/scores/compute';
+import type { SessionEvent } from '@/SCHEMA';
 
-describe("scores compute", () => {
-  it("streak calcule au moins 0", () => {
-    expect(computeStreakDays([])).toBe(0);
+describe('scores compute selectors', () => {
+  afterEach(() => {
+    vi.useRealTimers();
   });
-  it("bucketByDay regroupe par date", () => {
-    const b = bucketByDay([{ startedAt: "2025-01-01T10:00:00Z", durationSec: 300 }, { startedAt: "2025-01-01T11:00:00Z", durationSec: 60 }]);
-    expect(b[0].date).toBe("2025-01-01");
-    expect(Math.round(b[0].value || 0)).toBe(6); // 300+60 sec ~ 6 min
+
+  it('groups events by day and sums durations and scores', () => {
+    const events: SessionEvent[] = [
+      { startedAt: '2024-03-10T10:00:00Z', durationSec: 600 },
+      { startedAt: '2024-03-10T18:15:00Z', score: 5 },
+      { startedAt: '2024-03-09T09:00:00Z', durationSec: 120 },
+    ];
+
+    const buckets = bucketByDay(events);
+
+    expect(buckets).toHaveLength(2);
+    expect(buckets[0].date).toBe('2024-03-09');
+    expect(buckets[0].value).toBeCloseTo(2); // 120s -> 2 minutes
+    expect(buckets[1].date).toBe('2024-03-10');
+    expect(buckets[1].value).toBeCloseTo(15); // 10 minutes + score 5
   });
-  it("level augmente avec le total", () => {
-    const l1 = computeLevel(0), l2 = computeLevel(200);
-    expect(l2).toBeGreaterThanOrEqual(l1);
+
+  it('counts only consecutive days ending today for streaks', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-03-12T12:00:00Z'));
+
+    const events: SessionEvent[] = [
+      { startedAt: '2024-03-12T09:00:00Z', score: 2 },
+      { startedAt: '2024-03-11T09:00:00Z', score: 3 },
+      { startedAt: '2024-03-09T09:00:00Z', score: 4 },
+    ];
+
+    expect(computeStreakDays(events)).toBe(2);
   });
-  it("snapshot renvoie des champs clés", () => {
-    const s = computeSnapshot([]);
-    expect(s.total).toBeDefined();
-    expect(s.byDay).toBeDefined();
+
+  it('increases the level as total points grow', () => {
+    expect(computeLevel(0)).toBe(1);
+    expect(computeLevel(10)).toBeGreaterThanOrEqual(1);
+    expect(computeLevel(200)).toBeGreaterThan(computeLevel(10));
+  });
+
+  it('awards milestone badges based on streaks and totals', () => {
+    expect(computeBadges(0, 0)).toEqual([]);
+    expect(computeBadges(7, 120)).toEqual([
+      'first-session',
+      'streak-3',
+      'streak-7',
+      'centurion',
+    ]);
+  });
+
+  it('produces a consistent snapshot aggregation', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-03-12T12:00:00Z'));
+
+    const events: SessionEvent[] = [
+      { startedAt: '2024-03-12T10:00:00Z', score: 6 },
+      { startedAt: '2024-03-11T10:00:00Z', durationSec: 300 },
+      { startedAt: '2024-03-10T10:00:00Z', durationSec: 600 },
+    ];
+
+    const snapshot = computeSnapshot(events);
+
+    expect(snapshot.total).toBeCloseTo(21); // 6 + 5 + 10 minutes
+    expect(snapshot.streakDays).toBe(3);
+    expect(snapshot.badges).toEqual(['first-session', 'streak-3']);
+    expect(snapshot.byDay?.map(d => d.date)).toEqual([
+      '2024-03-10',
+      '2024-03-11',
+      '2024-03-12',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- add unit coverage for the mood mixer zustand store actions
- introduce tests for emotion scan history mapping and coach context assembly
- expand scores compute selectors tests with additional scenarios

## Testing
- `npx vitest run --reporter=basic` *(fails: existing suite failures such as safe-helpers, useMusicRecommendation, API service specs, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8925378c832da53610ab2ef03fe5