### PR TITLE
docs: document required environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,11 +2,24 @@
 # URL et clé publique de votre projet Supabase
 VITE_SUPABASE_URL=https://yaincoxihiqdksxgrsrk.supabase.co
 VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlhaW5jb3hpaGlxZGtzeGdyc3JrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDI4MTE4MjcsImV4cCI6MjA1ODM4NzgyN30.HBfwymB2F9VBvb3uyeTtHBMZFZYXzL0wQmS5fqd65yU
+# Clés supplémentaires utilisées par certains outils/scripts (optionnel)
+VITE_SUPABASE_PUBLISHABLE_KEY=
+VITE_SUPABASE_SERVICE_ROLE_KEY=
+
+# Accès serveur et scripts Supabase
+SUPABASE_URL=https://yaincoxihiqdksxgrsrk.supabase.co
+SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlhaW5jb3hpaGlxZGtzeGdyc3JrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDI4MTE4MjcsImV4cCI6MjA1ODM4NzgyN30.HBfwymB2F9VBvb3uyeTtHBMZFZYXzL0wQmS5fqd65yU
+SUPABASE_SERVICE_ROLE_KEY=
+SUPABASE_SERVICE_ROLE=
+SUPA_URL=
+SUPA_SERVICE_ROLE_KEY=
+NEXT_PUBLIC_SUPABASE_URL=
 
 # === API CONFIGURATION OPTIONNELLE ===
 # URLs de votre API (optionnel - valeurs par défaut incluses)
 VITE_API_URL=https://api.emotionscare.dev
 VITE_WEB_URL=http://localhost:3000
+BACKEND_BASE_URL=
 
 # === FIREBASE (OPTIONNEL) ===
 # Configuration Firebase pour fonctionnalités étendues
@@ -18,12 +31,84 @@ VITE_FIREBASE_MESSAGING_SENDER_ID=
 VITE_FIREBASE_APP_ID=
 VITE_FIREBASE_MEASUREMENT_ID=
 
+# === IA & INTÉGRATIONS EXTERNES ===
+# Renseignez vos clés si vous souhaitez activer les services IA
+VITE_OPENAI_API_KEY=
+OPENAI_API_KEY=
+NEXT_PUBLIC_OPENAI_API_KEY=
+HUME_API_KEY=
+NEXT_PUBLIC_HUME_API_KEY=
+SUNO_API_KEY=
+MUSIC_API_KEY=
+FAL_AI_API_KEY=
+
+# === EMAILS & PAIEMENTS ===
+RESEND_API_KEY=
+STRIPE_SECRET_KEY=
+
+# === NOTIFICATIONS PUSH ===
+VITE_VAPID_PUBLIC_KEY=
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+NEXT_PUBLIC_VAPID_KEY=
+
 # === PARAMÈTRES UPLOAD ===
 # Limites de taille et types de fichiers autorisés
 VITE_UPLOAD_MAX_SIZE=10485760
 VITE_ALLOWED_IMAGE_TYPES=image/jpeg,image/png,image/webp,image/avif
 VITE_ALLOWED_AUDIO_TYPES=audio/mpeg,audio/wav,audio/ogg
 
-# === DÉVELOPPEMENT ===
-# Variables pour environnement de développement local
+# === BASE DE DONNÉES LOCALE ===
+# Configuration PostgreSQL (utilisée par scripts/tests locaux)
+DATABASE_URL=
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=
+DB_USER=
+DB_PASS=
+TEST_DB_SECRET=
+
+# === SÉCURITÉ BACKEND ===
+JWT_SECRETS=
+HASH_PEPPER=
+
+# === TESTS & QUALITÉ ===
+PW_BASE_URL=http://localhost:3000
+PW_B2C_EMAIL=
+PW_B2C_PASSWORD=
+PLAYWRIGHT_BASE_URL=http://localhost:3000
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=
+
+# === ENVIRONNEMENT DE CONSTRUCTION (optionnel) ===
 NODE_ENV=development
+PORT=
+API_PORT=
+ANALYZE=
+USE_BUN=
+
+# Variables de confort pour les scripts (laisser vides si non utilisés)
+CYPRESS_INSTALL_BINARY=
+CYPRESS_SKIP_BINARY_CACHE=
+CYPRESS_SKIP_BINARY_INSTALL=
+HUSKY_SKIP_INSTALL=
+PUPPETEER_SKIP_DOWNLOAD=
+SKIP_HEAVY=
+SKIP_POSTINSTALL=
+SKIP_TEST_DEPS=
+SKIP_TYPE_CHECK=
+NODE_OPTIONS=
+TSC_NONPOLLING_WATCHER=
+TSC_COMPILE_ON_ERROR=
+ESBUILD_BINARY_PATH=
+
+# === DEBUG FRONTEND ===
+# Active/Désactive des outils côté client
+VITE_SENTRY_DSN=
+VITE_SENTRY_ENVIRONMENT=
+VITE_SENTRY_TRACES_SAMPLE_RATE=0.1
+VITE_SENTRY_REPLAYS_SESSION_SAMPLE_RATE=0
+VITE_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE=1
+
+# === AUTRES ===
+ADMIN_ID=
+


### PR DESCRIPTION
## Summary
- expand `.env.example` with the full set of Supabase credentials and related script variables
- add placeholders for AI integrations, notifications, database, and tooling environment keys so newcomers know what to configure

## Testing
- not run (documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68ca91774f54832d98a0252cc103d91b