### PR TITLE
docs: add automated UI component registry

### DIFF
--- a/docs/UI_COMPONENTS_REGISTRY.md
+++ b/docs/UI_COMPONENTS_REGISTRY.md
@@ -1,0 +1,68 @@
+# Registre des composants UI
+
+> 📌 Généré automatiquement le 17 septembre 2025 à 12:48 à partir de `src/COMPONENTS.reg.ts`. Utilisez `npm run generate:ui-registry` pour rafraîchir cette liste.
+
+
+## Statistiques rapides
+
+- **42** entrées référencées
+- Animation : 2
+- Audio : 1
+- Composant UI : 14
+- Consentement : 2
+- Feature flags : 5
+- Hook : 10
+- Internationalisation : 3
+- SEO : 1
+- Thème : 3
+- Visualisation : 1
+
+## Détails des exports
+
+| Export | Type | Source |
+| --- | --- | --- |
+| AudioPlayer | Audio | `src/ui/AudioPlayer` |
+| BadgeLevel | Composant UI | `src/ui/BadgeLevel` |
+| Button | Composant UI | `src/components/ui/button.tsx` |
+| Card | Composant UI | `src/components/ui/card.tsx` |
+| clearOverride | Feature flags | `src/lib/flags/rollout` |
+| CommandPalette | Composant UI | `src/ui/CommandPalette` |
+| ConstellationCanvas | Composant UI | `src/ui/ConstellationCanvas` |
+| CookieConsent | Consentement | `src/ui/CookieConsent` |
+| FadeIn | Animation | `src/ui/motion/FadeIn` |
+| FeedbackForm | Composant UI | `src/ui/FeedbackForm` |
+| flagActive | Feature flags | `src/lib/flags/rollout` |
+| Footer | Composant UI | `src/ui/Footer` |
+| getOverrides | Feature flags | `src/lib/flags/rollout` |
+| GlowSurface | Composant UI | `src/ui/GlowSurface` |
+| hasConsent | Consentement | `src/ui/CookieConsent` |
+| I18nProvider | Internationalisation | `src/lib/i18n/i18n` |
+| inCohort | Feature flags | `src/lib/flags/rollout` |
+| Input | Composant UI | `src/components/ui/input.tsx` |
+| LoadingSpinner | Composant UI | `src/components/ui/LoadingSpinner.tsx` |
+| NavBar | Composant UI | `src/ui/NavBar` |
+| PageHeader | Composant UI | `src/components/ui/PageHeader.tsx` |
+| ProgressBar | Visualisation | `src/ui/ProgressBar` |
+| SeoHead | SEO | `src/lib/seo/SeoHead` |
+| setOverride | Feature flags | `src/lib/flags/rollout` |
+| SlideIn | Animation | `src/ui/motion/SlideIn` |
+| Sparkline | Composant UI | `src/ui/Sparkline` |
+| t | Internationalisation | `src/lib/i18n/i18n` |
+| Textarea | Composant UI | `src/components/ui/textarea.tsx` |
+| ThemeProvider | Thème | `src/theme/ThemeProvider` |
+| ThemeToggle | Thème | `src/theme/ThemeProvider` |
+| useAudioBus | Hook | `src/ui/hooks/useAudioBus` |
+| useCommandPalette | Hook | `src/ui/CommandPalette` |
+| useCrossfade | Hook | `src/ui/hooks/useCrossfade` |
+| useDebounce | Hook | `src/ui/hooks/useDebounce` |
+| useI18n | Internationalisation | `src/lib/i18n/i18n` |
+| usePrefetchOnHover | Hook | `src/hooks/usePrefetchOnHover` |
+| usePulseClock | Hook | `src/ui/hooks/usePulseClock` |
+| useRaf | Hook | `src/ui/hooks/useRaf` |
+| useSound | Hook | `src/ui/hooks/useSound` |
+| useTheme | Thème | `src/theme/ThemeProvider` |
+| useThrottle | Hook | `src/ui/hooks/useThrottle` |
+| useTimer | Hook | `src/ui/hooks/useTimer` |
+
+_Généré pour faciliter l'exploration et la réutilisation des composants._
+

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "ci:guard": "npm run lock:check && npm run test:quick && npm run struct:verify",
     "lovable:push": "npm run ci:guard && lovable sync",
     "prepare": "husky",
-    "lock:check": "node scripts/validate-lockfile.mjs"
+    "lock:check": "node scripts/validate-lockfile.mjs",
+    "generate:ui-registry": "node scripts/generate-ui-registry.mjs"
   },
   "dependencies": {
     "@axe-core/playwright": "^4.10.2",

--- a/scripts/generate-ui-registry.mjs
+++ b/scripts/generate-ui-registry.mjs
@@ -1,0 +1,176 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+const REGISTRY_PATH = "src/COMPONENTS.reg.ts";
+const OUTPUT_PATH = "docs/UI_COMPONENTS_REGISTRY.md";
+
+async function readFileSafe(filePath) {
+  try {
+    return await fs.readFile(filePath, "utf8");
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return "";
+    }
+    throw error;
+  }
+}
+
+function normalizeSource(source) {
+  if (source.startsWith("./")) {
+    const trimmed = source.slice(2);
+    return trimmed.startsWith("src/") ? trimmed : `src/${trimmed}`;
+  }
+  if (source.startsWith("@/")) {
+    return source.replace(/^@\//, "src/");
+  }
+  return source;
+}
+
+function extractExports(code) {
+  const exports = [];
+  const regex = /export\s*\{\s*([^}]+?)\s*\}\s*from\s*["']([^"']+)["']/gs;
+
+  for (const match of code.matchAll(regex)) {
+    const namesBlock = match[1];
+    const source = match[2];
+    const normalizedSource = normalizeSource(source);
+
+    const tokens = namesBlock
+      .split(",")
+      .map((token) => token.trim())
+      .filter(Boolean);
+
+    for (const token of tokens) {
+      const aliasMatch = token.match(/^(?:default\s+as\s+)?(.+)$/i);
+      const rawName = aliasMatch ? aliasMatch[1] : token;
+      const name = rawName.replace(/\s+as\s+.*/, "").trim();
+      exports.push({ name, source: normalizedSource });
+    }
+  }
+
+  return exports;
+}
+
+function determineType(name, source) {
+  const lowerSource = source.toLowerCase();
+  const lowerName = name.toLowerCase();
+
+  if (lowerName === "t" || lowerSource.includes("/lib/i18n")) {
+    return "Internationalisation";
+  }
+
+  if (lowerSource.includes("/lib/seo")) {
+    return "SEO";
+  }
+
+  if (lowerSource.includes("/theme/")) {
+    return "Thème";
+  }
+
+  if (lowerSource.includes("/motion/")) {
+    return "Animation";
+  }
+
+  if (lowerSource.includes("/lib/flags/")) {
+    return "Feature flags";
+  }
+
+  if (name.startsWith("use") || lowerSource.includes("/hooks/")) {
+    return "Hook";
+  }
+
+  if (lowerName.includes("provider")) {
+    return "Provider";
+  }
+
+  if (lowerName.includes("consent")) {
+    return "Consentement";
+  }
+
+  if (lowerName.includes("audio")) {
+    return "Audio";
+  }
+
+  if (lowerName.includes("progress")) {
+    return "Visualisation";
+  }
+
+  if (name[0] === name[0]?.toLowerCase()) {
+    return "Utilitaire";
+  }
+
+  if (lowerSource.includes("/ui/")) {
+    return "Composant UI";
+  }
+
+  return "Utilitaire";
+}
+
+function formatDate(date) {
+  const formatter = new Intl.DateTimeFormat("fr-FR", {
+    dateStyle: "long",
+    timeStyle: "short",
+  });
+  return formatter.format(date);
+}
+
+function buildMarkdown(entries) {
+  const total = entries.length;
+  const counts = new Map();
+
+  for (const entry of entries) {
+    counts.set(entry.type, (counts.get(entry.type) ?? 0) + 1);
+  }
+
+  const now = new Date();
+  const lines = [];
+  lines.push("# Registre des composants UI\n");
+  lines.push(
+    `> 📌 Généré automatiquement le ${formatDate(now)} à partir de \`${REGISTRY_PATH}\`. Utilisez \`npm run generate:ui-registry\` pour rafraîchir cette liste.\n`
+  );
+  lines.push("\n## Statistiques rapides\n");
+  lines.push(`- **${total}** entrées référencées`);
+
+  const sortedCounts = [...counts.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  for (const [type, count] of sortedCounts) {
+    lines.push(`- ${type} : ${count}`);
+  }
+
+  lines.push("\n## Détails des exports\n");
+  lines.push("| Export | Type | Source |");
+  lines.push("| --- | --- | --- |");
+
+  for (const entry of entries) {
+    lines.push(`| ${entry.name} | ${entry.type} | \`${entry.source}\` |`);
+  }
+
+  lines.push("\n_Généré pour faciliter l'exploration et la réutilisation des composants._\n");
+
+  return lines.join("\n");
+}
+
+async function main() {
+  const code = await readFileSafe(REGISTRY_PATH);
+  if (!code) {
+    throw new Error(`Impossible de lire ${REGISTRY_PATH}.`);
+  }
+
+  const extracted = extractExports(code);
+  const enriched = extracted
+    .map((entry) => ({
+      ...entry,
+      type: determineType(entry.name, entry.source),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const markdown = buildMarkdown(enriched);
+  await fs.mkdir(path.dirname(OUTPUT_PATH), { recursive: true });
+  await fs.writeFile(OUTPUT_PATH, `${markdown}\n`, "utf8");
+
+  console.log(`✅ Registre généré (${enriched.length} entrées) → ${OUTPUT_PATH}`);
+}
+
+main().catch((error) => {
+  console.error("❌ Impossible de générer le registre UI:", error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a node script that parses `src/COMPONENTS.reg.ts` and writes a Markdown registry
- document the registry in `docs/UI_COMPONENTS_REGISTRY.md` with categorized exports
- expose an npm script to regenerate the registry on demand

## Testing
- node scripts/generate-ui-registry.mjs

------
https://chatgpt.com/codex/tasks/task_e_68ca916e5bcc832da88f6d6557c8146c