### PR TITLE
feat(observability): harden sentry wiring and validations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,9 @@
 import React from 'react';
 import { RouterProvider } from 'react-router-dom';
-import { RootProvider } from '@/providers';
 import { routerV2 } from '@/routerV2';
 
 function App() {
-  return (
-    <RootProvider>
-      <RouterProvider router={routerV2} />
-    </RootProvider>
-  );
+  return <RouterProvider router={routerV2} />;
 }
 
 export default App;

--- a/src/__tests__/__snapshots__/emotion-scan.snapshot.spec.tsx.snap
+++ b/src/__tests__/__snapshots__/emotion-scan.snapshot.spec.tsx.snap
@@ -4,18 +4,21 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
 <div>
   <main
     aria-label="Emotion Scan"
+    id="main-content"
   >
     <div>
       Emotion Scan
     </div>
     <div>
       <form>
-        <fieldset>
+        <fieldset
+          aria-invalid="false"
+        >
           <legend>
             Émotions positives
           </legend>
           <div
-            style="display: grid; grid-template-columns: 1fr auto auto auto auto auto; align-items: center; gap: 6px; padding-block: 4px;"
+            style="display: grid; grid-template-columns: 1fr repeat(5, minmax(32px, auto)); align-items: center; gap: 6px; padding-block: 4px;"
           >
             <label
               for="active-3"
@@ -28,6 +31,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="active-1"
                 name="active"
                 type="radio"
@@ -41,6 +45,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="active-2"
                 name="active"
                 type="radio"
@@ -54,6 +59,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="active-3"
                 name="active"
                 type="radio"
@@ -67,6 +73,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="active-4"
                 name="active"
                 type="radio"
@@ -80,6 +87,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="active-5"
                 name="active"
                 type="radio"
@@ -90,7 +98,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
             </label>
           </div>
           <div
-            style="display: grid; grid-template-columns: 1fr auto auto auto auto auto; align-items: center; gap: 6px; padding-block: 4px;"
+            style="display: grid; grid-template-columns: 1fr repeat(5, minmax(32px, auto)); align-items: center; gap: 6px; padding-block: 4px;"
           >
             <label
               for="determined-3"
@@ -103,6 +111,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="determined-1"
                 name="determined"
                 type="radio"
@@ -116,6 +125,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="determined-2"
                 name="determined"
                 type="radio"
@@ -129,6 +139,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="determined-3"
                 name="determined"
                 type="radio"
@@ -142,6 +153,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="determined-4"
                 name="determined"
                 type="radio"
@@ -155,6 +167,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="determined-5"
                 name="determined"
                 type="radio"
@@ -165,7 +178,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
             </label>
           </div>
           <div
-            style="display: grid; grid-template-columns: 1fr auto auto auto auto auto; align-items: center; gap: 6px; padding-block: 4px;"
+            style="display: grid; grid-template-columns: 1fr repeat(5, minmax(32px, auto)); align-items: center; gap: 6px; padding-block: 4px;"
           >
             <label
               for="attentive-3"
@@ -178,6 +191,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="attentive-1"
                 name="attentive"
                 type="radio"
@@ -191,6 +205,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="attentive-2"
                 name="attentive"
                 type="radio"
@@ -204,6 +219,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="attentive-3"
                 name="attentive"
                 type="radio"
@@ -217,6 +233,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="attentive-4"
                 name="attentive"
                 type="radio"
@@ -230,6 +247,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="attentive-5"
                 name="attentive"
                 type="radio"
@@ -240,7 +258,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
             </label>
           </div>
           <div
-            style="display: grid; grid-template-columns: 1fr auto auto auto auto auto; align-items: center; gap: 6px; padding-block: 4px;"
+            style="display: grid; grid-template-columns: 1fr repeat(5, minmax(32px, auto)); align-items: center; gap: 6px; padding-block: 4px;"
           >
             <label
               for="inspired-3"
@@ -253,6 +271,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="inspired-1"
                 name="inspired"
                 type="radio"
@@ -266,6 +285,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="inspired-2"
                 name="inspired"
                 type="radio"
@@ -279,6 +299,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="inspired-3"
                 name="inspired"
                 type="radio"
@@ -292,6 +313,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="inspired-4"
                 name="inspired"
                 type="radio"
@@ -305,6 +327,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="inspired-5"
                 name="inspired"
                 type="radio"
@@ -315,7 +338,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
             </label>
           </div>
           <div
-            style="display: grid; grid-template-columns: 1fr auto auto auto auto auto; align-items: center; gap: 6px; padding-block: 4px;"
+            style="display: grid; grid-template-columns: 1fr repeat(5, minmax(32px, auto)); align-items: center; gap: 6px; padding-block: 4px;"
           >
             <label
               for="alert-3"
@@ -328,6 +351,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="alert-1"
                 name="alert"
                 type="radio"
@@ -341,6 +365,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="alert-2"
                 name="alert"
                 type="radio"
@@ -354,6 +379,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="alert-3"
                 name="alert"
                 type="radio"
@@ -367,6 +393,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="alert-4"
                 name="alert"
                 type="radio"
@@ -380,6 +407,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="alert-5"
                 name="alert"
                 type="radio"
@@ -391,13 +419,14 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
           </div>
         </fieldset>
         <fieldset
+          aria-invalid="false"
           style="margin-top: 12px;"
         >
           <legend>
             Émotions négatives
           </legend>
           <div
-            style="display: grid; grid-template-columns: 1fr auto auto auto auto auto; align-items: center; gap: 6px; padding-block: 4px;"
+            style="display: grid; grid-template-columns: 1fr repeat(5, minmax(32px, auto)); align-items: center; gap: 6px; padding-block: 4px;"
           >
             <label
               for="upset-3"
@@ -410,6 +439,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="upset-1"
                 name="upset"
                 type="radio"
@@ -423,6 +453,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="upset-2"
                 name="upset"
                 type="radio"
@@ -436,6 +467,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="upset-3"
                 name="upset"
                 type="radio"
@@ -449,6 +481,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="upset-4"
                 name="upset"
                 type="radio"
@@ -462,6 +495,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="upset-5"
                 name="upset"
                 type="radio"
@@ -472,7 +506,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
             </label>
           </div>
           <div
-            style="display: grid; grid-template-columns: 1fr auto auto auto auto auto; align-items: center; gap: 6px; padding-block: 4px;"
+            style="display: grid; grid-template-columns: 1fr repeat(5, minmax(32px, auto)); align-items: center; gap: 6px; padding-block: 4px;"
           >
             <label
               for="hostile-3"
@@ -485,6 +519,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="hostile-1"
                 name="hostile"
                 type="radio"
@@ -498,6 +533,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="hostile-2"
                 name="hostile"
                 type="radio"
@@ -511,6 +547,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="hostile-3"
                 name="hostile"
                 type="radio"
@@ -524,6 +561,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="hostile-4"
                 name="hostile"
                 type="radio"
@@ -537,6 +575,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="hostile-5"
                 name="hostile"
                 type="radio"
@@ -547,7 +586,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
             </label>
           </div>
           <div
-            style="display: grid; grid-template-columns: 1fr auto auto auto auto auto; align-items: center; gap: 6px; padding-block: 4px;"
+            style="display: grid; grid-template-columns: 1fr repeat(5, minmax(32px, auto)); align-items: center; gap: 6px; padding-block: 4px;"
           >
             <label
               for="ashamed-3"
@@ -560,6 +599,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="ashamed-1"
                 name="ashamed"
                 type="radio"
@@ -573,6 +613,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="ashamed-2"
                 name="ashamed"
                 type="radio"
@@ -586,6 +627,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="ashamed-3"
                 name="ashamed"
                 type="radio"
@@ -599,6 +641,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="ashamed-4"
                 name="ashamed"
                 type="radio"
@@ -612,6 +655,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="ashamed-5"
                 name="ashamed"
                 type="radio"
@@ -622,7 +666,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
             </label>
           </div>
           <div
-            style="display: grid; grid-template-columns: 1fr auto auto auto auto auto; align-items: center; gap: 6px; padding-block: 4px;"
+            style="display: grid; grid-template-columns: 1fr repeat(5, minmax(32px, auto)); align-items: center; gap: 6px; padding-block: 4px;"
           >
             <label
               for="nervous-3"
@@ -635,6 +679,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="nervous-1"
                 name="nervous"
                 type="radio"
@@ -648,6 +693,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="nervous-2"
                 name="nervous"
                 type="radio"
@@ -661,6 +707,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="nervous-3"
                 name="nervous"
                 type="radio"
@@ -674,6 +721,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="nervous-4"
                 name="nervous"
                 type="radio"
@@ -687,6 +735,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="nervous-5"
                 name="nervous"
                 type="radio"
@@ -697,7 +746,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
             </label>
           </div>
           <div
-            style="display: grid; grid-template-columns: 1fr auto auto auto auto auto; align-items: center; gap: 6px; padding-block: 4px;"
+            style="display: grid; grid-template-columns: 1fr repeat(5, minmax(32px, auto)); align-items: center; gap: 6px; padding-block: 4px;"
           >
             <label
               for="afraid-3"
@@ -710,6 +759,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="afraid-1"
                 name="afraid"
                 type="radio"
@@ -723,6 +773,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="afraid-2"
                 name="afraid"
                 type="radio"
@@ -736,6 +787,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="afraid-3"
                 name="afraid"
                 type="radio"
@@ -749,6 +801,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="afraid-4"
                 name="afraid"
                 type="radio"
@@ -762,6 +815,7 @@ exports[`EmotionScanPage > rend la page et le CTA Calculer 1`] = `
               style="display: grid; place-items: center;"
             >
               <input
+                aria-invalid="false"
                 id="afraid-5"
                 name="afraid"
                 type="radio"

--- a/src/__tests__/audio.player.snapshot.spec.tsx
+++ b/src/__tests__/audio.player.snapshot.spec.tsx
@@ -1,8 +1,19 @@
-import { beforeEach, describe, it, expect } from "vitest";
+import { beforeAll, beforeEach, describe, it, expect, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { AudioPlayer } from "@/ui/AudioPlayer";
 
 describe("AudioPlayer", () => {
+  beforeAll(() => {
+    Object.defineProperty(window.HTMLMediaElement.prototype, "pause", {
+      configurable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(window.HTMLMediaElement.prototype, "play", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue(undefined),
+    });
+  });
+
   beforeEach(() => {
     window.localStorage.clear();
   });

--- a/src/__tests__/emotionScan.service.test.ts
+++ b/src/__tests__/emotionScan.service.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { mapScanRow } from '@/services/emotionScan.service';
+import type { EmotionScanRow } from '@/services/emotionScan.service';
+
+describe('emotionScan.service mapScanRow', () => {
+  const baseRow: EmotionScanRow = {
+    id: 'scan-1',
+    user_id: 'user-1',
+    created_at: '2024-09-01T10:00:00.000Z',
+    updated_at: null,
+    summary: 'Énergie positive et centrée.',
+    mood: 'calme',
+    confidence: 82,
+    emotional_balance: 64,
+    emotions: {
+      scores: {
+        joie: 6,
+        confiance: 5,
+        anticipation: 4,
+        surprise: 3,
+        tristesse: 1,
+        colere: 0,
+        peur: 1,
+        degout: 0,
+      },
+      insights: ['Respiration équilibrée.'],
+      context: 'Auto-évaluation I-PANAS-SF',
+    },
+    insights: ['Focus sur la respiration.'],
+    recommendations: ['Programmer une séance Breath Constellation.'],
+    scan_type: 'ipanassf',
+  } as EmotionScanRow;
+
+  it('conserve les champs principaux et normalise le score', () => {
+    const entry = mapScanRow(baseRow);
+
+    expect(entry.id).toBe('scan-1');
+    expect(entry.mood).toBe('calme');
+    expect(entry.summary).toMatch(/Énergie positive/);
+    expect(entry.confidence).toBe(82);
+    expect(entry.normalizedBalance).toBe(64);
+    expect(entry.insights).toEqual(['Focus sur la respiration.']);
+    expect(entry.recommendations).toEqual(['Programmer une séance Breath Constellation.']);
+    expect(entry.scores.joie).toBe(6);
+    expect(entry.scanType).toBe('ipanassf');
+  });
+
+  it('reconstitue le payload lorsque emotions est un dictionnaire simple', () => {
+    const rawRow: EmotionScanRow = {
+      ...baseRow,
+      id: 'scan-2',
+      emotional_balance: null,
+      emotions: {
+        joie: 7,
+        confiance: 6,
+        anticipation: 5,
+        surprise: 3,
+        tristesse: 2,
+        colere: 1,
+        peur: 0,
+        degout: 0,
+      } as unknown as EmotionScanRow['emotions'],
+      insights: null,
+      recommendations: [],
+    };
+
+    const entry = mapScanRow(rawRow);
+
+    expect(entry.id).toBe('scan-2');
+    expect(entry.normalizedBalance).toBeGreaterThan(0);
+    expect(entry.insights).toEqual([]);
+    expect(entry.recommendations).toEqual([]);
+    expect(entry.scores.joie).toBe(7);
+  });
+
+  it('utilise les insights embarqués lorsque la colonne est vide', () => {
+    const rowWithEmbeddedInsights: EmotionScanRow = {
+      ...baseRow,
+      id: 'scan-3',
+      insights: null,
+      emotions: {
+        scores: baseRow.emotions?.scores,
+        insights: ['Hydrate-toi avant la séance suivante.'],
+      } as unknown as EmotionScanRow['emotions'],
+    };
+
+    const entry = mapScanRow(rowWithEmbeddedInsights);
+
+    expect(entry.insights).toEqual(['Hydrate-toi avant la séance suivante.']);
+  });
+});

--- a/src/__tests__/moodPresets.store.test.ts
+++ b/src/__tests__/moodPresets.store.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MoodPresetRecord } from '@/types/mood-mixer';
+import { useMoodPresetsStore } from '@/store/moodPresets.store';
+import { moodPresetsService } from '@/services/moodPresetsService';
+
+vi.mock('@/services/moodPresetsService', () => ({
+  moodPresetsService: {
+    listPresets: vi.fn(),
+    createPreset: vi.fn(),
+    updatePreset: vi.fn(),
+    deletePreset: vi.fn(),
+  },
+}));
+
+const serviceMock = vi.mocked(moodPresetsService);
+
+const samplePreset = (overrides: Partial<MoodPresetRecord> = {}): MoodPresetRecord => ({
+  id: overrides.id ?? 'preset-1',
+  slug: overrides.slug ?? null,
+  userId: overrides.userId ?? 'user-1',
+  name: overrides.name ?? 'Morning Boost',
+  description: overrides.description ?? 'Réveil énergique',
+  icon: overrides.icon ?? 'sun',
+  gradient: overrides.gradient ?? 'from-orange-400 to-yellow-500',
+  tags: overrides.tags ?? ['Matin'],
+  softness: overrides.softness ?? 65,
+  clarity: overrides.clarity ?? 40,
+  blend: overrides.blend ?? { joy: 0.8, calm: 0.2, energy: 0.7, focus: 0.5 },
+  createdAt: overrides.createdAt ?? '2024-06-01T08:00:00.000Z',
+  updatedAt: overrides.updatedAt ?? '2024-06-01T08:00:00.000Z',
+});
+
+describe('useMoodPresetsStore', () => {
+  beforeEach(() => {
+    useMoodPresetsStore.getState().reset();
+    vi.clearAllMocks();
+  });
+
+  it('loads presets only once unless forced', async () => {
+    serviceMock.listPresets.mockResolvedValue([
+      samplePreset({ id: 'preset-1' }),
+      samplePreset({ id: 'preset-2', name: 'Focus Deep', createdAt: '2024-05-01T12:00:00.000Z' }),
+    ]);
+
+    const { loadPresets } = useMoodPresetsStore.getState();
+
+    const firstLoad = await loadPresets();
+    expect(firstLoad).toHaveLength(2);
+    expect(serviceMock.listPresets).toHaveBeenCalledTimes(1);
+
+    const secondLoad = await loadPresets();
+    expect(secondLoad).toHaveLength(2);
+    expect(serviceMock.listPresets).toHaveBeenCalledTimes(1);
+
+    await loadPresets({ force: true });
+    expect(serviceMock.listPresets).toHaveBeenCalledTimes(2);
+  });
+
+  it('deduplicates presets by id on load', async () => {
+    serviceMock.listPresets.mockResolvedValue([
+      samplePreset({ id: 'preset-1', updatedAt: '2024-06-02T10:00:00.000Z' }),
+      samplePreset({ id: 'preset-1', name: 'Duplicate', updatedAt: '2024-06-01T10:00:00.000Z' }),
+      samplePreset({ id: 'preset-2', name: 'Second Preset' }),
+    ]);
+
+    const { loadPresets } = useMoodPresetsStore.getState();
+    const presets = await loadPresets({ force: true });
+
+    expect(presets).toHaveLength(2);
+    expect(useMoodPresetsStore.getState().presets).toHaveLength(2);
+    expect(presets.some((preset) => preset.id === 'preset-1')).toBe(true);
+    expect(presets.some((preset) => preset.id === 'preset-2')).toBe(true);
+  });
+
+  it('creates a preset and selects it', async () => {
+    const created = samplePreset({ id: 'preset-created', name: 'Creative Flow' });
+    serviceMock.createPreset.mockResolvedValueOnce(created);
+
+    const { createPreset } = useMoodPresetsStore.getState();
+
+    const result = await createPreset({
+      name: created.name,
+      description: created.description,
+      blend: created.blend,
+      softness: created.softness,
+      clarity: created.clarity,
+      userId: created.userId,
+    });
+
+    expect(result).toEqual(created);
+    const state = useMoodPresetsStore.getState();
+    expect(state.presets[0]).toEqual(created);
+    expect(state.selectedPresetId).toBe('preset-created');
+    expect(state.isSaving).toBe(false);
+  });
+
+  it('updates an existing preset in place', async () => {
+    useMoodPresetsStore.setState({
+      presets: [samplePreset({ id: 'preset-1' })],
+      hasInitialized: true,
+    });
+
+    const updated = samplePreset({ id: 'preset-1', name: 'Sunrise Boost', softness: 72 });
+    serviceMock.updatePreset.mockResolvedValueOnce(updated);
+
+    const { updatePreset } = useMoodPresetsStore.getState();
+    const result = await updatePreset('preset-1', { name: 'Sunrise Boost', softness: 72 });
+
+    expect(result).toEqual(updated);
+    const state = useMoodPresetsStore.getState();
+    expect(state.presets).toHaveLength(1);
+    expect(state.presets[0].name).toBe('Sunrise Boost');
+    expect(state.presets[0].softness).toBe(72);
+    expect(state.selectedPresetId).toBe('preset-1');
+  });
+
+  it('removes a preset and clears selection when deleting the active one', async () => {
+    useMoodPresetsStore.setState({
+      presets: [
+        samplePreset({ id: 'preset-1', name: 'Morning' }),
+        samplePreset({ id: 'preset-2', name: 'Night' }),
+      ],
+      selectedPresetId: 'preset-2',
+    });
+
+    serviceMock.deletePreset.mockResolvedValueOnce(true);
+
+    const { deletePreset } = useMoodPresetsStore.getState();
+    const success = await deletePreset('preset-2');
+
+    expect(success).toBe(true);
+    const state = useMoodPresetsStore.getState();
+    expect(state.presets).toHaveLength(1);
+    expect(state.presets[0].id).toBe('preset-1');
+    expect(state.selectedPresetId).toBeNull();
+  });
+
+  it('exposes error messages when operations fail', async () => {
+    serviceMock.listPresets.mockRejectedValueOnce(new Error('Network down'));
+
+    const { loadPresets } = useMoodPresetsStore.getState();
+    await expect(loadPresets()).rejects.toThrow('Network down');
+
+    const stateAfterLoad = useMoodPresetsStore.getState();
+    expect(stateAfterLoad.error).toBe('Network down');
+
+    serviceMock.createPreset.mockRejectedValueOnce('Insert failed');
+    const { createPreset } = useMoodPresetsStore.getState();
+    await expect(createPreset({ name: 'Test', blend: { joy: 0.5, calm: 0.5, energy: 0.5, focus: 0.5 } })).rejects.toThrow('Insert failed');
+    expect(useMoodPresetsStore.getState().error).toBe('Insert failed');
+  });
+});

--- a/src/components/HeroVideo.tsx
+++ b/src/components/HeroVideo.tsx
@@ -1,6 +1,20 @@
 
 import React, { useState, useEffect } from 'react';
 
+const HeroFallbackImage: React.FC<{ className?: string; priority?: boolean }> = ({ className = '', priority = false }) => (
+  <picture className={`block w-full h-full ${className}`.trim()}>
+    <source srcSet="/hero/hero-fallback.avif" type="image/avif" />
+    <source srcSet="/hero/hero-fallback.webp" type="image/webp" />
+    <img
+      src="/hero/hero-fallback.webp"
+      alt="EmotionsCare - Plateforme de bien-être émotionnel"
+      className="w-full h-full object-cover"
+      loading={priority ? 'eager' : 'lazy'}
+      decoding="async"
+    />
+  </picture>
+);
+
 interface HeroVideoProps {
   className?: string;
 }
@@ -30,29 +44,16 @@ const HeroVideo: React.FC<HeroVideoProps> = ({ className = '' }) => {
 
   // Fallback vers l'image si vidéo désactivée, en erreur, ou pas encore chargée
   if (!shouldShowVideo || videoError) {
-    return (
-      <img
-        src="/hero/hero-fallback.webp"
-        alt="EmotionsCare - Plateforme de bien-être émotionnel"
-        className={`w-full h-full object-cover ${className}`}
-        loading="lazy"
-        onError={() => console.warn('[HeroVideo] Fallback image also failed to load')}
-      />
-    );
+    return <HeroFallbackImage className={className} priority={!shouldShowVideo} />;
   }
 
   return (
     <div className={`relative w-full h-full ${className}`}>
       {/* Afficher l'image en fallback pendant le chargement */}
       {!videoLoaded && (
-        <img
-          src="/hero/hero-fallback.webp"
-          alt="EmotionsCare - Plateforme de bien-être émotionnel"
-          className="absolute inset-0 w-full h-full object-cover"
-          loading="lazy"
-        />
+        <HeroFallbackImage className="absolute inset-0" />
       )}
-      
+
       <video
         className={`w-full h-full object-cover ${videoLoaded ? 'opacity-100' : 'opacity-0'} transition-opacity duration-500`}
         autoPlay
@@ -67,11 +68,7 @@ const HeroVideo: React.FC<HeroVideoProps> = ({ className = '' }) => {
         <source src="/hero/hero.mp4" type="video/mp4" />
         
         {/* Fallback pour navigateurs non compatibles */}
-        <img
-          src="/hero/hero-fallback.webp"
-          alt="EmotionsCare - Plateforme de bien-être émotionnel"
-          className="w-full h-full object-cover"
-        />
+        <HeroFallbackImage />
       </video>
     </div>
   );

--- a/src/components/dashboard/EmotionScanSection.tsx
+++ b/src/components/dashboard/EmotionScanSection.tsx
@@ -1,35 +1,223 @@
-
 import React from 'react';
+import { Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { Activity, ArrowRight, Clock } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Sparkline } from '@/COMPONENTS.reg';
+import {
+  EmotionScanHistoryEntry,
+  deriveScore10,
+  getEmotionScanHistory,
+} from '@/services/emotionScan.service';
 
-export interface EmotionScanSectionProps {
-  collapsed: boolean;
-  onToggle: () => void;
+interface EmotionScanSectionProps {
   userId?: string;
-  latestEmotion?: {
-    emotion: string;
-    score: number;
-  };
-  userMode?: string;
+  className?: string;
 }
 
-const EmotionScanSection: React.FC<EmotionScanSectionProps> = ({ 
-  collapsed, 
-  onToggle, 
-  userId,
-  latestEmotion,
-  userMode
-}) => {
-  return (
-    <div>
-      <p>Emotion Scan Section</p>
-      {latestEmotion && (
-        <div>
-          <p>Latest emotion: {latestEmotion.emotion}</p>
-          <p>Score: {latestEmotion.score}</p>
-        </div>
-      )}
-      {userMode && <p>User Mode: {userMode}</p>}
+function formatDate(value: string) {
+  try {
+    return new Intl.DateTimeFormat('fr-FR', {
+      day: '2-digit',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(new Date(value));
+  } catch {
+    return value;
+  }
+}
+
+function formatRelative(value: string) {
+  const date = new Date(value);
+  const now = Date.now();
+  const diffMinutes = Math.max(0, Math.round((now - date.getTime()) / (1000 * 60)));
+
+  if (diffMinutes < 1) {
+    return "à l'instant";
+  }
+  if (diffMinutes < 60) {
+    return `il y a ${diffMinutes} min`;
+  }
+
+  const diffHours = Math.round(diffMinutes / 60);
+  if (diffHours < 24) {
+    return `il y a ${diffHours} h`;
+  }
+
+  const diffDays = Math.round(diffHours / 24);
+  return `il y a ${diffDays} j`;
+}
+
+const EmptyState = () => (
+  <div className="flex flex-col items-start gap-3 rounded-lg border border-dashed p-6 text-left" role="status">
+    <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+      <Activity className="h-4 w-4" aria-hidden="true" />
+      Aucun scan enregistré pour le moment
     </div>
+    <p className="text-sm text-muted-foreground">
+      Lancez un premier Emotion Scan pour commencer à suivre votre équilibre émotionnel.
+    </p>
+    <Button asChild size="sm">
+      <Link to="/app/scan">Commencer un scan</Link>
+    </Button>
+  </div>
+);
+
+function TimelineSkeleton() {
+  return (
+    <div className="space-y-4" aria-hidden="true">
+      <Skeleton className="h-16 w-full" />
+      <div className="space-y-3">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div key={index} className="space-y-2">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-5 w-full" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function LatestScan({ entry }: { entry: EmotionScanHistoryEntry }) {
+  const score10 = deriveScore10(entry.normalizedBalance).toFixed(1);
+
+  return (
+    <div className="rounded-lg border bg-muted/40 p-4" data-testid="emotion-scan-latest">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Clock className="h-4 w-4" aria-hidden="true" />
+          <span>{formatRelative(entry.createdAt)}</span>
+        </div>
+        <Badge variant="secondary" className="capitalize" aria-label={`Humeur dominante ${entry.mood ?? 'indéterminée'}`}>
+          {entry.mood ?? 'Indéterminé'}
+        </Badge>
+      </div>
+      <div className="mt-3 flex flex-wrap items-baseline gap-3">
+        <p className="text-3xl font-semibold" aria-label={`Score émotionnel ${score10} sur 10`}>
+          {score10}
+          <span className="text-base text-muted-foreground">/10</span>
+        </p>
+        <span className="text-sm text-muted-foreground">Confiance {Math.round(entry.confidence)}%</span>
+      </div>
+      {entry.summary && (
+        <p className="mt-3 text-sm text-muted-foreground">
+          {entry.summary}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function Timeline({ entries }: { entries: EmotionScanHistoryEntry[] }) {
+  return (
+    <ol
+      className="relative space-y-4 border-l border-border pl-5"
+      aria-label="Timeline des scans émotionnels"
+      data-testid="emotion-scan-timeline"
+    >
+      {entries.map((entry) => {
+        const score = deriveScore10(entry.normalizedBalance).toFixed(1);
+        return (
+          <li key={entry.id} className="relative pl-3" data-testid="emotion-scan-timeline-item">
+            <span className="absolute -left-5 top-2 h-2.5 w-2.5 rounded-full border border-background bg-primary" aria-hidden="true" />
+            <div className="flex flex-wrap items-center justify-between gap-2 text-sm font-medium">
+              <span>{formatDate(entry.createdAt)}</span>
+              <span>{score}/10</span>
+            </div>
+            <div className="mt-1 flex flex-wrap items-center gap-2">
+              <Badge variant="outline" className="capitalize">
+                {entry.mood ?? 'Indéterminé'}
+              </Badge>
+              {entry.insights[0] && (
+                <span className="text-xs text-muted-foreground">
+                  {entry.insights[0]}
+                </span>
+              )}
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+const EmotionScanSection: React.FC<EmotionScanSectionProps> = ({ userId, className }) => {
+  const isAuthenticated = Boolean(userId);
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['emotion-scan-history', userId],
+    queryFn: () => getEmotionScanHistory(userId!, 12),
+    enabled: isAuthenticated,
+    staleTime: 60 * 1000,
+  });
+
+  const history = React.useMemo(() => (data ?? []), [data]);
+  const sparklineValues = React.useMemo(
+    () => history.slice().reverse().map((entry) => entry.normalizedBalance),
+    [history],
+  );
+  const timelineEntries = React.useMemo(() => history.slice(0, 6), [history]);
+  const latestEntry = history[0];
+
+  return (
+    <Card className={className} data-testid="dashboard-emotion-scan">
+      <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-4">
+        <div className="space-y-1">
+          <CardTitle className="text-lg font-semibold">Derniers scans émotionnels</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Visualisez l'évolution de votre équilibre émotionnel et revisitez vos derniers insights.
+          </p>
+        </div>
+        <Button asChild variant="outline" size="sm">
+          <Link to="/app/scan" className="inline-flex items-center gap-1">
+            Nouveau scan
+            <ArrowRight className="h-4 w-4" aria-hidden="true" />
+          </Link>
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {!isAuthenticated && (
+          <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
+            Connectez-vous pour synchroniser vos résultats Emotion Scan avec le dashboard.
+          </div>
+        )}
+
+        {isAuthenticated && isLoading && <TimelineSkeleton />}
+
+        {isAuthenticated && isError && (
+          <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive" role="alert">
+            Impossible de récupérer votre historique de scans pour le moment.
+          </div>
+        )}
+
+        {isAuthenticated && !isLoading && !isError && history.length === 0 && <EmptyState />}
+
+        {isAuthenticated && !isLoading && !isError && history.length > 0 && (
+          <div className="space-y-6">
+            {latestEntry && <LatestScan entry={latestEntry} />}
+
+            {sparklineValues.length > 1 && (
+              <div className="rounded-lg border bg-muted/30 p-4" role="presentation">
+                <div className="flex items-center justify-between text-sm text-muted-foreground">
+                  <span>Tendance des 12 derniers scans</span>
+                  <span>{sparklineValues[sparklineValues.length - 1].toFixed(0)} / 100</span>
+                </div>
+                <div className="mt-3 overflow-x-auto">
+                  <Sparkline values={sparklineValues} width={Math.max(240, sparklineValues.length * 28)} height={64} />
+                </div>
+              </div>
+            )}
+
+            {timelineEntries.length > 0 && <Timeline entries={timelineEntries} />}
+          </div>
+        )}
+      </CardContent>
+    </Card>
   );
 };
 

--- a/src/components/dashboard/JournalSummaryCard.tsx
+++ b/src/components/dashboard/JournalSummaryCard.tsx
@@ -1,0 +1,173 @@
+import React, { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import { NotebookPen, Loader2, Tag, ArrowRight, Sparkles } from 'lucide-react';
+
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { fetchJournalFeed, type JournalFeedEntry } from '@/services/journalFeed.service';
+
+type JournalSummaryCardProps = {
+  userId?: string;
+};
+
+const formatDateTime = (iso: string) => {
+  try {
+    return new Intl.DateTimeFormat('fr-FR', {
+      day: '2-digit',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+};
+
+const THIRTY_DAYS = 30 * 24 * 60 * 60 * 1000;
+
+const computeTopTags = (entries: JournalFeedEntry[]) => {
+  const counts = new Map<string, number>();
+  entries.forEach((entry) => {
+    entry.tags.forEach((tag) => {
+      counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    });
+  });
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 3);
+};
+
+export const JournalSummaryCard: React.FC<JournalSummaryCardProps> = ({ userId }) => {
+  const {
+    data: entries = [],
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ['journal-feed-summary', userId],
+    queryFn: fetchJournalFeed,
+    enabled: Boolean(userId),
+    staleTime: 60_000,
+  });
+
+  const latestEntry = entries[0];
+  const { recentCount, uniqueTags, topTags } = useMemo(() => {
+    const now = Date.now();
+    const recent = entries.filter((entry) => now - new Date(entry.timestamp).getTime() <= THIRTY_DAYS).length;
+    const tagSet = new Set<string>();
+    entries.forEach((entry) => entry.tags.forEach((tag) => tagSet.add(tag)));
+    return {
+      recentCount: recent,
+      uniqueTags: tagSet.size,
+      topTags: computeTopTags(entries),
+    };
+  }, [entries]);
+
+  return (
+    <Card>
+      <CardHeader className="space-y-1">
+        <CardTitle className="flex items-center gap-2 text-base font-semibold">
+          <NotebookPen className="h-4 w-4 text-primary" aria-hidden="true" />
+          <span>Journal récent</span>
+        </CardTitle>
+        <CardDescription>Un aperçu des dernières réflexions consignées.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {!userId && (
+          <div className="flex flex-col gap-3 text-sm text-muted-foreground">
+            <p>Connectez-vous pour retrouver vos entrées et vos tags favoris.</p>
+            <Button asChild size="sm">
+              <Link to="/login">Se connecter</Link>
+            </Button>
+          </div>
+        )}
+
+        {userId && isLoading && (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground" aria-live="polite">
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            <span>Chargement du journal…</span>
+          </div>
+        )}
+
+        {userId && isError && (
+          <p role="alert" className="text-sm text-destructive">
+            {(error as Error)?.message ?? 'Impossible de charger le résumé du journal.'}
+          </p>
+        )}
+
+        {userId && !isLoading && !isError && !entries.length && (
+          <div className="flex items-center gap-3 rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+            <Sparkles className="h-4 w-4" aria-hidden="true" />
+            <span>Commencez une première entrée pour activer le suivi de vos émotions.</span>
+          </div>
+        )}
+
+        {userId && latestEntry && (
+          <div className="space-y-4">
+            <div className="rounded-lg border p-4">
+              <div className="flex items-center justify-between text-xs text-muted-foreground">
+                <span>Dernière entrée</span>
+                <time dateTime={latestEntry.timestamp}>{formatDateTime(latestEntry.timestamp)}</time>
+              </div>
+              <p className="mt-2 text-sm leading-relaxed text-foreground">
+                {latestEntry.summary ?? latestEntry.text}
+              </p>
+              {latestEntry.tags.length > 0 && (
+                <div className="mt-3 flex flex-wrap gap-2" aria-label="Tags de la dernière entrée">
+                  {latestEntry.tags.slice(0, 4).map((tag) => (
+                    <Badge key={tag} variant="outline" className="text-xs uppercase tracking-wide">
+                      #{tag}
+                    </Badge>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div className="grid gap-3 rounded-lg border p-4 sm:grid-cols-3">
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">Entrées (30 derniers jours)</p>
+                <p className="text-lg font-semibold text-foreground">{recentCount}</p>
+              </div>
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">Tags actifs</p>
+                <p className="text-lg font-semibold text-foreground">{uniqueTags}</p>
+              </div>
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">Top tags</p>
+                <div className="flex flex-wrap gap-2">
+                  {topTags.length ? (
+                    topTags.map(([tag, count]) => (
+                      <span key={tag} className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-1 text-xs">
+                        <Tag className="h-3 w-3" aria-hidden="true" />
+                        <span>#{tag}</span>
+                        <span className="text-muted-foreground">×{count}</span>
+                      </span>
+                    ))
+                  ) : (
+                    <span className="text-xs text-muted-foreground">Aucun tag récurrent</span>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between gap-2 rounded-lg bg-muted/40 p-3 text-sm">
+              <div className="text-muted-foreground">
+                <p className="font-medium text-foreground">Poursuivre l'écriture</p>
+                <p>Enrichissez votre progression émotionnelle quotidienne.</p>
+              </div>
+              <Button asChild size="sm" variant="secondary">
+                <Link to="/app/journal" className="inline-flex items-center gap-1">
+                  Ouvrir <ArrowRight className="h-3 w-3" aria-hidden="true" />
+                </Link>
+              </Button>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default JournalSummaryCard;

--- a/src/components/error/HttpErrorLayout.tsx
+++ b/src/components/error/HttpErrorLayout.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import type { LucideIcon } from 'lucide-react';
+import { AlertTriangle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface HttpErrorAction {
+  label: string;
+  to?: string;
+  onClick?: () => void;
+  variant?: 'default' | 'secondary' | 'outline' | 'ghost';
+  icon?: LucideIcon;
+}
+
+interface HttpErrorSuggestion {
+  label: string;
+  href: string;
+  description?: string;
+}
+
+interface HttpErrorLayoutProps {
+  statusCode: number;
+  title: string;
+  description: string;
+  icon?: LucideIcon;
+  actions?: HttpErrorAction[];
+  suggestions?: HttpErrorSuggestion[];
+  supportText?: string;
+}
+
+const HttpErrorLayout: React.FC<HttpErrorLayoutProps> = ({
+  statusCode,
+  title,
+  description,
+  icon: Icon = AlertTriangle,
+  actions = [],
+  suggestions = [],
+  supportText,
+}) => {
+  return (
+    <div
+      className="min-h-screen bg-gradient-to-br from-background via-background to-muted/30 flex items-center justify-center p-6"
+      data-testid="page-root"
+    >
+      <div className="w-full max-w-4xl space-y-8">
+        <Card className="text-center shadow-lg border border-border/60">
+          <CardHeader className="space-y-6">
+            <div className="flex justify-center">
+              <span className="inline-flex h-20 w-20 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <Icon className="h-10 w-10" aria-hidden="true" />
+              </span>
+            </div>
+
+            <div className="space-y-2">
+              <p className="text-sm font-semibold tracking-[0.35em] text-muted-foreground uppercase">
+                {statusCode}
+              </p>
+              <CardTitle className="text-3xl">{title}</CardTitle>
+              <CardDescription className="text-base leading-relaxed text-muted-foreground">
+                {description}
+              </CardDescription>
+            </div>
+          </CardHeader>
+
+          {actions.length > 0 && (
+            <CardContent className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:justify-center">
+              {actions.map(action => {
+                const ActionIcon = action.icon;
+                const content = (
+                  <>
+                    {ActionIcon ? <ActionIcon className="mr-2 h-4 w-4" aria-hidden="true" /> : null}
+                    {action.label}
+                  </>
+                );
+
+                if (action.to) {
+                  return (
+                    <Button key={`${action.label}-${action.to}`} variant={action.variant ?? 'default'} size="lg" asChild>
+                      <Link to={action.to}>{content}</Link>
+                    </Button>
+                  );
+                }
+
+                return (
+                  <Button
+                    key={action.label}
+                    variant={action.variant ?? 'default'}
+                    size="lg"
+                    onClick={action.onClick}
+                  >
+                    {content}
+                  </Button>
+                );
+              })}
+            </CardContent>
+          )}
+        </Card>
+
+        {(suggestions.length > 0 || supportText) && (
+          <Card className="border-dashed border-border/60">
+            <CardHeader>
+              <CardTitle className="text-lg font-semibold">Raccourcis utiles</CardTitle>
+              {supportText ? (
+                <CardDescription className="text-muted-foreground">{supportText}</CardDescription>
+              ) : null}
+            </CardHeader>
+
+            {suggestions.length > 0 && (
+              <CardContent className="grid gap-3 sm:grid-cols-2">
+                {suggestions.map(suggestion => (
+                  <Link
+                    key={`${suggestion.href}-${suggestion.label}`}
+                    to={suggestion.href}
+                    className="flex flex-col rounded-lg border border-border/60 p-4 transition hover:border-primary/60 hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                  >
+                    <span className="font-medium text-foreground">{suggestion.label}</span>
+                    {suggestion.description ? (
+                      <span className="text-sm text-muted-foreground">{suggestion.description}</span>
+                    ) : null}
+                  </Link>
+                ))}
+              </CardContent>
+            )}
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export type { HttpErrorAction, HttpErrorSuggestion };
+export default HttpErrorLayout;

--- a/src/components/mood-mixer/index.ts
+++ b/src/components/mood-mixer/index.ts
@@ -5,3 +5,4 @@ export { default as PlaybackControls } from './PlaybackControls';
 export { default as MoodVisualization } from './MoodVisualization';
 export { default as MixLibrary } from './MixLibrary';
 export { default as SessionInsights } from './SessionInsights';
+export { default as PresetSelector } from './PresetSelector';

--- a/src/hooks/useJournalFeed.ts
+++ b/src/hooks/useJournalFeed.ts
@@ -63,10 +63,8 @@ export const useJournalFeed = () => {
   };
 
   const entriesSource: JournalFeedEntry[] = useMemo(() => {
-    if (user?.id) {
-      return remoteEntries;
-    }
-    return localEntries.map(mapLocalEntry);
+    const base = user?.id ? remoteEntries : localEntries.map(mapLocalEntry);
+    return [...base].sort((a, b) => b.timestamp.localeCompare(a.timestamp));
   }, [localEntries, remoteEntries, user?.id]);
 
   const availableTags = useMemo(() => {

--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -1,0 +1,69 @@
+const HEX_TABLE = Array.from({ length: 256 }, (_, index) => index.toString(16).padStart(2, "0"));
+
+function resolveSubtleCrypto(): SubtleCrypto | null {
+  const globalCrypto = typeof globalThis !== "undefined" ? (globalThis as typeof globalThis & { webcrypto?: Crypto }) : undefined;
+  if (globalCrypto?.crypto?.subtle) {
+    return globalCrypto.crypto.subtle;
+  }
+
+  if (globalCrypto?.webcrypto?.subtle) {
+    return globalCrypto.webcrypto.subtle;
+  }
+
+  if (typeof globalThis !== "undefined" && (globalThis as { crypto?: Crypto }).crypto?.subtle) {
+    return (globalThis as { crypto?: Crypto }).crypto!.subtle;
+  }
+
+  return null;
+}
+
+function toHex(buffer: ArrayBuffer): string {
+  const view = new Uint8Array(buffer);
+  let hex = "";
+  for (let index = 0; index < view.length; index += 1) {
+    hex += HEX_TABLE[view[index]!];
+  }
+  return hex;
+}
+
+function fallbackHash(value: string): string {
+  if (!value.length) {
+    return "";
+  }
+
+  // Non cryptographique : suffisant pour des identifiants anonymisés en fallback.
+  const encoder = new TextEncoder();
+  const input = encoder.encode(value);
+  const bytes = new Uint8Array(32);
+
+  for (let index = 0; index < bytes.length; index += 1) {
+    const charCode = input[index % input.length] ?? index;
+    const prev = bytes[(index + bytes.length - 1) % bytes.length] ?? 0;
+    const mixed = prev ^ charCode ^ ((index * 31) & 0xff);
+    bytes[index] = (mixed + ((mixed << 3) & 0xff)) & 0xff;
+  }
+
+  return Array.from(bytes, byte => HEX_TABLE[byte]).join("");
+}
+
+export async function hashString(value: string): Promise<string> {
+  if (typeof value !== "string" || value.length === 0) {
+    return "";
+  }
+
+  const subtle = resolveSubtleCrypto();
+
+  if (!subtle) {
+    return fallbackHash(value);
+  }
+
+  const encoder = new TextEncoder();
+  const data = encoder.encode(value);
+  const digest = await subtle.digest("SHA-256", data);
+  return toHex(digest);
+}
+
+export const __hashInternals = {
+  resolveSubtleCrypto,
+  fallbackHash,
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,25 +1,28 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App';
+import { RouterProvider } from 'react-router-dom';
 import './index.css';
 import './styles/accessibility.css';
 import './theme/theme.css';
-import { ThemeProvider, I18nProvider } from '@/COMPONENTS.reg';
+import '@/lib/i18n';
 import { initializeSentry, monitorDOMErrors } from '@/lib/sentry-config';
+import { RootProvider } from '@/providers';
+import { routerV2 } from '@/routerV2';
 
 // Configuration de l'attribut lang pour l'accessibilité
 document.documentElement.lang = 'fr';
-document.title = 'EmotionsCare - Plateforme d\'intelligence émotionnelle';
+document.title = "EmotionsCare - Plateforme d'intelligence émotionnelle";
 
 // Ajouter les métadonnées d'accessibilité essentielles
 const addAccessibilityMeta = () => {
   if (!document.querySelector('meta[name="description"]')) {
     const metaDesc = document.createElement('meta');
     metaDesc.name = 'description';
-    metaDesc.content = 'Plateforme d\'intelligence émotionnelle pour le bien-être personnel et professionnel. Analysez et améliorez vos émotions avec nos outils innovants.';
+    metaDesc.content =
+      "Plateforme d'intelligence émotionnelle pour le bien-être personnel et professionnel. Analysez et améliorez vos émotions avec nos outils innovants.";
     document.head.appendChild(metaDesc);
   }
-  
+
   if (!document.querySelector('meta[name="viewport"]')) {
     const metaViewport = document.createElement('meta');
     metaViewport.name = 'viewport';
@@ -37,10 +40,8 @@ if (typeof window !== 'undefined') {
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <ThemeProvider>
-      <I18nProvider>
-        <App />
-      </I18nProvider>
-    </ThemeProvider>
-  </React.StrictMode>
+    <RootProvider>
+      <RouterProvider router={routerV2} />
+    </RootProvider>
+  </React.StrictMode>,
 );

--- a/src/modules/breath-constellation/BreathConstellationPage.tsx
+++ b/src/modules/breath-constellation/BreathConstellationPage.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { useReducedMotion } from "framer-motion";
 import { PageHeader, Card, Button } from "@/COMPONENTS.reg";
 import { ConstellationCanvas } from "@/COMPONENTS.reg";
-import { useBreathPattern, type Pattern, type Phase } from "@/ui/hooks/useBreathPattern";
+import { useBreathPattern, type Phase } from "@/ui/hooks/useBreathPattern";
 import { useSound } from "@/COMPONENTS.reg";
 import { ff } from "@/lib/flags/ff";
 import { recordEvent } from "@/lib/scores/events";
@@ -13,133 +13,17 @@ import {
   BreathworkSessionAuthError,
   BreathworkSessionPersistError,
 } from "@/services/breathworkSessions.service";
-
-type BreathProtocolId = "coherence-5-5" | "4-7-8" | "box-4-4-4-4" | "triangle-4-6-8";
-
-type BreathProtocolDefinition = {
-  id: BreathProtocolId;
-  label: string;
-  description: string;
-  focus: string;
-  benefits: string[];
-  recommendedCycles: number;
-  recommendedDensity: number;
-  pattern: Pattern;
-};
-
-type BreathProtocol = BreathProtocolDefinition & {
-  cycleDuration: number;
-  cadence: number;
-};
+import {
+  BREATH_PROTOCOL_SEQUENCE,
+  DEFAULT_PROTOCOL_ID,
+  PHASE_DESCRIPTIONS,
+  PHASE_LABELS,
+  PROTOCOLS_BY_ID,
+  type BreathProtocol,
+  type BreathProtocolId,
+} from "./protocols";
 
 type SaveStatus = "idle" | "saving" | "saved" | "error" | "unauthenticated";
-
-const PHASE_LABELS: Record<Phase, string> = {
-  inhale: "Inspiration",
-  hold: "Rétention pleine",
-  exhale: "Expiration",
-  hold2: "Rétention basse",
-};
-
-const PHASE_DESCRIPTIONS: Record<Phase, string> = {
-  inhale: "Soulevez doucement la cage thoracique et remplissez vos poumons.",
-  hold: "Suspendez la respiration, épaules relâchées.",
-  exhale: "Relâchez l'air sans effort, videz complètement.",
-  hold2: "Gardez les poumons vides dans le calme avant le prochain cycle.",
-};
-
-const PROTOCOL_DEFINITIONS: BreathProtocolDefinition[] = [
-  {
-    id: "coherence-5-5",
-    label: "Cohérence cardiaque 5-5",
-    description: "6 respirations par minute pour réguler le système nerveux.",
-    focus: "Équilibre & clarté",
-    benefits: [
-      "Stabilise la variabilité cardiaque",
-      "Idéal pour une pause active ou avant une réunion",
-    ],
-    recommendedCycles: 10,
-    recommendedDensity: 0.8,
-    pattern: [
-      { phase: "inhale", sec: 5 },
-      { phase: "exhale", sec: 5 },
-    ],
-  },
-  {
-    id: "4-7-8",
-    label: "Sommeil profond 4-7-8",
-    description: "Allonge l'expiration pour apaiser le mental et préparer le repos.",
-    focus: "Apaisement & lâcher-prise",
-    benefits: [
-      "Réduit rapidement la tension accumulée",
-      "Facilite l'endormissement et calme les ruminations",
-    ],
-    recommendedCycles: 6,
-    recommendedDensity: 0.7,
-    pattern: [
-      { phase: "inhale", sec: 4 },
-      { phase: "hold", sec: 7 },
-      { phase: "exhale", sec: 8 },
-    ],
-  },
-  {
-    id: "box-4-4-4-4",
-    label: "Carré 4-4-4-4",
-    description: "Rythme symétrique pour la concentration et la préparation mentale.",
-    focus: "Focus & préparation",
-    benefits: [
-      "Améliore la clarté d'esprit",
-      "Structure la respiration avant un effort cognitif",
-    ],
-    recommendedCycles: 12,
-    recommendedDensity: 0.9,
-    pattern: [
-      { phase: "inhale", sec: 4 },
-      { phase: "hold", sec: 4 },
-      { phase: "exhale", sec: 4 },
-      { phase: "hold2", sec: 4 },
-    ],
-  },
-  {
-    id: "triangle-4-6-8",
-    label: "Triangle 4-6-8",
-    description: "Progression douce vers une expiration allongée pour relâcher les tensions.",
-    focus: "Décompression & ancrage",
-    benefits: [
-      "Déverrouille la respiration abdominale",
-      "Idéal après une journée dense ou avant un soin",
-    ],
-    recommendedCycles: 9,
-    recommendedDensity: 0.75,
-    pattern: [
-      { phase: "inhale", sec: 4 },
-      { phase: "hold", sec: 6 },
-      { phase: "exhale", sec: 8 },
-    ],
-  },
-];
-
-const toProtocol = (definition: BreathProtocolDefinition): BreathProtocol => {
-  const cycleDuration = definition.pattern.reduce((total, step) => total + Math.max(0, step.sec), 0);
-  const cadence = cycleDuration > 0 ? Number.parseFloat((60 / cycleDuration).toFixed(2)) : 0;
-  return {
-    ...definition,
-    cycleDuration,
-    cadence,
-  };
-};
-
-const PROTOCOLS_BY_ID = PROTOCOL_DEFINITIONS.reduce<Record<BreathProtocolId, BreathProtocol>>(
-  (acc, definition) => {
-    acc[definition.id] = toProtocol(definition);
-    return acc;
-  },
-  {} as Record<BreathProtocolId, BreathProtocol>,
-);
-
-const PROTOCOL_SEQUENCE = PROTOCOL_DEFINITIONS.map(definition => PROTOCOLS_BY_ID[definition.id]);
-
-const DEFAULT_PROTOCOL_ID: BreathProtocolId = "coherence-5-5";
 
 const formatDuration = (seconds: number): string => {
   if (!Number.isFinite(seconds) || seconds <= 0) return "0 s";
@@ -410,7 +294,7 @@ export default function BreathConstellationPage() {
                 onChange={event => handlePatternChange(event.target.value as BreathProtocolId)}
                 style={{ padding: "8px 10px", borderRadius: 8, border: "1px solid #1f2937" }}
               >
-                {PROTOCOL_SEQUENCE.map(option => (
+                {BREATH_PROTOCOL_SEQUENCE.map(option => (
                   <option key={option.id} value={option.id}>
                     {option.label}
                   </option>

--- a/src/modules/breath-constellation/__tests__/protocols.test.ts
+++ b/src/modules/breath-constellation/__tests__/protocols.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BREATH_PROTOCOL_SEQUENCE,
+  DEFAULT_PROTOCOL_ID,
+  PROTOCOLS_BY_ID,
+  calculateCadence,
+  calculateCycleDuration,
+} from '../protocols';
+
+describe('breath constellation – protocoles', () => {
+  it('déclare les protocoles clés avec les durées attendues', () => {
+    const coherence = PROTOCOLS_BY_ID['coherence-5-5'];
+    expect(coherence.cycleDuration).toBe(10);
+    expect(coherence.cadence).toBe(6);
+    expect(coherence.pattern.map(step => step.phase)).toEqual(['inhale', 'exhale']);
+
+    const fourSevenEight = PROTOCOLS_BY_ID['4-7-8'];
+    expect(fourSevenEight.cycleDuration).toBe(19);
+    expect(fourSevenEight.cadence).toBeCloseTo(3.16, 2);
+    expect(fourSevenEight.pattern.map(step => step.phase)).toEqual([
+      'inhale',
+      'hold',
+      'exhale',
+    ]);
+  });
+
+  it('expose une séquence cohérente et un protocole par défaut', () => {
+    expect(BREATH_PROTOCOL_SEQUENCE[0].id).toBe(DEFAULT_PROTOCOL_ID);
+    const ids = BREATH_PROTOCOL_SEQUENCE.map(protocol => protocol.id);
+    expect(new Set(ids).size).toBe(BREATH_PROTOCOL_SEQUENCE.length);
+  });
+
+  it('calcule la cadence même sur des entrées extrêmes', () => {
+    expect(calculateCycleDuration([{ phase: 'inhale', sec: 0 }])).toBe(0);
+    expect(calculateCadence(0)).toBe(0);
+    expect(calculateCadence(15)).toBeCloseTo(4, 0);
+  });
+});
+

--- a/src/modules/breath-constellation/protocols.ts
+++ b/src/modules/breath-constellation/protocols.ts
@@ -1,0 +1,144 @@
+import type { Pattern, Phase } from "@/ui/hooks/useBreathPattern";
+
+export type BreathProtocolId =
+  | "coherence-5-5"
+  | "4-7-8"
+  | "box-4-4-4-4"
+  | "triangle-4-6-8";
+
+export interface BreathProtocolDefinition {
+  id: BreathProtocolId;
+  label: string;
+  description: string;
+  focus: string;
+  benefits: string[];
+  recommendedCycles: number;
+  recommendedDensity: number;
+  pattern: Pattern;
+}
+
+export interface BreathProtocol extends BreathProtocolDefinition {
+  cycleDuration: number;
+  cadence: number;
+}
+
+export const PHASE_LABELS: Record<Phase, string> = {
+  inhale: "Inspiration",
+  hold: "Rétention pleine",
+  exhale: "Expiration",
+  hold2: "Rétention basse",
+};
+
+export const PHASE_DESCRIPTIONS: Record<Phase, string> = {
+  inhale: "Soulevez doucement la cage thoracique et remplissez vos poumons.",
+  hold: "Suspendez la respiration, épaules relâchées.",
+  exhale: "Relâchez l'air sans effort, videz complètement.",
+  hold2: "Gardez les poumons vides dans le calme avant le prochain cycle.",
+};
+
+export const BREATH_PROTOCOL_DEFINITIONS: readonly BreathProtocolDefinition[] = [
+  {
+    id: "coherence-5-5",
+    label: "Cohérence cardiaque 5-5",
+    description: "6 respirations par minute pour réguler le système nerveux.",
+    focus: "Équilibre & clarté",
+    benefits: [
+      "Stabilise la variabilité cardiaque",
+      "Idéal pour une pause active ou avant une réunion",
+    ],
+    recommendedCycles: 10,
+    recommendedDensity: 0.8,
+    pattern: [
+      { phase: "inhale", sec: 5 },
+      { phase: "exhale", sec: 5 },
+    ],
+  },
+  {
+    id: "4-7-8",
+    label: "Sommeil profond 4-7-8",
+    description: "Allonge l'expiration pour apaiser le mental et préparer le repos.",
+    focus: "Apaisement & lâcher-prise",
+    benefits: [
+      "Réduit rapidement la tension accumulée",
+      "Facilite l'endormissement et calme les ruminations",
+    ],
+    recommendedCycles: 6,
+    recommendedDensity: 0.7,
+    pattern: [
+      { phase: "inhale", sec: 4 },
+      { phase: "hold", sec: 7 },
+      { phase: "exhale", sec: 8 },
+    ],
+  },
+  {
+    id: "box-4-4-4-4",
+    label: "Carré 4-4-4-4",
+    description: "Rythme symétrique pour la concentration et la préparation mentale.",
+    focus: "Focus & préparation",
+    benefits: [
+      "Améliore la clarté d'esprit",
+      "Structure la respiration avant un effort cognitif",
+    ],
+    recommendedCycles: 12,
+    recommendedDensity: 0.9,
+    pattern: [
+      { phase: "inhale", sec: 4 },
+      { phase: "hold", sec: 4 },
+      { phase: "exhale", sec: 4 },
+      { phase: "hold2", sec: 4 },
+    ],
+  },
+  {
+    id: "triangle-4-6-8",
+    label: "Triangle 4-6-8",
+    description:
+      "Progression douce vers une expiration allongée pour relâcher les tensions.",
+    focus: "Décompression & ancrage",
+    benefits: [
+      "Déverrouille la respiration abdominale",
+      "Idéal après une journée dense ou avant un soin",
+    ],
+    recommendedCycles: 9,
+    recommendedDensity: 0.75,
+    pattern: [
+      { phase: "inhale", sec: 4 },
+      { phase: "hold", sec: 6 },
+      { phase: "exhale", sec: 8 },
+    ],
+  },
+];
+
+export const calculateCycleDuration = (pattern: Pattern): number =>
+  pattern.reduce((total, step) => total + Math.max(0, step.sec), 0);
+
+export const calculateCadence = (cycleDuration: number): number => {
+  if (!Number.isFinite(cycleDuration) || cycleDuration <= 0) {
+    return 0;
+  }
+
+  return Number.parseFloat((60 / cycleDuration).toFixed(2));
+};
+
+export const toProtocol = (definition: BreathProtocolDefinition): BreathProtocol => {
+  const cycleDuration = calculateCycleDuration(definition.pattern);
+  return {
+    ...definition,
+    cycleDuration,
+    cadence: calculateCadence(cycleDuration),
+  };
+};
+
+export const PROTOCOLS_BY_ID: Record<BreathProtocolId, BreathProtocol> =
+  BREATH_PROTOCOL_DEFINITIONS.reduce<Record<BreathProtocolId, BreathProtocol>>(
+    (acc, definition) => {
+      acc[definition.id] = toProtocol(definition);
+      return acc;
+    },
+    {} as Record<BreathProtocolId, BreathProtocol>,
+  );
+
+export const BREATH_PROTOCOL_SEQUENCE: BreathProtocol[] =
+  BREATH_PROTOCOL_DEFINITIONS.map(definition => PROTOCOLS_BY_ID[definition.id]);
+
+export const DEFAULT_PROTOCOL_ID: BreathProtocolId = "coherence-5-5";
+

--- a/src/modules/coach/__tests__/coachService.test.ts
+++ b/src/modules/coach/__tests__/coachService.test.ts
@@ -39,5 +39,21 @@ describe('coachService internals', () => {
     expect(first).toBe(second);
     expect(different).not.toBe(first);
   });
+
+  it('keeps summary instructions stable', () => {
+    const { SUMMARY_INSTRUCTIONS } = __coachInternals;
+
+    expect(SUMMARY_INSTRUCTIONS).toMatchInlineSnapshot(`
+"Tu es un agent de conformité EmotionsCare.
+Tu reçois l'historique d'un échange entre un utilisateur et un coach IA.
+Rédige un résumé anonymisé sans mentionner de noms propres ni de détails identifiants.
+Réponds en JSON strict avec le format suivant :
+{
+  \"summary\": \"phrase synthétique (max 180 caractères)\",
+  \"signals\": [\"mot-clé 1\", \"mot-clé 2\", \"mot-clé 3\"]
+}
+Ne fournis aucune autre clé que summary et signals."
+    `);
+  });
 });
 

--- a/src/modules/coach/coachService.ts
+++ b/src/modules/coach/coachService.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { supabase } from "@/integrations/supabase/client";
+import { hashString } from "@/lib/hash";
 
 export const COACH_DISCLAIMERS = [
   "Le coach IA ne remplace pas un professionnel de santé ou de santé mentale.",
@@ -116,29 +117,11 @@ function truncateForSummary(text: string, maxLength = HASH_TRUNCATE): string {
 }
 
 async function hashText(value: string): Promise<string> {
-  if (typeof value !== "string" || !value.length) {
+  if (typeof value !== "string" || value.length === 0) {
     return "";
   }
 
-  // Use Web Crypto API (available in modern browsers)
-  if (typeof crypto !== "undefined" && crypto.subtle) {
-    const encoder = new TextEncoder();
-    const data = encoder.encode(value);
-    const hashBuffer = await crypto.subtle.digest("SHA-256", data);
-    return Array.from(new Uint8Array(hashBuffer))
-      .map(b => b.toString(16).padStart(2, "0"))
-      .join("");
-  }
-
-  // Fallback for environments without Web Crypto API
-  // Simple hash using string manipulation (less secure but works)
-  let hash = 0;
-  for (let i = 0; i < value.length; i++) {
-    const char = value.charCodeAt(i);
-    hash = ((hash << 5) - hash) + char;
-    hash = hash & hash; // Convert to 32bit integer
-  }
-  return Math.abs(hash).toString(16);
+  return hashString(value);
 }
 
 async function summarizeConversation(history: CoachHistoryItem[]): Promise<string | null> {
@@ -397,5 +380,6 @@ export const __coachInternals = {
   clampHistory,
   truncateForSummary,
   hashText,
+  SUMMARY_INSTRUCTIONS,
 };
 

--- a/src/modules/emotion-scan/__tests__/emotionScan.validation.test.ts
+++ b/src/modules/emotion-scan/__tests__/emotionScan.validation.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { emotionScanResponsesSchema } from '@/modules/emotion-scan/EmotionScanPage';
+
+const buildValidPayload = () => ({
+  active: 3,
+  determined: 4,
+  attentive: 3,
+  inspired: 5,
+  alert: 4,
+  upset: 2,
+  hostile: 1,
+  ashamed: 2,
+  nervous: 3,
+  afraid: 2,
+});
+
+describe('emotionScanResponsesSchema', () => {
+  it('accepts a fully completed questionnaire', () => {
+    const result = emotionScanResponsesSchema.safeParse(buildValidPayload());
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects submissions with missing answers', () => {
+    const invalid = { ...buildValidPayload() };
+    delete invalid.alert;
+
+    const result = emotionScanResponsesSchema.safeParse(invalid);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((issue) => issue.path[0] === 'alert')).toBe(true);
+    }
+  });
+
+  it('rejects answers outside the Likert scale bounds', () => {
+    const invalid = { ...buildValidPayload(), nervous: 6 };
+
+    const result = emotionScanResponsesSchema.safeParse(invalid);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((issue) => issue.path[0] === 'nervous')).toBe(true);
+    }
+  });
+});
+

--- a/src/modules/flash-glow/journal.ts
+++ b/src/modules/flash-glow/journal.ts
@@ -91,6 +91,9 @@ export async function createFlashGlowJournalEntry({
   const labelInfo = label ? LABEL_CONFIG[label] : DEFAULT_LABEL_INFO;
   const friendlyGlowType = formatGlowType(glowType);
   const sectionTitle = context ?? 'Flash Glow';
+  const normalizedModeTag = friendlyGlowType.toLowerCase().replace(/[^\p{L}\p{N}]+/gu, '');
+  const normalizedToneTag = labelInfo.title.toLowerCase().replace(/[^\p{L}\p{N}]+/gu, '');
+  const tags = ['flashglow', normalizedModeTag, normalizedToneTag].filter(Boolean);
 
   const summary = `${sectionTitle} - ${labelInfo.title}`;
   const contentLines = [
@@ -130,6 +133,7 @@ export async function createFlashGlowJournalEntry({
       tone: labelInfo.tone,
       ephemeral: false,
       duration: safeDuration,
+      tags,
       metadata: {
         mood_before: normalizedMoodBefore,
         mood_after: normalizedMoodAfter,

--- a/src/modules/flash-glow/useFlashGlowMachine.ts
+++ b/src/modules/flash-glow/useFlashGlowMachine.ts
@@ -9,6 +9,7 @@ import { flashGlowService, FlashGlowSession } from './flash-glowService';
 import { toast } from '@/hooks/use-toast';
 import { createFlashGlowJournalEntry } from './journal';
 import type { JournalEntry } from '@/modules/journal/journalService';
+import { SessionsAuthError } from '@/services/sessions.service';
 
 interface FlashGlowConfig {
   glowType: string;
@@ -311,6 +312,9 @@ export const useFlashGlowMachine = (): FlashGlowMachineReturn => {
         glow_type: config.glowType,
         intensity: config.intensity,
         result: 'completed',
+        mood_before: baseline ?? null,
+        mood_after: resolvedMoodAfter ?? null,
+        mood_delta: moodDelta,
         metadata: {
           timestamp: new Date().toISOString(),
           extended: sessionExtendedRef.current,
@@ -361,11 +365,18 @@ export const useFlashGlowMachine = (): FlashGlowMachineReturn => {
 
     } catch (error) {
       console.error('Error completing session:', error);
-      toast({
-        title: "Erreur",
-        description: "Impossible d'enregistrer la session",
-        variant: "destructive",
-      });
+      if (error instanceof SessionsAuthError) {
+        toast({
+          title: "Connexion requise",
+          description: "Identifiez-vous pour enregistrer vos séances et alimenter votre journal.",
+        });
+      } else {
+        toast({
+          title: "Erreur",
+          description: "Impossible d'enregistrer la session",
+          variant: "destructive",
+        });
+      }
     }
   }, [extendSession, sessionDuration, elapsedSeconds, config, loadStats, setMoodAfter]);
 

--- a/src/modules/journal/useJournalMachine.ts
+++ b/src/modules/journal/useJournalMachine.ts
@@ -49,6 +49,7 @@ export const useJournalMachine = (config: JournalConfig = {}) => {
             summary: result.summary,
             tone: result.tone,
             ephemeral: false, // Par défaut, pas éphémère
+            voice_blob: event.data,
             voice_url: URL.createObjectURL(event.data),
             duration: recordingDuration
           });

--- a/src/pages/B2CDashboardPage.tsx
+++ b/src/pages/B2CDashboardPage.tsx
@@ -18,9 +18,13 @@ import {
 } from 'lucide-react';
 import { useAccessibilityAudit } from '@/lib/accessibility-checker';
 import { useEffect } from 'react';
+import EmotionScanSection from '@/components/dashboard/EmotionScanSection';
+import JournalSummaryCard from '@/components/dashboard/JournalSummaryCard';
+import { useAuth } from '@/contexts/AuthContext';
 
 export default function B2CDashboardPage() {
   const { runAudit } = useAccessibilityAudit();
+  const { user } = useAuth();
 
   useEffect(() => {
     // Audit d'accessibilité en développement
@@ -246,6 +250,16 @@ export default function B2CDashboardPage() {
               </Link>
             </Card>
           </div>
+        </section>
+
+        {/* Journal summary */}
+        <section className="mb-8">
+          <JournalSummaryCard userId={user?.id ?? undefined} />
+        </section>
+
+        {/* Emotion Scan Widget */}
+        <section className="mb-8">
+          <EmotionScanSection userId={user?.id ?? undefined} />
         </section>
 
         {/* Recommandations personnalisées */}

--- a/src/pages/B2CMoodMixerPage.tsx
+++ b/src/pages/B2CMoodMixerPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { ArrowLeft, Volume2, Save, Play, Pause, RotateCcw, Trash2, Loader2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
@@ -7,11 +7,13 @@ import { Slider } from '@/components/ui/slider';
 import { useMotionPrefs } from '@/hooks/useMotionPrefs';
 import { FadeIn, SeoHead } from '@/COMPONENTS.reg';
 import { supabase } from '@/integrations/supabase/client';
-import type { Database } from '@/integrations/supabase/types';
 import { toast } from 'sonner';
 import { useMusicControls } from '@/hooks/useMusicControls';
 import { adaptiveMusicService } from '@/services/adaptiveMusicService';
 import type { MusicTrack } from '@/types/music';
+import { useMoodPresetsStore } from '@/store/moodPresets.store';
+import type { MoodPresetRecord } from '@/types/mood-mixer';
+import { moodPresetPayloadSchema } from '@/services/moodPresetsService';
 
 interface MoodVibe {
   id: string;
@@ -21,7 +23,10 @@ interface MoodVibe {
   description: string;
 }
 
-type MoodPresetRow = Database['public']['Tables']['mood_presets']['Row'];
+type RawTrack = Partial<MusicTrack> & {
+  audioUrl?: string | null;
+  url?: string | null;
+};
 
 const clamp01 = (value: number) => Math.min(1, Math.max(0, value));
 
@@ -35,13 +40,28 @@ const buildBlend = (soft: number, clear: number) => ({
   focus: clamp01(1 - clear / 100),
 });
 
-const mapPresetToVibe = (preset: MoodPresetRow): MoodVibe => ({
-  id: preset.id,
-  name: preset.name,
-  softness: preset.softness,
-  clarity: preset.clarity,
-  description: preset.description ?? buildDescription(preset.softness, preset.clarity),
-});
+const toPercent = (value: number | null | undefined, fallback: number) => {
+  if (typeof value === 'number' && !Number.isNaN(value)) {
+    return Math.min(100, Math.max(0, Math.round(value)));
+  }
+  return fallback;
+};
+
+const mapPresetToVibe = (preset: MoodPresetRecord): MoodVibe => {
+  const blend = preset.blend ?? buildBlend(50, 50);
+  const fallbackSoftness = Math.round((blend.joy ?? 0.5) * 100);
+  const fallbackClarity = Math.round((blend.energy ?? 0.5) * 100);
+  const softness = toPercent(preset.softness, fallbackSoftness);
+  const clarity = toPercent(preset.clarity, fallbackClarity);
+
+  return {
+    id: preset.id,
+    name: preset.name,
+    softness,
+    clarity,
+    description: preset.description ?? buildDescription(softness, clarity),
+  };
+};
 
 const B2CMoodMixerPage: React.FC = () => {
   const navigate = useNavigate();
@@ -49,15 +69,40 @@ const B2CMoodMixerPage: React.FC = () => {
   const [softness, setSoftness] = useState([50]);
   const [clarity, setClarity] = useState([50]);
   const [currentVibe, setCurrentVibe] = useState<string>('');
-  const [savedVibes, setSavedVibes] = useState<MoodVibe[]>([]);
-  const [activePresetId, setActivePresetId] = useState<string | null>(null);
-  const [isLoadingPresets, setIsLoadingPresets] = useState(true);
-  const [isSavingPreset, setIsSavingPreset] = useState(false);
   const [dustParticles, setDustParticles] = useState<Array<{ x: number; y: number; opacity: number }>>([]);
   const [isFetchingPreview, setIsFetchingPreview] = useState(false);
   const [previewSource, setPreviewSource] = useState<'api' | 'mock'>('mock');
   const [previewError, setPreviewError] = useState<string | null>(null);
   const { playTrack, pause, isPlaying: isPreviewPlaying, isLoading: isAudioLoading, currentTrack } = useMusicControls();
+  const {
+    presets,
+    isLoading: isLoadingPresets,
+    isSaving: isSavingPreset,
+    hasInitialized,
+    selectedPresetId,
+    loadPresets,
+    selectPreset,
+    createPreset: persistPreset,
+    updatePreset: persistPresetUpdate,
+    deletePreset: persistPresetDeletion,
+  } = useMoodPresetsStore((state) => ({
+    presets: state.presets,
+    isLoading: state.isLoading,
+    isSaving: state.isSaving,
+    hasInitialized: state.hasInitialized,
+    selectedPresetId: state.selectedPresetId,
+    loadPresets: state.loadPresets,
+    selectPreset: state.selectPreset,
+    createPreset: state.createPreset,
+    updatePreset: state.updatePreset,
+    deletePreset: state.deletePreset,
+  }));
+
+  const savedVibes = useMemo(() => presets.map(mapPresetToVibe).slice(0, 6), [presets]);
+  const activePreset = useMemo(() => {
+    if (!selectedPresetId) return null;
+    return presets.find((preset) => preset.id === selectedPresetId) ?? null;
+  }, [presets, selectedPresetId]);
 
   // Générateur de nom de vibe basé sur les sliders
   const generateVibeName = useCallback((soft: number, clear: number) => {
@@ -74,56 +119,41 @@ const B2CMoodMixerPage: React.FC = () => {
     }
   }, []);
 
-  const fetchSavedVibes = useCallback(async () => {
-    setIsLoadingPresets(true);
-    try {
-      const {
-        data: { user },
-        error: authError,
-      } = await supabase.auth.getUser();
+  const requireUser = useCallback(async () => {
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
 
-      if (authError) {
-        throw authError;
-      }
-
-      if (!user) {
-        setSavedVibes([]);
-        setActivePresetId(null);
-        return;
-      }
-
-      const { data, error } = await supabase
-        .from('mood_presets')
-        .select('id, user_id, name, description, softness, clarity, blend, created_at, updated_at')
-        .eq('user_id', user.id)
-        .order('created_at', { ascending: false });
-
-      if (error) {
-        throw error;
-      }
-
-      const vibes = (data ?? []).map(mapPresetToVibe).slice(0, 6);
-      setSavedVibes(vibes);
-
-      if (!vibes.some((vibe) => vibe.id === activePresetId)) {
-        setActivePresetId(null);
-      }
-    } catch (error) {
-      console.error('Error fetching mood presets:', error);
-      toast.error('Impossible de charger vos vibes pour le moment');
-    } finally {
-      setIsLoadingPresets(false);
+    if (authError) {
+      console.error('Error retrieving auth session:', authError);
+      toast.error('Session utilisateur introuvable');
+      return null;
     }
-  }, [activePresetId]);
+
+    if (!user) {
+      toast.error('Connectez-vous pour gérer vos vibes');
+      return null;
+    }
+
+    return user;
+  }, []);
 
   useEffect(() => {
-    fetchSavedVibes();
-  }, [fetchSavedVibes]);
+    if (hasInitialized) {
+      return;
+    }
+
+    loadPresets().catch((error) => {
+      console.error('Error fetching mood presets:', error);
+      toast.error('Impossible de charger vos vibes pour le moment');
+    });
+  }, [hasInitialized, loadPresets]);
 
   // Animation des particules de poussière
   useEffect(() => {
     if (!shouldAnimate) return;
-    
+
     const generateParticles = () => {
       const particles = [];
       for (let i = 0; i < 5; i++) {
@@ -141,11 +171,26 @@ const B2CMoodMixerPage: React.FC = () => {
     return () => clearInterval(interval);
   }, [shouldAnimate]);
 
+  useEffect(() => {
+    if (!activePreset) {
+      return;
+    }
+
+    const vibe = mapPresetToVibe(activePreset);
+    setSoftness([vibe.softness]);
+    setClarity([vibe.clarity]);
+  }, [activePreset]);
+
   // Mise à jour du nom de vibe en temps réel
   useEffect(() => {
+    if (selectedPresetId && activePreset) {
+      setCurrentVibe(activePreset.name);
+      return;
+    }
+
     const vibeName = generateVibeName(softness[0], clarity[0]);
     setCurrentVibe(vibeName);
-  }, [softness, clarity, generateVibeName]);
+  }, [softness, clarity, generateVibeName, selectedPresetId, activePreset]);
 
   const determineTargetEmotion = (soft: number, clear: number) => {
     if (soft >= 65 && clear <= 40) return 'calm';
@@ -280,160 +325,125 @@ const B2CMoodMixerPage: React.FC = () => {
       return;
     }
 
-    setIsSavingPreset(true);
+    const user = await requireUser();
+    if (!user) {
+      return;
+    }
+
+    const description = buildDescription(softness[0], clarity[0]);
+    const blend = buildBlend(softness[0], clarity[0]);
+
+    const payload = {
+      userId: user.id,
+      name: (currentVibe || generateVibeName(softness[0], clarity[0])).trim(),
+      description,
+      softness: softness[0],
+      clarity: clarity[0],
+      blend,
+    };
+
+    const parsed = moodPresetPayloadSchema.safeParse(payload);
+
+    if (!parsed.success) {
+      console.error('Invalid mood preset payload', parsed.error.flatten());
+      toast.error('Les données de la vibe sont invalides. Vérifiez le nom et les curseurs.');
+      return;
+    }
+
     try {
-      const {
-        data: { user },
-        error: authError,
-      } = await supabase.auth.getUser();
-
-      if (authError) {
-        throw authError;
-      }
-
-      if (!user) {
-        toast.error('Connectez-vous pour sauvegarder vos vibes');
-        return;
-      }
-
-      const description = buildDescription(softness[0], clarity[0]);
-      const blend = buildBlend(softness[0], clarity[0]);
-      const { data, error } = await supabase
-        .from('mood_presets')
-        .insert({
-          user_id: user.id,
-          name: currentVibe || generateVibeName(softness[0], clarity[0]),
-          description,
-          softness: softness[0],
-          clarity: clarity[0],
-          blend,
-        })
-        .select('id, user_id, name, description, softness, clarity, blend, created_at, updated_at')
-        .single();
-
-      if (error) {
-        throw error;
-      }
-
-      const newVibe = mapPresetToVibe(data as MoodPresetRow);
-      setSavedVibes((prev) => [newVibe, ...prev].slice(0, 6));
-      setActivePresetId(newVibe.id);
+      await persistPreset(parsed.data);
       toast.success('Ambiance sauvegardée');
     } catch (error) {
       console.error('Error saving mood preset:', error);
       toast.error('Impossible de sauvegarder la vibe');
-    } finally {
-      setIsSavingPreset(false);
     }
-  }, [clarity, currentVibe, generateVibeName, isSavingPreset, softness]);
+  }, [
+    isSavingPreset,
+    requireUser,
+    softness,
+    clarity,
+    currentVibe,
+    generateVibeName,
+    persistPreset,
+  ]);
 
   const updateActiveVibe = useCallback(async () => {
-    if (!activePresetId || isSavingPreset) {
+    if (!selectedPresetId || isSavingPreset) {
       return;
     }
 
-    setIsSavingPreset(true);
+    const user = await requireUser();
+    if (!user) {
+      return;
+    }
+
+    const description = buildDescription(softness[0], clarity[0]);
+    const blend = buildBlend(softness[0], clarity[0]);
+
+    const payload = {
+      userId: user.id,
+      name: (currentVibe || generateVibeName(softness[0], clarity[0])).trim(),
+      description,
+      softness: softness[0],
+      clarity: clarity[0],
+      blend,
+    };
+
+    const parsed = moodPresetPayloadSchema.safeParse(payload);
+
+    if (!parsed.success) {
+      console.error('Invalid mood preset update payload', parsed.error.flatten());
+      toast.error('Impossible de mettre à jour : données invalides.');
+      return;
+    }
+
     try {
-      const {
-        data: { user },
-        error: authError,
-      } = await supabase.auth.getUser();
-
-      if (authError) {
-        throw authError;
-      }
-
-      if (!user) {
-        toast.error('Connectez-vous pour mettre à jour vos vibes');
-        return;
-      }
-
-      const description = buildDescription(softness[0], clarity[0]);
-      const blend = buildBlend(softness[0], clarity[0]);
-      const { data, error } = await supabase
-        .from('mood_presets')
-        .update({
-          name: currentVibe || generateVibeName(softness[0], clarity[0]),
-          description,
-          softness: softness[0],
-          clarity: clarity[0],
-          blend,
-        })
-        .eq('id', activePresetId)
-        .eq('user_id', user.id)
-        .select('id, user_id, name, description, softness, clarity, blend, created_at, updated_at')
-        .single();
-
-      if (error) {
-        throw error;
-      }
-
-      const updatedVibe = mapPresetToVibe(data as MoodPresetRow);
-      setSavedVibes((prev) =>
-        prev.map((vibe) => (vibe.id === updatedVibe.id ? updatedVibe : vibe))
-      );
+      await persistPresetUpdate(selectedPresetId, parsed.data);
       toast.success('Ambiance mise à jour');
     } catch (error) {
       console.error('Error updating mood preset:', error);
       toast.error('Impossible de mettre à jour la vibe');
-    } finally {
-      setIsSavingPreset(false);
     }
-  }, [activePresetId, clarity, currentVibe, generateVibeName, isSavingPreset, softness]);
+  }, [
+    selectedPresetId,
+    isSavingPreset,
+    requireUser,
+    softness,
+    clarity,
+    currentVibe,
+    generateVibeName,
+    persistPresetUpdate,
+  ]);
 
   const loadVibe = (vibe: MoodVibe) => {
     setSoftness([vibe.softness]);
     setClarity([vibe.clarity]);
     setCurrentVibe(vibe.name);
-    setActivePresetId(vibe.id);
+    selectPreset(vibe.id);
   };
 
   const handleDeleteVibe = useCallback(
     async (event: React.MouseEvent<HTMLButtonElement>, vibeId: string) => {
       event.stopPropagation();
 
-      const {
-        data: { user },
-        error: authError,
-      } = await supabase.auth.getUser();
-
-      if (authError) {
-        console.error('Error retrieving auth session:', authError);
-        toast.error('Session utilisateur introuvable');
-        return;
-      }
-
-      if (!user) {
-        toast.error('Connectez-vous pour gérer vos vibes');
-        return;
-      }
-
       if (!window.confirm('Supprimer cette vibe ?')) {
         return;
       }
 
+      const user = await requireUser();
+      if (!user) {
+        return;
+      }
+
       try {
-        const { error } = await supabase
-          .from('mood_presets')
-          .delete()
-          .eq('id', vibeId)
-          .eq('user_id', user.id);
-
-        if (error) {
-          throw error;
-        }
-
-        setSavedVibes((prev) => prev.filter((vibe) => vibe.id !== vibeId));
-        if (activePresetId === vibeId) {
-          setActivePresetId(null);
-        }
+        await persistPresetDeletion(vibeId);
         toast.success('Ambiance supprimée');
       } catch (error) {
         console.error('Error deleting mood preset:', error);
         toast.error('Impossible de supprimer la vibe');
       }
     },
-    [activePresetId]
+    [persistPresetDeletion, requireUser]
   );
 
   const getVibeColor = () => {
@@ -559,7 +569,7 @@ const B2CMoodMixerPage: React.FC = () => {
             >
               <Save className="h-4 w-4" />
             </Button>
-            {activePresetId && (
+            {selectedPresetId && (
               <Button
                 variant="ghost"
                 size="icon"
@@ -608,7 +618,7 @@ const B2CMoodMixerPage: React.FC = () => {
           ) : (
             <div className="space-y-2">
               {savedVibes.map((vibe) => {
-                const isActive = activePresetId === vibe.id;
+                const isActive = selectedPresetId === vibe.id;
                 return (
                   <Card
                     key={vibe.id}

--- a/src/pages/ForbiddenPage.tsx
+++ b/src/pages/ForbiddenPage.tsx
@@ -1,76 +1,42 @@
 import React from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-import { Button } from '@/components/ui/button';
-import { motion } from 'framer-motion';
-import { ShieldAlert, ArrowLeft, Home } from 'lucide-react';
+import { ArrowLeft, Home, ShieldAlert } from 'lucide-react';
+import HttpErrorLayout from '@/components/error/HttpErrorLayout';
 
 const ForbiddenPage: React.FC = () => {
-  const navigate = useNavigate();
-  
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center p-6">
-      <motion.div 
-        className="max-w-md w-full text-center"
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.5 }}
-      >
-        <motion.div 
-          className="mx-auto w-24 h-24 bg-muted rounded-full flex items-center justify-center mb-6"
-          initial={{ scale: 0.8, opacity: 0 }}
-          animate={{ scale: 1, opacity: 1 }}
-          transition={{ delay: 0.2, duration: 0.5 }}
-        >
-          <ShieldAlert className="h-12 w-12 text-destructive" />
-        </motion.div>
-        
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ delay: 0.3, duration: 0.5 }}
-        >
-          <h1 className="text-6xl font-bold mb-4">403</h1>
-          <h2 className="text-2xl font-semibold mb-4">Accès interdit</h2>
-          <p className="text-muted-foreground mb-8">
-            Vous n'avez pas les permissions nécessaires pour accéder à cette page.
-          </p>
-        </motion.div>
-        
-        <motion.div 
-          className="flex flex-col sm:flex-row gap-4 justify-center"
-          initial={{ opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.5, duration: 0.5 }}
-        >
-          <Button 
-            variant="outline" 
-            className="flex items-center gap-2"
-            onClick={() => navigate(-1)}
-          >
-            <ArrowLeft size={16} />
-            Retour
-          </Button>
-          
-          <Button asChild className="flex items-center gap-2">
-            <Link to="/">
-              <Home size={16} />
-              Page d'accueil
-            </Link>
-          </Button>
-        </motion.div>
-        
-        <motion.div 
-          className="mt-12"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ delay: 0.7, duration: 0.5 }}
-        >
-          <p className="text-sm text-muted-foreground">
-            Si vous pensez qu'il s'agit d'une erreur, veuillez contacter notre support.
-          </p>
-        </motion.div>
-      </motion.div>
-    </div>
+    <HttpErrorLayout
+      statusCode={403}
+      title="Accès interdit"
+      description="Vous n'avez pas les autorisations suffisantes pour consulter cette ressource."
+      icon={ShieldAlert}
+      actions={[
+        { label: 'Retour au tableau de bord', to: '/app/home', icon: Home },
+        { label: 'Page précédente', onClick: () => window.history.back(), icon: ArrowLeft, variant: 'outline' },
+      ]}
+      suggestions={[
+        {
+          label: 'Centre d\'aide',
+          href: '/help',
+          description: 'Découvrir comment demander un accès supplémentaire.',
+        },
+        {
+          label: 'Contact support',
+          href: '/contact',
+          description: 'Notre équipe peut vérifier vos permissions.',
+        },
+        {
+          label: 'Politique de sécurité',
+          href: '/privacy',
+          description: 'Comprendre la gestion des accès sur EmotionsCare.',
+        },
+        {
+          label: 'Portail administrateur',
+          href: '/b2b/admin/dashboard',
+          description: 'Réservé aux responsables habilités.',
+        },
+      ]}
+      supportText="Besoin d'un niveau d'accès supérieur ? Contactez votre administrateur ou notre support sécurité."
+    />
   );
 };
 

--- a/src/pages/UnauthorizedPage.tsx
+++ b/src/pages/UnauthorizedPage.tsx
@@ -1,254 +1,43 @@
-
 import React from 'react';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { 
-  Shield, 
-  Home, 
-  LogIn, 
-  UserPlus, 
-  HelpCircle, 
-  ArrowLeft,
-  Lock,
-  Key,
-  AlertTriangle
-} from 'lucide-react';
-import { motion } from 'framer-motion';
-import { useNavigate } from 'react-router-dom';
+import { Home, Lock, LogIn, Shield } from 'lucide-react';
+import HttpErrorLayout from '@/components/error/HttpErrorLayout';
 
 const UnauthorizedPage: React.FC = () => {
-  const navigate = useNavigate();
-
-  const authOptions = [
-    {
-      title: "Se connecter",
-      description: "J'ai déjà un compte",
-      icon: LogIn,
-      action: () => navigate('/auth'),
-      variant: "default" as const,
-      color: "bg-blue-500"
-    },
-    {
-      title: "Créer un compte",
-      description: "Je suis nouveau sur EmotionsCare",
-      icon: UserPlus,
-      action: () => navigate('/auth'),
-      variant: "outline" as const,
-      color: "bg-green-500"
-    },
-    {
-      title: "Mode Entreprise",
-      description: "Accès professionnel B2B",
-      icon: Shield,
-      action: () => navigate('/b2b/selection'),
-      variant: "outline" as const,
-      color: "bg-purple-500"
-    }
-  ];
-
-  const helpOptions = [
-    {
-      title: "Mot de passe oublié",
-      description: "Récupérer l'accès à votre compte",
-      path: "/reset-password"
-    },
-    {
-      title: "Centre d'aide",
-      description: "FAQ et guides d'utilisation",
-      path: "/help"
-    },
-    {
-      title: "Contact support",
-      description: "Obtenir de l'aide personnalisée",
-      path: "/contact"
-    }
-  ];
-
   return (
-    <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20 flex items-center justify-center p-4" data-testid="page-root">
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.6 }}
-        className="max-w-4xl w-full"
-      >
-        <div className="text-center mb-12">
-          <motion.div
-            initial={{ scale: 0.8 }}
-            animate={{ scale: 1 }}
-            transition={{ duration: 0.5, delay: 0.2 }}
-            className="mb-8"
-          >
-            <div className="flex justify-center mb-6">
-              <div className="p-4 rounded-full bg-destructive/10 border border-destructive/20">
-                <Lock className="h-12 w-12 text-destructive" />
-              </div>
-            </div>
-            <h1 className="text-4xl font-bold mb-4">Accès non autorisé</h1>
-            <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-              Cette page nécessite une authentification pour être consultée. 
-              Veuillez vous connecter ou créer un compte pour continuer votre parcours de bien-être.
-            </p>
-          </motion.div>
-
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ delay: 0.4 }}
-            className="flex flex-wrap justify-center gap-4 mb-12"
-          >
-            <Button
-              onClick={() => navigate(-1)}
-              variant="outline"
-              size="lg"
-              className="flex items-center gap-2"
-            >
-              <ArrowLeft className="h-4 w-4" />
-              Retour
-            </Button>
-            <Button
-              onClick={() => navigate('/')}
-              variant="outline"
-              size="lg"
-              className="flex items-center gap-2"
-            >
-              <Home className="h-4 w-4" />
-              Accueil
-            </Button>
-          </motion.div>
-        </div>
-
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-12">
-          <motion.div
-            initial={{ opacity: 0, x: -20 }}
-            animate={{ opacity: 1, x: 0 }}
-            transition={{ delay: 0.6 }}
-          >
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Key className="h-5 w-5" />
-                  Options d'Authentification
-                </CardTitle>
-                <CardDescription>
-                  Choisissez votre mode de connexion
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                {authOptions.map((option, index) => (
-                  <motion.button
-                    key={index}
-                    onClick={option.action}
-                    whileHover={{ scale: 1.02 }}
-                    whileTap={{ scale: 0.98 }}
-                    className="w-full p-4 rounded-lg border hover:border-primary/50 transition-all text-left"
-                  >
-                    <div className="flex items-center gap-3">
-                      <div className={`p-2 rounded-md ${option.color} text-white`}>
-                        <option.icon className="h-4 w-4" />
-                      </div>
-                      <div>
-                        <div className="font-medium">{option.title}</div>
-                        <div className="text-sm text-muted-foreground">
-                          {option.description}
-                        </div>
-                      </div>
-                    </div>
-                  </motion.button>
-                ))}
-              </CardContent>
-            </Card>
-          </motion.div>
-
-          <motion.div
-            initial={{ opacity: 0, x: 20 }}
-            animate={{ opacity: 1, x: 0 }}
-            transition={{ delay: 0.8 }}
-          >
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <HelpCircle className="h-5 w-5" />
-                  Besoin d'aide ?
-                </CardTitle>
-                <CardDescription>
-                  Ressources pour résoudre vos problèmes d'accès
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                {helpOptions.map((help, index) => (
-                  <button
-                    key={index}
-                    onClick={() => navigate(help.path)}
-                    className="w-full p-3 rounded-lg border hover:border-primary/50 hover:bg-primary/5 transition-all text-left"
-                  >
-                    <div className="font-medium text-sm">{help.title}</div>
-                    <div className="text-xs text-muted-foreground">
-                      {help.description}
-                    </div>
-                  </button>
-                ))}
-              </CardContent>
-            </Card>
-
-            <Card className="mt-6 border-amber-200 bg-amber-50/50">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-amber-800">
-                  <AlertTriangle className="h-5 w-5" />
-                  Information Importante
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-3 text-sm text-amber-700">
-                  <p>
-                    <strong>Sécurité :</strong> Vos données émotionnelles sont sensibles et protégées.
-                  </p>
-                  <p>
-                    <strong>Confidentialité :</strong> Seuls les utilisateurs authentifiés peuvent accéder à leurs données personnelles.
-                  </p>
-                  <p>
-                    <strong>RGPD :</strong> Conformité totale avec la réglementation européenne sur la protection des données.
-                  </p>
-                </div>
-              </CardContent>
-            </Card>
-          </motion.div>
-        </div>
-
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ delay: 1 }}
-          className="text-center"
-        >
-          <Card className="bg-gradient-to-r from-primary/10 to-blue-500/10 border-primary/20">
-            <CardContent className="py-8">
-              <h3 className="text-lg font-semibold mb-2">
-                Rejoignez la communauté EmotionsCare
-              </h3>
-              <p className="text-muted-foreground mb-6">
-                Découvrez un espace sécurisé pour prendre soin de votre bien-être émotionnel. 
-                Plus de 10,000 utilisateurs nous font déjà confiance.
-              </p>
-              <div className="flex flex-wrap justify-center gap-4">
-                <Button
-                  onClick={() => navigate('/auth')}
-                  className="bg-gradient-to-r from-primary to-blue-600 hover:from-primary/90 hover:to-blue-600/90"
-                >
-                  Créer mon compte gratuit
-                </Button>
-                <Button
-                  onClick={() => navigate('/about')}
-                  variant="outline"
-                >
-                  En savoir plus
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        </motion.div>
-      </motion.div>
-    </div>
+    <HttpErrorLayout
+      statusCode={401}
+      title="Authentification requise"
+      description="Vous devez être connecté pour accéder à cette zone sécurisée de la plateforme."
+      icon={Lock}
+      actions={[
+        { label: 'Se connecter', to: '/login', icon: LogIn },
+        { label: "Créer un compte", to: '/signup', icon: Shield, variant: 'secondary' },
+        { label: "Retour à l'accueil", to: '/', icon: Home, variant: 'outline' },
+      ]}
+      suggestions={[
+        {
+          label: 'Mot de passe oublié',
+          href: '/reset-password',
+          description: 'Récupérez l\'accès à votre espace personnel.',
+        },
+        {
+          label: 'Centre d\'aide',
+          href: '/help',
+          description: 'Consultez les questions fréquentes et tutoriels.',
+        },
+        {
+          label: 'Contact support',
+          href: '/contact',
+          description: 'Notre équipe peut vous aider à activer votre compte.',
+        },
+        {
+          label: 'Espace entreprise',
+          href: '/entreprise',
+          description: 'Accès B2B pour les organisations et équipes.',
+        },
+      ]}
+      supportText="Besoin d'un accompagnement ? Notre équipe support est disponible 7j/7 pour sécuriser votre accès."
+    />
   );
 };
 

--- a/src/pages/unified/UnifiedErrorPage.tsx
+++ b/src/pages/unified/UnifiedErrorPage.tsx
@@ -1,402 +1,73 @@
-/**
- * UNIFIED ERROR PAGE - Fusion de 404Page + Enhanced404Page + NotFoundPage
- * Préserve EXACTEMENT la même fonctionnalité des trois composants
- */
-
-import React, { useEffect, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-import { Home, Search, ArrowLeft, HelpCircle, AlertTriangle } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import React from 'react';
+import { AlertTriangle, Compass, HelpCircle, Home } from 'lucide-react';
+import HttpErrorLayout from '@/components/error/HttpErrorLayout';
 
 interface UnifiedErrorPageProps {
-  variant?: 'simple' | 'enhanced' | 'accessible';
   errorCode?: number;
+  title?: string;
+  description?: string;
+  variant?: 'simple' | 'enhanced' | 'accessible';
 }
 
-export default function UnifiedErrorPage({ 
-  variant = 'enhanced', 
-  errorCode = 404 
-}: UnifiedErrorPageProps) {
-  const navigate = useNavigate();
-  const [searchTerm, setSearchTerm] = useState('');
+const DEFAULT_TITLES: Record<number, string> = {
+  401: 'Authentification requise',
+  403: 'Accès interdit',
+  404: 'Page introuvable',
+  500: 'Erreur interne du serveur',
+};
 
-  // Focus management pour l'accessibilité
-  useEffect(() => {
-    document.title = `${errorCode} - Page introuvable | EmotionsCare`;
-    const skipLink = document.getElementById('skip-link');
-    if (skipLink) {
-      skipLink.focus();
-    }
-  }, [errorCode]);
+const DEFAULT_DESCRIPTIONS: Record<number, string> = {
+  401: "Vous devez être connecté pour poursuivre votre parcours émotionnel.",
+  403: "Cette ressource est protégée. Vérifiez vos autorisations ou contactez votre administrateur.",
+  404: "La page que vous cherchez n'existe plus ou a été déplacée. Explorons d'autres espaces inspirants.",
+  500: "Un imprévu technique est survenu. Nos équipes ont été alertées pour corriger l'incident.",
+};
 
-  const handleGoBack = () => {
-    navigate(-1);
-  };
+const UnifiedErrorPage: React.FC<UnifiedErrorPageProps> = ({
+  errorCode = 404,
+  title,
+  description,
+}) => {
+  const resolvedTitle = title ?? DEFAULT_TITLES[errorCode] ?? 'Une erreur est survenue';
+  const resolvedDescription =
+    description ?? DEFAULT_DESCRIPTIONS[errorCode] ?? "Nous n'avons pas pu afficher cette page. Réessayez plus tard.";
 
-  const handleGoHome = () => {
-    navigate('/');
-  };
-
-  const handleSearch = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (searchTerm.trim()) {
-      // Global search will be implemented when search API is ready
-      navigate(`/search?q=${encodeURIComponent(searchTerm)}`);
-    }
-  };
-
-  const handleKeyDown = (event: React.KeyboardEvent, action: () => void) => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      action();
-    }
-  };
-
-  const popularPages = [
-    { 
-      title: 'Accueil', 
-      href: '/', 
-      description: 'Retour à l\'accueil principal'
-    },
-    { 
-      title: 'Tableau de bord', 
-      href: '/app/home', 
-      description: 'Accéder à votre tableau de bord personnel'
-    },
-    { 
-      title: 'Scanner émotionnel', 
-      href: '/app/scan', 
-      description: 'Effectuer un scan émotionnel'
-    },
-    { 
-      title: 'Musique thérapeutique', 
-      href: '/app/music', 
-      description: 'Explorer la musicothérapie'
-    },
-    { 
-      title: 'Centre d\'aide', 
-      href: '/help', 
-      description: 'Centre d\'aide et documentation'
-    },
-  ];
-
-  // Version Simple (comme NotFoundPage)
-  if (variant === 'simple') {
-    return (
-      <div className="min-h-screen bg-gradient-to-br from-background to-muted flex items-center justify-center p-4" data-testid="page-root">
-        <div className="max-w-md w-full text-center">
-          {/* Illustration 404 */}
-          <div className="mb-8">
-            <div className="text-9xl font-bold text-primary/20 mb-4">{errorCode}</div>
-            <div className="text-muted-foreground text-lg">
-              {errorCode} - Page introuvable
-            </div>
-          </div>
-
-          {/* Message d'erreur */}
-          <div className="mb-8 space-y-2">
-            <h1 className="text-2xl font-semibold text-foreground">
-              Page introuvable
-            </h1>
-            <p className="text-muted-foreground">
-              La page que vous recherchez a peut-être été déplacée, supprimée ou n'existe pas.
-            </p>
-          </div>
-
-          {/* Actions de navigation */}
-          <div className="space-y-4">
-            <Link to="/" aria-label="Retour à l'accueil">
-              <Button size="lg" className="w-full">
-                <Home className="w-4 h-4 mr-2" />
-                Retour à l'accueil
-              </Button>
-            </Link>
-            
-            <Button 
-              variant="outline" 
-              size="lg" 
-              className="w-full"
-              onClick={() => window.history.back()}
-              aria-label="Page précédente"
-            >
-              <ArrowLeft className="w-4 h-4 mr-2" />
-              Page précédente
-            </Button>
-          </div>
-
-          {/* Liens utiles */}
-          <div className="mt-12 pt-8 border-t border-border">
-            <p className="text-sm text-muted-foreground mb-4">
-              Liens utiles :
-            </p>
-            <div className="space-y-2 text-sm">
-              <Link 
-                to="/app/journal" 
-                className="block text-primary hover:underline"
-                aria-label="Aller au journal"
-              >
-                📝 Mon Journal
-              </Link>
-              <Link 
-                to="/app/music" 
-                className="block text-primary hover:underline"
-                aria-label="Aller à la musique thérapeutique"
-              >
-                🎵 Musique thérapeutique
-              </Link>
-              <Link 
-                to="/help" 
-                className="block text-primary hover:underline"
-                aria-label="Aller à l'aide"
-              >
-                ❓ Centre d'aide
-              </Link>
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  // Version Accessible (comme 404Page original)
-  if (variant === 'accessible') {
-    return (
-      <>
-        {/* Skip Links pour l'accessibilité */}
-        <a 
-          id="skip-link"
-          href="#main-content" 
-          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-primary text-primary-foreground px-4 py-2 rounded-md z-50"
-          tabIndex={0}
-        >
-          Aller au contenu principal
-        </a>
-
-        <div className="min-h-screen bg-background" data-testid="page-root">
-          <main 
-            id="main-content"
-            role="main"
-            className="min-h-screen flex items-center justify-center p-4"
-            aria-labelledby="error-title"
-          >
-            <Card className="w-full max-w-md text-center border-2 hover:border-primary/20 transition-colors">
-              <CardHeader className="space-y-4">
-                <div className="flex justify-center mb-4" role="img" aria-label="Icône de recherche">
-                  <div className="p-4 bg-muted/50 rounded-full">
-                    <Search className="h-16 w-16 text-muted-foreground" aria-hidden="true" />
-                  </div>
-                </div>
-                
-                <div className="space-y-2">
-                  <CardTitle 
-                    id="error-title"
-                    className="text-3xl font-bold text-foreground"
-                  >
-                    {errorCode} - Page introuvable
-                  </CardTitle>
-                  <CardDescription className="text-lg text-muted-foreground">
-                    La page que vous recherchez n'existe pas ou a été déplacée.
-                  </CardDescription>
-                </div>
-              </CardHeader>
-              
-              <CardContent className="space-y-6">
-                <div 
-                  className="p-4 bg-muted/30 rounded-lg border-l-4 border-orange-500"
-                  role="alert"
-                  aria-live="polite"
-                >
-                  <div className="flex items-start space-x-3">
-                    <AlertTriangle className="h-5 w-5 text-orange-500 flex-shrink-0 mt-0.5" aria-hidden="true" />
-                    <div className="text-left">
-                      <p className="text-sm font-medium text-foreground">
-                        Que s'est-il passé ?
-                      </p>
-                      <p className="text-sm text-muted-foreground mt-1">
-                        Cette adresse ne correspond à aucune page de notre plateforme. 
-                        Vérifiez l'URL ou utilisez la navigation pour explorer nos fonctionnalités.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-                
-                <nav aria-label="Actions de navigation d'erreur" className="space-y-3">
-                  <div className="flex flex-col sm:flex-row gap-3">
-                    <Button
-                      onClick={handleGoBack}
-                      onKeyDown={(e) => handleKeyDown(e, handleGoBack)}
-                      variant="outline"
-                      className="flex-1 h-12 text-base hover:bg-muted/50 focus:ring-2 focus:ring-primary focus:ring-offset-2"
-                      aria-label="Retourner à la page précédente"
-                      tabIndex={0}
-                    >
-                      <ArrowLeft className="h-4 w-4 mr-2" aria-hidden="true" />
-                      Retour
-                    </Button>
-                    
-                    <Button
-                      onClick={handleGoHome}
-                      onKeyDown={(e) => handleKeyDown(e, handleGoHome)}
-                      className="flex-1 h-12 text-base bg-primary hover:bg-primary/90 focus:ring-2 focus:ring-primary focus:ring-offset-2"
-                      aria-label="Retourner à la page d'accueil d'EmotionsCare"
-                      tabIndex={0}
-                    >
-                      <Home className="h-4 w-4 mr-2" aria-hidden="true" />
-                      Accueil
-                    </Button>
-                  </div>
-                  
-                  <p className="text-xs text-muted-foreground mt-4">
-                    Si le problème persiste, contactez notre{' '}
-                    <a 
-                      href="/contact" 
-                      className="text-primary hover:underline focus:underline focus:outline-none"
-                      aria-label="Contacter le support technique d'EmotionsCare"
-                    >
-                      support technique
-                    </a>
-                  </p>
-                </nav>
-              </CardContent>
-            </Card>
-          </main>
-        </div>
-      </>
-    );
-  }
-
-  // Version Enhanced (par défaut, comme Enhanced404Page)
   return (
-    <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted flex items-center justify-center p-4" data-testid="page-root">
-      {/* Skip Links */}
-      <a 
-        href="#main-content" 
-        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 z-50 bg-primary text-primary-foreground px-4 py-2 rounded-md"
-        tabIndex={0}
-      >
-        Aller au contenu principal
-      </a>
-      
-      <div className="max-w-2xl w-full">
-        <main id="main-content" className="text-center space-y-8">
-          {/* Titre principal */}
-          <div className="space-y-4">
-            <div className="text-8xl font-bold text-primary/20 select-none" aria-hidden="true">
-              {errorCode}
-            </div>
-            <h1 className="text-3xl md:text-4xl font-bold text-foreground">
-              Page introuvable
-            </h1>
-            <p className="text-lg text-muted-foreground max-w-md mx-auto">
-              La page que vous recherchez n'existe pas ou a été déplacée. 
-              Ne vous inquiétez pas, nous allons vous aider à retrouver votre chemin.
-            </p>
-          </div>
-
-          {/* Recherche avec accessibilité améliorée */}
-          <div className="max-w-md mx-auto">
-            <form onSubmit={handleSearch} className="flex gap-2" role="search">
-              <div className="flex-1">
-                <label htmlFor="search-404" className="sr-only">
-                  Rechercher une page
-                </label>
-                <Input
-                  id="search-404"
-                  type="search"
-                  placeholder="Rechercher une page..."
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  className="w-full"
-                  aria-describedby="search-help"
-                />
-                <div id="search-help" className="sr-only">
-                  Entrez des mots-clés pour rechercher une page
-                </div>
-              </div>
-              <Button type="submit" variant="outline" size="icon">
-                <Search className="h-4 w-4" />
-                <span className="sr-only">Lancer la recherche</span>
-              </Button>
-            </form>
-          </div>
-
-          {/* Actions rapides avec navigation assistée */}
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Button 
-              onClick={handleGoBack}
-              variant="outline"
-              className="flex items-center gap-2"
-            >
-              <ArrowLeft className="h-4 w-4" />
-              Retour
-            </Button>
-            
-            <Button 
-              asChild
-              className="flex items-center gap-2"
-            >
-              <Link to="/" data-testid="home-link">
-                <Home className="h-4 w-4" />
-                Accueil
-              </Link>
-            </Button>
-            
-            <Button 
-              asChild
-              variant="outline"
-              className="flex items-center gap-2"
-            >
-              <Link to="/help">
-                <HelpCircle className="h-4 w-4" />
-                Aide
-              </Link>
-            </Button>
-          </div>
-
-          {/* Pages populaires avec navigation optimisée */}
-          <div className="bg-card rounded-lg border p-6 text-left">
-            <h2 className="text-xl font-semibold mb-4 text-center">
-              Pages populaires
-            </h2>
-            
-            <nav aria-label="Pages populaires" role="navigation">
-              <ul className="space-y-3">
-                {popularPages.map((page) => (
-                  <li key={page.href}>
-                    <Link
-                      to={page.href}
-                      className="block p-3 rounded-md hover:bg-muted transition-colors focus:outline-none focus:ring-2 focus:ring-primary group"
-                    >
-                      <div className="font-medium text-foreground group-hover:text-primary">
-                        {page.title}
-                      </div>
-                      <div className="text-sm text-muted-foreground">
-                        {page.description}
-                      </div>
-                    </Link>
-                  </li>
-                ))}
-              </ul>
-            </nav>
-          </div>
-
-          {/* Informations techniques (développement) */}
-          {process.env.NODE_ENV === 'development' && (
-            <details className="bg-muted/50 rounded-lg p-4 text-left text-sm">
-              <summary className="cursor-pointer font-medium">
-                Informations techniques (dev)
-              </summary>
-              <div className="mt-2 space-y-1 text-muted-foreground">
-                <div>URL: {window.location.href}</div>
-                <div>Referrer: {document.referrer || 'Direct'}</div>
-                <div>User Agent: {navigator.userAgent}</div>
-              </div>
-            </details>
-          )}
-        </main>
-      </div>
-    </div>
+    <HttpErrorLayout
+      statusCode={errorCode}
+      title={resolvedTitle}
+      description={resolvedDescription}
+      icon={AlertTriangle}
+      actions={[
+        { label: "Retour à l'accueil", to: '/', icon: Home },
+        { label: 'Ouvrir le centre d\'aide', to: '/help', icon: HelpCircle, variant: 'outline' },
+        { label: 'Explorer le Dashboard', to: '/app/home', icon: Compass, variant: 'ghost' },
+      ]}
+      suggestions={[
+        {
+          label: 'Scanner émotionnel',
+          href: '/app/scan',
+          description: 'Analysez votre humeur et vos besoins actuels.',
+        },
+        {
+          label: 'Journal intelligent',
+          href: '/app/journal',
+          description: 'Consignez vos ressentis pour suivre votre progression.',
+        },
+        {
+          label: 'Musique adaptative',
+          href: '/app/music',
+          description: 'Laissez la musique guider votre équilibre émotionnel.',
+        },
+        {
+          label: 'Explorateur de modules',
+          href: '/navigation',
+          description: 'Parcourez l\'ensemble des expériences disponibles.',
+        },
+      ]}
+      supportText="Toujours perdu(e) ? Appuyez-vous sur le centre d'aide ou contactez notre équipe support."
+    />
   );
-}
+};
+
+export default UnifiedErrorPage;

--- a/src/routerV2/registry.ts
+++ b/src/routerV2/registry.ts
@@ -469,6 +469,16 @@ export const ROUTES_REGISTRY: RouteMeta[] = [
     aliases: ['/weekly-bars', '/activity-history'],
   },
   {
+    name: 'scores',
+    path: '/app/scores',
+    segment: 'consumer',
+    role: 'consumer',
+    layout: 'app',
+    component: 'ScoresV2Page',
+    guard: true,
+    aliases: ['/modules/scores-v2', '/modules/scores'],
+  },
+  {
     name: 'heatmap',
     path: '/app/heatmap',
     segment: 'consumer',

--- a/src/routerV2/routes.ts
+++ b/src/routerV2/routes.ts
@@ -52,12 +52,13 @@ export const b2cRoutes = {
   vr: () => '/app/vr',
   meditation: () => '/meditation',
   emotions: () => '/app/emotions',
-  community: () => '/app/community',
+  community: () => '/app/social-cocon',
   settings: () => '/settings',
   profile: () => '/profile',
   
   // Modules Fun-First
   flashGlow: () => '/app/flash-glow',
+  scores: () => '/app/scores',
   breathwork: () => '/app/breathwork',
   arFilters: () => '/app/ar-filters',
   bubbleBeat: () => '/app/bubble-beat',

--- a/src/routerV2/routes.tsx
+++ b/src/routerV2/routes.tsx
@@ -14,6 +14,7 @@ export const routes = {
     coach: () => '/app/coach',
     settings: () => '/app/settings',
     flashGlow: () => '/app/flash-glow',
+    scores: () => '/app/scores',
     community: () => '/app/community',
   },
   b2b: {

--- a/src/services/__tests__/breathworkSessions.service.test.ts
+++ b/src/services/__tests__/breathworkSessions.service.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  logBreathworkSession,
+  BreathworkSessionAuthError,
+  BreathworkSessionPersistError,
+} from '../breathworkSessions.service';
+
+const supabaseMocks = vi.hoisted(() => ({
+  authGetUser: vi.fn(),
+  from: vi.fn(),
+  insert: vi.fn(),
+  select: vi.fn(),
+  single: vi.fn(),
+}));
+
+const sessionsMocks = vi.hoisted(() => ({
+  logSession: vi.fn(),
+}));
+
+const SessionsAuthErrorStub = vi.hoisted(
+  () => class SessionsAuthErrorStub extends Error {},
+);
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    auth: {
+      getUser: supabaseMocks.authGetUser,
+    },
+    from: supabaseMocks.from,
+  },
+}));
+
+vi.mock('../sessions.service', () => ({
+  sessionsService: {
+    logSession: sessionsMocks.logSession,
+  },
+  SessionsAuthError: SessionsAuthErrorStub,
+}));
+
+const {
+  authGetUser: mockGetUser,
+  from: mockFrom,
+  insert: mockInsert,
+  select: mockSelect,
+  single: mockSingle,
+} = supabaseMocks;
+
+const { logSession: mockLogSession } = sessionsMocks;
+
+describe('breathworkSessions.service', () => {
+  beforeEach(() => {
+    mockGetUser.mockReset();
+    mockFrom.mockReset();
+    mockInsert.mockReset();
+    mockSelect.mockReset();
+    mockSingle.mockReset();
+    mockLogSession.mockReset();
+
+    mockFrom.mockImplementation(() => ({ insert: mockInsert }));
+    mockInsert.mockImplementation(() => ({ select: mockSelect }));
+    mockSelect.mockImplementation(() => ({ single: mockSingle }));
+  });
+
+  it('persiste la session respiration et alimente la table unifiée', async () => {
+    const now = new Date().toISOString();
+    const supabaseRecord = {
+      id: 'breath-1',
+      user_id: 'user-1',
+      technique_type: '4-7-8',
+      duration: 313,
+      session_data: {
+        started_at: now,
+        ended_at: now,
+        cycles_planned: 6,
+        cycles_completed: 6,
+        density: 0.92,
+        completed: false,
+        cadence: 3.19,
+        cues: { sound: true, haptics: true },
+      },
+    } as any;
+
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockSingle.mockResolvedValue({ data: supabaseRecord, error: null });
+    mockLogSession.mockResolvedValue({ id: 'session-1' });
+
+    const result = await logBreathworkSession({
+      technique: '4-7-8',
+      durationSec: 312.8,
+      startedAt: now,
+      endedAt: now,
+      cyclesPlanned: 6.4,
+      cyclesCompleted: 5.6,
+      density: 0.917,
+      completed: false,
+      cadence: 3.193,
+      soundCues: true,
+      haptics: true,
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith('breathwork_sessions');
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'user-1',
+        technique_type: '4-7-8',
+        duration: 313,
+      }),
+    );
+    expect(mockLogSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'breath',
+        durationSec: 313,
+        userId: 'user-1',
+        meta: expect.objectContaining({
+          technique: '4-7-8',
+          cyclesPlanned: 6,
+          cyclesCompleted: 6,
+          density: 0.92,
+          cadence: 3.19,
+          cues: { sound: true, haptics: true },
+        }),
+      }),
+    );
+    expect(result).toEqual(supabaseRecord);
+  });
+
+  it('signale une authentification manquante', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+    await expect(
+      logBreathworkSession({
+        technique: 'coherence-5-5',
+        durationSec: 120,
+        startedAt: new Date().toISOString(),
+        endedAt: new Date().toISOString(),
+        cyclesPlanned: 2,
+        cyclesCompleted: 1,
+        density: 0.5,
+        completed: false,
+        cadence: 6,
+        soundCues: false,
+        haptics: false,
+      }),
+    ).rejects.toBeInstanceOf(BreathworkSessionAuthError);
+  });
+
+  it('propage les erreurs d’insertion Supabase', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockSingle.mockResolvedValue({ data: null, error: { message: 'insert failed' } });
+
+    await expect(
+      logBreathworkSession({
+        technique: 'coherence-5-5',
+        durationSec: 60,
+        startedAt: new Date().toISOString(),
+        endedAt: new Date().toISOString(),
+        cyclesPlanned: 4,
+        cyclesCompleted: 3,
+        density: 0.6,
+        completed: true,
+        cadence: 6,
+        soundCues: false,
+        haptics: false,
+      }),
+    ).rejects.toBeInstanceOf(BreathworkSessionPersistError);
+  });
+
+  it('relève les erreurs de logging unifié comme erreurs de persistance', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockSingle.mockResolvedValue({
+      data: {
+        id: 'breath-1',
+        user_id: 'user-1',
+        technique_type: 'coherence-5-5',
+        duration: 600,
+        session_data: {},
+      },
+      error: null,
+    });
+    mockLogSession.mockRejectedValueOnce(new Error('network down'));
+
+    await expect(
+      logBreathworkSession({
+        technique: 'coherence-5-5',
+        durationSec: 600,
+        startedAt: new Date().toISOString(),
+        endedAt: new Date().toISOString(),
+        cyclesPlanned: 10,
+        cyclesCompleted: 10,
+        density: 0.8,
+        completed: true,
+        cadence: 6,
+        soundCues: true,
+        haptics: true,
+      }),
+    ).rejects.toBeInstanceOf(BreathworkSessionPersistError);
+  });
+
+  it('requalifie les SessionsAuthError en BreathworkSessionAuthError', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockSingle.mockResolvedValue({
+      data: {
+        id: 'breath-2',
+        user_id: 'user-1',
+        technique_type: 'triangle-4-6-8',
+        duration: 420,
+        session_data: {},
+      },
+      error: null,
+    });
+    mockLogSession.mockRejectedValueOnce(new SessionsAuthErrorStub('missing user'));
+
+    await expect(
+      logBreathworkSession({
+        technique: 'triangle-4-6-8',
+        durationSec: 420,
+        startedAt: new Date().toISOString(),
+        endedAt: new Date().toISOString(),
+        cyclesPlanned: 9,
+        cyclesCompleted: 7,
+        density: 0.7,
+        completed: false,
+        cadence: 5,
+        soundCues: false,
+        haptics: false,
+      }),
+    ).rejects.toBeInstanceOf(BreathworkSessionAuthError);
+  });
+});
+

--- a/src/services/__tests__/moodPresets.validation.test.ts
+++ b/src/services/__tests__/moodPresets.validation.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { moodPresetPayloadSchema } from '@/services/moodPresetsService';
+
+describe('moodPresetPayloadSchema', () => {
+  const basePayload = {
+    name: 'Calm Evening',
+    description: 'Ambiance douce pour se détendre',
+    blend: { joy: 0.3, calm: 0.8, energy: 0.4, focus: 0.6 },
+    softness: 70,
+    clarity: 45,
+    userId: '00000000-0000-0000-0000-000000000001',
+  };
+
+  it('validates a complete payload', () => {
+    const result = moodPresetPayloadSchema.safeParse(basePayload);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects payloads with invalid blend values', () => {
+    const result = moodPresetPayloadSchema.safeParse({
+      ...basePayload,
+      blend: { joy: 1.5, calm: -0.2, energy: 0.4, focus: 0.6 },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects payloads with too short names', () => {
+    const result = moodPresetPayloadSchema.safeParse({
+      ...basePayload,
+      name: 'A',
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/services/__tests__/sessions.service.test.ts
+++ b/src/services/__tests__/sessions.service.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { sessionsService, SessionsAuthError } from '../sessions.service';
+
+const supabaseMocks = vi.hoisted(() => ({
+  authGetUser: vi.fn(),
+  from: vi.fn(),
+  insert: vi.fn(),
+  select: vi.fn(),
+  single: vi.fn(),
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    auth: {
+      getUser: supabaseMocks.authGetUser,
+    },
+    from: supabaseMocks.from,
+  },
+}));
+
+const {
+  authGetUser: mockGetUser,
+  insert: mockInsert,
+  select: mockSelect,
+  single: mockSingle,
+  from: mockFrom,
+} = supabaseMocks;
+
+describe('sessionsService.logSession', () => {
+  beforeEach(() => {
+    mockGetUser.mockReset();
+    mockInsert.mockReset();
+    mockSelect.mockReset();
+    mockSingle.mockReset();
+    mockFrom.mockReset();
+
+    mockSelect.mockImplementation(() => ({ single: mockSingle }));
+    mockInsert.mockImplementation(() => ({ select: mockSelect }));
+    mockFrom.mockImplementation(() => ({ insert: mockInsert }));
+  });
+
+  it('enregistre une session et normalise les données', async () => {
+    const expectedRecord = {
+      id: 'session-1',
+      created_at: new Date().toISOString(),
+      type: 'flash_glow',
+      duration_sec: 88,
+      mood_delta: 32,
+      meta: {
+        label: 'gain',
+        moodBefore: 40,
+        moodAfter: 72,
+      },
+    };
+
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockSingle.mockResolvedValue({ data: expectedRecord, error: null });
+
+    const result = await sessionsService.logSession({
+      type: 'flash_glow',
+      durationSec: 87.6,
+      moodBefore: 40,
+      moodAfter: 71.6,
+      meta: { label: 'gain' },
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith('sessions');
+    expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({
+      user_id: 'user-1',
+      type: 'flash_glow',
+      duration_sec: 88,
+      mood_delta: 32,
+      meta: expect.objectContaining({
+        moodBefore: 40,
+        moodAfter: 72,
+        label: 'gain',
+      }),
+    }));
+    expect(mockSelect).toHaveBeenCalledWith('id, created_at, type, duration_sec, mood_delta, meta');
+    expect(result).toEqual(expectedRecord);
+  });
+
+  it('utilise le delta explicite lorsqu’il est fourni', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockSingle.mockResolvedValue({
+      data: {
+        id: 'session-2',
+        created_at: new Date().toISOString(),
+        type: 'flash_glow_ultra',
+        duration_sec: 60,
+        mood_delta: 5,
+        meta: null,
+      },
+      error: null,
+    });
+
+    await sessionsService.logSession({
+      type: 'flash_glow_ultra',
+      durationSec: 60,
+      moodBefore: 51,
+      moodAfter: 55,
+      moodDelta: 5.2,
+    });
+
+    expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({
+      mood_delta: 5,
+    }));
+  });
+
+  it('rejette avec SessionsAuthError si aucun utilisateur', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+    await expect(() => sessionsService.logSession({
+      type: 'flash_glow',
+      durationSec: 40,
+    })).rejects.toBeInstanceOf(SessionsAuthError);
+  });
+});

--- a/src/services/sessions.service.ts
+++ b/src/services/sessions.service.ts
@@ -1,0 +1,106 @@
+import { supabase } from '@/integrations/supabase/client';
+
+export class SessionsAuthError extends Error {
+  constructor(message = "Utilisateur non authentifié") {
+    super(message);
+    this.name = 'SessionsAuthError';
+  }
+}
+
+interface SessionLogPayload {
+  type: string;
+  durationSec: number;
+  moodBefore?: number | null;
+  moodAfter?: number | null;
+  moodDelta?: number | null;
+  meta?: Record<string, unknown>;
+  userId?: string;
+}
+
+interface SessionRecord {
+  id: string;
+  created_at: string;
+  type: string;
+  duration_sec: number | null;
+  mood_delta: number | null;
+  meta: Record<string, unknown> | null;
+}
+
+class SessionsService {
+  private async resolveUserId(explicitUserId?: string): Promise<string> {
+    if (explicitUserId) {
+      return explicitUserId;
+    }
+
+    const { data, error } = await supabase.auth.getUser();
+
+    if (error) {
+      throw new Error(error.message || "Impossible de récupérer l'utilisateur authentifié");
+    }
+
+    if (!data?.user) {
+      throw new SessionsAuthError();
+    }
+
+    return data.user.id;
+  }
+
+  private normalizeMood(value?: number | null): number | null {
+    if (typeof value !== 'number' || Number.isNaN(value)) {
+      return null;
+    }
+
+    return Math.max(0, Math.min(100, Math.round(value)));
+  }
+
+  async logSession(payload: SessionLogPayload): Promise<SessionRecord | null> {
+    try {
+      const userId = await this.resolveUserId(payload.userId);
+
+      const safeDuration = Math.max(0, Math.round(payload.durationSec));
+      const moodBefore = this.normalizeMood(payload.moodBefore ?? null);
+      const moodAfter = this.normalizeMood(payload.moodAfter ?? null);
+      const hasExplicitDelta = typeof payload.moodDelta === 'number' && !Number.isNaN(payload.moodDelta);
+      const computedDelta = hasExplicitDelta
+        ? Math.round(payload.moodDelta)
+        : moodBefore !== null && moodAfter !== null
+          ? Math.round(moodAfter - moodBefore)
+          : null;
+
+      const meta = {
+        ...payload.meta,
+        moodBefore: payload.meta && 'moodBefore' in payload.meta ? (payload.meta as any).moodBefore : moodBefore,
+        moodAfter: payload.meta && 'moodAfter' in payload.meta ? (payload.meta as any).moodAfter : moodAfter,
+      } as Record<string, unknown>;
+
+      const { data, error } = await supabase
+        .from('sessions')
+        .insert({
+          user_id: userId,
+          type: payload.type,
+          duration_sec: safeDuration,
+          mood_delta: computedDelta,
+          meta,
+        })
+        .select('id, created_at, type, duration_sec, mood_delta, meta')
+        .single();
+
+      if (error) {
+        throw new Error(error.message || "Échec de l'enregistrement de la session");
+      }
+
+      return data as SessionRecord;
+    } catch (error) {
+      if (error instanceof SessionsAuthError) {
+        throw error;
+      }
+
+      console.error('sessionsService.logSession error', error);
+      throw error instanceof Error ? error : new Error('Échec inattendu lors de la création de la session');
+    }
+  }
+}
+
+export const sessionsService = new SessionsService();
+
+export type { SessionRecord, SessionLogPayload };

--- a/src/store/moodPresets.store.ts
+++ b/src/store/moodPresets.store.ts
@@ -1,0 +1,198 @@
+import { create } from 'zustand';
+import { MoodPresetRecord } from '@/types/mood-mixer';
+import { moodPresetsService, MoodPresetPayload } from '@/services/moodPresetsService';
+
+interface MoodPresetsState {
+  presets: MoodPresetRecord[];
+  isLoading: boolean;
+  isSaving: boolean;
+  error: string | null;
+  hasInitialized: boolean;
+  selectedPresetId: string | null;
+  lastFetchedAt: number | null;
+}
+
+interface MoodPresetsActions {
+  loadPresets: (options?: { force?: boolean }) => Promise<MoodPresetRecord[]>;
+  selectPreset: (id: string | null) => void;
+  createPreset: (payload: MoodPresetPayload) => Promise<MoodPresetRecord | null>;
+  updatePreset: (id: string, payload: Partial<MoodPresetPayload>) => Promise<MoodPresetRecord | null>;
+  deletePreset: (id: string) => Promise<boolean>;
+  reset: () => void;
+}
+
+export type MoodPresetsStore = MoodPresetsState & MoodPresetsActions;
+
+const initialState: MoodPresetsState = {
+  presets: [],
+  isLoading: false,
+  isSaving: false,
+  error: null,
+  hasInitialized: false,
+  selectedPresetId: null,
+  lastFetchedAt: null,
+};
+
+const sortPresets = (presets: MoodPresetRecord[]) =>
+  [...presets].sort((a, b) => {
+    const left = Date.parse(a.updatedAt ?? a.createdAt ?? '');
+    const right = Date.parse(b.updatedAt ?? b.createdAt ?? '');
+    if (Number.isNaN(left) && Number.isNaN(right)) return 0;
+    if (Number.isNaN(left)) return 1;
+    if (Number.isNaN(right)) return -1;
+    return right - left;
+  });
+
+const dedupePresets = (presets: MoodPresetRecord[]) => {
+  const byId = new Map<string, MoodPresetRecord>();
+  presets.forEach((preset) => {
+    byId.set(preset.id, preset);
+  });
+  return [...byId.values()];
+};
+
+const normalizeError = (error: unknown) => {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  return 'Une erreur inattendue est survenue.';
+};
+
+export const useMoodPresetsStore = create<MoodPresetsStore>((set, get) => ({
+  ...initialState,
+
+  async loadPresets({ force = false } = {}) {
+    const { isLoading, hasInitialized, lastFetchedAt } = get();
+    const stale = !lastFetchedAt || Date.now() - lastFetchedAt > 60_000;
+    if (isLoading || (hasInitialized && !force && !stale)) {
+      return get().presets;
+    }
+
+    set({ isLoading: true, error: null });
+
+    try {
+      const records = await moodPresetsService.listPresets();
+      const presets = sortPresets(dedupePresets(records));
+      const selectedPresetId = presets.some((preset) => preset.id === get().selectedPresetId)
+        ? get().selectedPresetId
+        : null;
+
+      set({
+        presets,
+        isLoading: false,
+        hasInitialized: true,
+        selectedPresetId,
+        lastFetchedAt: Date.now(),
+        error: null,
+      });
+
+      return presets;
+    } catch (error) {
+      set({
+        isLoading: false,
+        hasInitialized: true,
+        error: normalizeError(error),
+      });
+      throw error;
+    }
+  },
+
+  selectPreset(id) {
+    const { presets } = get();
+    if (id && !presets.some((preset) => preset.id === id)) {
+      return;
+    }
+    set({ selectedPresetId: id });
+  },
+
+  async createPreset(payload) {
+    if (get().isSaving) {
+      return null;
+    }
+
+    set({ isSaving: true, error: null });
+
+    try {
+      const record = await moodPresetsService.createPreset(payload);
+      if (!record) {
+        return null;
+      }
+
+      const presets = sortPresets([record, ...get().presets.filter((preset) => preset.id !== record.id)]);
+
+      set({
+        presets,
+        isSaving: false,
+        selectedPresetId: record.id,
+        error: null,
+      });
+
+      return record;
+    } catch (error) {
+      set({ isSaving: false, error: normalizeError(error) });
+      throw error;
+    }
+  },
+
+  async updatePreset(id, payload) {
+    if (get().isSaving) {
+      return null;
+    }
+
+    set({ isSaving: true, error: null });
+
+    try {
+      const record = await moodPresetsService.updatePreset(id, payload);
+      if (!record) {
+        return null;
+      }
+
+      const presets = sortPresets([
+        record,
+        ...get().presets.filter((preset) => preset.id !== record.id),
+      ]);
+
+      set({
+        presets,
+        isSaving: false,
+        selectedPresetId: record.id,
+        error: null,
+      });
+
+      return record;
+    } catch (error) {
+      set({ isSaving: false, error: normalizeError(error) });
+      throw error;
+    }
+  },
+
+  async deletePreset(id) {
+    if (get().isSaving) {
+      return false;
+    }
+
+    set({ isSaving: true, error: null });
+
+    try {
+      await moodPresetsService.deletePreset(id);
+
+      const presets = get().presets.filter((preset) => preset.id !== id);
+      const selectedPresetId = get().selectedPresetId === id ? null : get().selectedPresetId;
+
+      set({
+        presets,
+        isSaving: false,
+        selectedPresetId,
+        error: null,
+      });
+
+      return true;
+    } catch (error) {
+      set({ isSaving: false, error: normalizeError(error) });
+      throw error;
+    }
+  },
+
+  reset() {
+    set({ ...initialState });
+  },
+}));

--- a/src/ui/hooks/__tests__/useBreathPattern.test.ts
+++ b/src/ui/hooks/__tests__/useBreathPattern.test.ts
@@ -1,0 +1,84 @@
+import { renderHook, act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useBreathPattern } from '../useBreathPattern';
+
+const rafDriver = vi.hoisted(() => ({
+  callback: null as null | ((t: number) => void),
+}));
+
+vi.mock('@/ui/hooks/useRaf', () => ({
+  useRaf: (cb: (t: number) => void, enabled = true) => {
+    if (enabled) {
+      rafDriver.callback = cb;
+    } else if (rafDriver.callback === cb) {
+      rafDriver.callback = null;
+    }
+  },
+}));
+
+const SIMPLE_PATTERN: Array<{ phase: 'inhale' | 'exhale'; sec: number }> = [
+  { phase: 'inhale', sec: 1 },
+  { phase: 'exhale', sec: 1 },
+];
+
+describe('useBreathPattern', () => {
+  let now = 0;
+  let performanceSpy: ReturnType<typeof vi.spyOn>;
+
+  const advance = (ms: number) => {
+    now += ms;
+    const callback = rafDriver.callback;
+    if (callback) {
+      act(() => {
+        callback(now);
+      });
+    }
+  };
+
+  beforeEach(() => {
+    now = 0;
+    performanceSpy = vi.spyOn(performance, 'now').mockImplementation(() => now);
+    rafDriver.callback = null;
+  });
+
+  it('gère la progression des phases et cycles', () => {
+    const { result } = renderHook(() => useBreathPattern(SIMPLE_PATTERN, 2));
+
+    expect(result.current.running).toBe(false);
+    expect(result.current.current.phase).toBe('inhale');
+
+    act(() => {
+      result.current.start();
+    });
+
+    expect(result.current.running).toBe(true);
+    expect(rafDriver.callback).toBeTypeOf('function');
+
+    advance(500);
+    expect(result.current.phaseProgress).toBeCloseTo(0.5, 1);
+    expect(result.current.current.phase).toBe('inhale');
+
+    advance(600);
+    expect(result.current.current.phase).toBe('exhale');
+    expect(result.current.cycle).toBe(0);
+
+    advance(1000);
+    expect(result.current.current.phase).toBe('inhale');
+    expect(result.current.cycle).toBe(1);
+
+    act(() => {
+      result.current.stop();
+    });
+
+    expect(result.current.running).toBe(false);
+    expect(result.current.cycle).toBe(0);
+    expect(result.current.phaseProgress).toBe(0);
+    expect(result.current.current.phase).toBe('inhale');
+  });
+
+  afterEach(() => {
+    performanceSpy.mockRestore();
+    rafDriver.callback = null;
+  });
+});
+

--- a/tests/e2e/adaptive-music.spec.ts
+++ b/tests/e2e/adaptive-music.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect } from '@playwright/test';
+
+const PLAYLIST_ROUTE = '**/api/mood_playlist';
+
+const playlistPayload = {
+  playlist_id: 'relaxed_focus_set',
+  mood: 'relaxed',
+  requested_mood: 'relaxed',
+  title: 'Relaxed Focus Session',
+  description: 'Une sélection adaptée pour alléger la charge mentale.',
+  total_duration: 1800,
+  tracks: [
+    {
+      id: 'track-relax-1',
+      title: 'Deep Calm Waves',
+      artist: 'Adaptive Ensemble',
+      url: 'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAESsAACJWAAACABAAZGF0YQAAAAA=',
+      duration: 240,
+      mood: 'relaxed',
+      energy: 0.42,
+      focus: 'flow',
+      instrumentation: ['synth', 'pads'],
+      tags: ['calm', 'deep-work'],
+      description: 'Pads éthérés pour stabiliser la respiration.',
+    },
+    {
+      id: 'track-relax-2',
+      title: 'Morning Horizon',
+      artist: 'Adaptive Ensemble',
+      url: 'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAESsAACJWAAACABAAZGF0YQAAAAA=',
+      duration: 300,
+      mood: 'relaxed',
+      energy: 0.48,
+      focus: 'breathing',
+      instrumentation: ['piano', 'textures'],
+      tags: ['serenity'],
+      description: 'Textures lumineuses pour préparer la journée.',
+    },
+  ],
+  energy_profile: {
+    baseline: 0.35,
+    requested: 0.4,
+    recommended: 0.52,
+    alignment: 0.86,
+    curve: [
+      {
+        track_id: 'track-relax-1',
+        start: 0,
+        end: 240,
+        energy: 0.42,
+        focus: 'flow',
+      },
+      {
+        track_id: 'track-relax-2',
+        start: 240,
+        end: 540,
+        energy: 0.48,
+        focus: 'breathing',
+      },
+    ],
+  },
+  recommendations: [
+    'Installez-vous dans un espace calme pendant 20 minutes.',
+    'Respirez en carré sur les deux premières pistes.',
+  ],
+  guidance: {
+    focus: 'Maintenez une respiration régulière et relâchez progressivement les épaules.',
+    breathwork: 'Coherence cardiaque 5-5',
+    activities: ['Deep work', 'Lecture douce'],
+  },
+  metadata: {
+    curated_by: 'Adaptive Coach',
+    tags: ['relax', 'focus'],
+    dataset_version: '2024.09',
+  },
+};
+
+test.describe('Adaptive Music — recommandations & favoris', () => {
+  test.skip(({}, testInfo) => testInfo.project.name !== 'b2c-chromium');
+
+  test('propose une playlist, sauvegarde un favori et reprend la lecture', async ({ page }) => {
+    await page.route(PLAYLIST_ROUTE, async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ ok: true, data: playlistPayload }),
+        });
+        return;
+      }
+
+      await route.continue();
+    });
+
+    await page.goto('/modules/adaptive-music');
+    await page.evaluate(() => {
+      window.localStorage.clear();
+      window.sessionStorage.clear();
+    });
+    await page.reload();
+
+    await expect(page.getByRole('heading', { name: /Adaptive Music/i })).toBeVisible();
+
+    const listenButton = page.getByRole('button', { name: /Écouter/i }).first();
+    await listenButton.click();
+
+    const playerPlayButton = page.getByRole('button', { name: /^Lecture$/i }).first();
+    await playerPlayButton.click();
+    await expect(page.getByRole('button', { name: /^Pause$/i })).toBeVisible();
+
+    await page.waitForTimeout(1200);
+
+    const pauseButton = page.getByRole('button', { name: /^Pause$/i }).first();
+    await pauseButton.click();
+
+    const favoriteToggle = page.getByRole('button', { name: /Ajouter aux favoris/i });
+    await favoriteToggle.click();
+    await expect(favoriteToggle).toHaveAttribute('aria-pressed', 'true');
+
+    await page.reload();
+
+    await expect(page.getByText(/Favoris récents/)).toBeVisible();
+    const resumeCard = page.getByRole('button', { name: /Reprendre/i });
+    await expect(resumeCard).toBeEnabled();
+
+    await resumeCard.click();
+    await expect(page.getByRole('button', { name: /^Pause$/i })).toBeVisible();
+
+    const favoritePlay = page.getByRole('button', { name: /^Lire$/i }).first();
+    await favoritePlay.click();
+    await expect(page.getByRole('button', { name: /^Pause$/i })).toBeVisible();
+
+    await expect(page.getByText(/Installez-vous dans un espace calme/)).toBeVisible();
+    await expect(page.getByText(/Jeu de données 2024\.09/i)).toBeVisible();
+  });
+});
+

--- a/tests/e2e/breath-constellation-session.spec.ts
+++ b/tests/e2e/breath-constellation-session.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from '@playwright/test';
+
+const SUPABASE_AUTH_USER_URL = '**/auth/v1/user';
+const SUPABASE_BREATH_SESSIONS_URL = '**/rest/v1/breathwork_sessions*';
+const SUPABASE_SESSIONS_URL = '**/rest/v1/sessions*';
+
+const credentialsAvailable = Boolean(process.env.PW_B2C_EMAIL && process.env.PW_B2C_PASSWORD);
+
+test.describe('Breath Constellation — session guidée', () => {
+  test.skip(({}, testInfo) => testInfo.project.name !== 'b2c-chromium');
+
+  test('propose un protocole respiratoire et journalise la session', async ({ page }) => {
+    test.skip(
+      !credentialsAvailable,
+      'Identifiants B2C manquants pour valider le parcours Breath Constellation.',
+    );
+
+    const breathPayloads: any[] = [];
+    const sessionPayloads: any[] = [];
+
+    await page.route(SUPABASE_AUTH_USER_URL, async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'stub-user-id',
+          aud: 'authenticated',
+          role: 'authenticated',
+          email: process.env.PW_B2C_EMAIL,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        }),
+      });
+    });
+
+    await page.route(SUPABASE_BREATH_SESSIONS_URL, async route => {
+      if (route.request().method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+
+      const payload = JSON.parse(route.request().postData() ?? '{}');
+      breathPayloads.push(payload);
+
+      const record = {
+        id: `breath-${breathPayloads.length}`,
+        user_id: 'stub-user-id',
+        technique_type: payload.technique_type,
+        duration: payload.duration,
+        session_data: payload.session_data,
+        created_at: new Date().toISOString(),
+      };
+
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify(record),
+      });
+    });
+
+    await page.route(SUPABASE_SESSIONS_URL, async route => {
+      if (route.request().method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+
+      const payload = JSON.parse(route.request().postData() ?? '{}');
+      sessionPayloads.push(payload);
+
+      const record = {
+        id: `session-${sessionPayloads.length}`,
+        created_at: new Date().toISOString(),
+        type: payload.type,
+        duration_sec: payload.duration_sec,
+        mood_delta: payload.mood_delta ?? null,
+        meta: payload.meta ?? null,
+      };
+
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify(record),
+      });
+    });
+
+    await page.goto('/login?segment=b2c');
+    await page.getByLabel(/Adresse email/i).fill(process.env.PW_B2C_EMAIL!);
+    await page.getByLabel(/Mot de passe/i).fill(process.env.PW_B2C_PASSWORD!);
+    await page.getByRole('button', { name: /Se connecter/i }).click();
+    await expect(page.getByText(/Connexion réussie/i)).toBeVisible({ timeout: 20000 });
+
+    await page.goto('/app/breath');
+    await expect(page.getByRole('heading', { name: /Breath Constellation/i })).toBeVisible({ timeout: 20000 });
+
+    await page.getByLabel(/Protocole respiratoire/i).selectOption('4-7-8');
+    await page.getByLabel(/Nombre de cycles planifiés/i).fill('1');
+
+    await page.getByRole('button', { name: /Démarrer/i }).click();
+    await page.waitForTimeout(2200);
+    await page.getByRole('button', { name: /Terminer/i }).click();
+
+    await expect.poll(() => breathPayloads.length).toBe(1);
+    await expect.poll(() => sessionPayloads.length).toBe(1);
+
+    const supabaseInsert = breathPayloads[0];
+    expect(supabaseInsert.technique_type).toBe('4-7-8');
+    expect(supabaseInsert.duration).toBeGreaterThan(0);
+    expect(supabaseInsert.session_data.cycles_planned).toBe(1);
+
+    const sessionInsert = sessionPayloads[0];
+    expect(sessionInsert.type).toBe('breath');
+    expect(sessionInsert.meta.technique).toBe('4-7-8');
+    expect(sessionInsert.meta.completed).toBe(false);
+    expect(sessionInsert.meta.cues.sound).toBe(false);
+
+    await expect(
+      page.getByText(/Session enregistrée dans votre historique Supabase/i),
+    ).toBeVisible();
+  });
+});
+

--- a/tests/e2e/emotion-scan-dashboard.spec.ts
+++ b/tests/e2e/emotion-scan-dashboard.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect } from '@playwright/test';
+
+const SUPABASE_FUNCTION_URL = '**/functions/v1/ai-emotion-analysis';
+const SUPABASE_TABLE_URL = '**/rest/v1/emotion_scans*';
+
+const credentialsAvailable = Boolean(process.env.PW_B2C_EMAIL && process.env.PW_B2C_PASSWORD);
+
+test.describe('Emotion Scan → Dashboard', () => {
+  test.skip(({ }, testInfo) => testInfo.project.name !== 'b2c-chromium');
+
+  test('le widget dashboard reflète un scan récent', async ({ page }) => {
+    test.skip(!credentialsAvailable, 'Identifiants B2C manquants pour le parcours complet.');
+
+    const now = new Date();
+    const insertedScan = {
+      id: 'scan-e2e-1',
+      user_id: 'stub-user-id',
+      created_at: now.toISOString(),
+      updated_at: now.toISOString(),
+      summary: 'Test e2e — sérénité retrouvée.',
+      mood: 'serenite',
+      confidence: 88,
+      emotional_balance: 72,
+      recommendations: ['Continuer les respirations en carré.'],
+      insights: ['Baisse du stress après la session.'],
+      scan_type: 'ipanassf',
+      emotions: {
+        scores: {
+          joie: 7,
+          confiance: 6,
+          anticipation: 5,
+          surprise: 3,
+          tristesse: 1,
+          colere: 0,
+          peur: 0,
+          degout: 0,
+        },
+        context: 'Auto-évaluation I-PANAS-SF',
+      },
+    };
+
+    await page.route(SUPABASE_FUNCTION_URL, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          emotions: {
+            joie: 0.7,
+            confiance: 0.6,
+            anticipation: 0.5,
+            surprise: 0.3,
+            tristesse: 0.1,
+            colere: 0,
+            peur: 0,
+            degout: 0,
+          },
+          dominantEmotion: 'serenite',
+          confidence: 0.88,
+          insights: ['Respiration profonde recommandée.'],
+          recommendations: ['Continuer les respirations en carré.'],
+          emotionalBalance: 72,
+        }),
+      });
+    });
+
+    let persisted = false;
+    await page.route(SUPABASE_TABLE_URL, async (route) => {
+      const request = route.request();
+      if (request.method() === 'POST') {
+        persisted = true;
+        await route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify(insertedScan),
+        });
+        return;
+      }
+
+      // select history
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([insertedScan]),
+      });
+    });
+
+    await page.goto('/login?segment=b2c');
+    await page.getByLabel(/Adresse email/i).fill(process.env.PW_B2C_EMAIL!);
+    await page.getByLabel(/Mot de passe/i).fill(process.env.PW_B2C_PASSWORD!);
+    await page.getByRole('button', { name: /Se connecter/i }).click();
+
+    await expect(page.getByText(/Connexion réussie/i)).toBeVisible({ timeout: 20000 });
+
+    await page.goto('/app/scan');
+
+    const radioInputs = page.locator('input[type="radio"]');
+    await expect(radioInputs.first()).toBeVisible();
+    const radioCount = await radioInputs.count();
+    for (let index = 4; index < radioCount; index += 5) {
+      await radioInputs.nth(index).check();
+    }
+
+    await page.getByRole('button', { name: /Calculer/i }).click();
+    await expect(page.getByText(/Analyse de vos réponses/i)).toBeVisible();
+    await expect.poll(() => persisted).toBeTruthy();
+
+    await page.goto('/app/home');
+
+    const widget = page.getByTestId('dashboard-emotion-scan');
+    await expect(widget).toBeVisible();
+    await expect(widget.getByTestId('emotion-scan-latest')).toContainText(/72/);
+    await expect(widget.getByTestId('emotion-scan-timeline')).toContainText(/serenite/i);
+  });
+});

--- a/tests/e2e/flash-glow-session.spec.ts
+++ b/tests/e2e/flash-glow-session.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from '@playwright/test';
+
+const SUPABASE_AUTH_USER_URL = '**/auth/v1/user';
+const SUPABASE_SESSIONS_URL = '**/rest/v1/sessions*';
+const SUPABASE_FLASH_METRICS_URL = '**/functions/v1/flash-glow-metrics';
+
+const credentialsAvailable = Boolean(process.env.PW_B2C_EMAIL && process.env.PW_B2C_PASSWORD);
+
+test.describe('Flash Glow — parcours complet', () => {
+  test.skip(({}, testInfo) => testInfo.project.name !== 'b2c-chromium');
+
+  test('journalise une session et calcule le delta d’humeur', async ({ page }) => {
+    test.skip(!credentialsAvailable, 'Identifiants B2C manquants pour valider le parcours Flash Glow.');
+
+    const sessionCalls: any[] = [];
+    const statsRecords: any[] = [];
+
+    await page.route(SUPABASE_AUTH_USER_URL, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'stub-user-id',
+          aud: 'authenticated',
+          role: 'authenticated',
+          email: process.env.PW_B2C_EMAIL,
+          app_metadata: { provider: 'email' },
+          user_metadata: {},
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        }),
+      });
+    });
+
+    await page.route(SUPABASE_FLASH_METRICS_URL, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, message: 'Bravo', next_session_in: '4h' }),
+      });
+    });
+
+    await page.route(SUPABASE_SESSIONS_URL, async (route) => {
+      const request = route.request();
+      if (request.method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(statsRecords),
+        });
+        return;
+      }
+
+      if (request.method() === 'POST') {
+        const payload = JSON.parse(request.postData() ?? '{}');
+        sessionCalls.push(payload);
+
+        const record = {
+          id: `session-${sessionCalls.length}`,
+          created_at: new Date().toISOString(),
+          type: payload.type,
+          duration_sec: payload.duration_sec,
+          mood_delta: payload.mood_delta ?? null,
+          meta: payload.meta ?? null,
+        };
+        statsRecords.unshift(record);
+
+        await route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify(record),
+        });
+        return;
+      }
+
+      await route.continue();
+    });
+
+    await page.goto('/login?segment=b2c');
+    await page.getByLabel(/Adresse email/i).fill(process.env.PW_B2C_EMAIL!);
+    await page.getByLabel(/Mot de passe/i).fill(process.env.PW_B2C_PASSWORD!);
+    await page.getByRole('button', { name: /Se connecter/i }).click();
+    await expect(page.getByText(/Connexion réussie/i)).toBeVisible({ timeout: 20000 });
+
+    await page.goto('/app/flash-glow');
+    await expect(page.getByRole('heading', { name: /Flash Glow Ultra/i })).toBeVisible({ timeout: 20000 });
+
+    await page.getByRole('button', { name: /Déclencher le Flash Glow/i }).click();
+    const stopButton = page.getByRole('button', { name: /Arrêter/i });
+    await expect(stopButton).toBeVisible({ timeout: 10000 });
+    await stopButton.click();
+
+    await expect(page.getByText(/Ressenti après séance/i)).toBeVisible();
+
+    const afterSlider = page.getByRole('slider').first();
+    await afterSlider.focus();
+    for (let i = 0; i < 12; i += 1) {
+      await afterSlider.press('ArrowRight');
+    }
+
+    await page.getByRole('button', { name: /Gain ressenti/i }).click();
+
+    await expect.poll(() => sessionCalls.length).toBe(1);
+
+    const payload = sessionCalls[0];
+    expect(payload.user_id).toBe('stub-user-id');
+    expect(payload.type).toBe('flash_glow');
+    expect(payload.duration_sec).toBeGreaterThan(0);
+    expect(payload.meta?.moodBefore).toBeGreaterThanOrEqual(0);
+    expect(payload.meta?.moodAfter).toBeGreaterThan(payload.meta?.moodBefore ?? 0);
+    expect(payload.mood_delta).toBeGreaterThan(0);
+
+    await expect(page.getByText(/Votre expérience a été ajoutée automatiquement au journal/i)).toBeVisible();
+  });
+});

--- a/tests/e2e/journal-feed.spec.ts
+++ b/tests/e2e/journal-feed.spec.ts
@@ -1,0 +1,135 @@
+import { test, expect } from '@playwright/test';
+
+const SUPABASE_AUTH_USER_URL = '**/auth/v1/user';
+const JOURNAL_FEED_URL = '**/functions/v1/api/v1/me/journal';
+const JOURNAL_TEXT_URL = '**/functions/v1/api/v1/journal/text';
+
+const credentialsAvailable = Boolean(process.env.PW_B2C_EMAIL && process.env.PW_B2C_PASSWORD);
+
+const buildAuthUserPayload = () => ({
+  id: 'stub-user-id',
+  aud: 'authenticated',
+  role: 'authenticated',
+  email: process.env.PW_B2C_EMAIL,
+  app_metadata: { provider: 'email' },
+  user_metadata: {},
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+});
+
+const buildJournalResponse = (entries: any[]) => ({
+  ok: true,
+  data: { entries },
+});
+
+const extractTags = (payload: Record<string, any>) => {
+  const raw = String(payload.text_raw ?? '');
+  return Array.from(raw.match(/#([\p{L}\p{N}_-]{2,24})/gu) ?? []).map((tag) => tag.slice(1).toLowerCase());
+};
+
+test.describe('Journal — parcours complet', () => {
+  test.skip(({}, testInfo) => testInfo.project.name !== 'b2c-chromium');
+
+  test('permet de créer une entrée et de filtrer le feed', async ({ page }) => {
+    test.skip(!credentialsAvailable, 'Identifiants B2C manquants pour valider le parcours Journal.');
+
+    const feedEntries: any[] = [
+      {
+        id: 'entry-1',
+        ts: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+        type: 'text',
+        text_raw: 'Ancienne note #bilan',
+        preview: 'Ancienne note #bilan',
+        summary: null,
+        tags: ['bilan'],
+        valence: 0,
+        meta: { tags: ['bilan'] },
+      },
+    ];
+
+    await page.route(SUPABASE_AUTH_USER_URL, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(buildAuthUserPayload()),
+      });
+    });
+
+    await page.route(JOURNAL_FEED_URL, async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(buildJournalResponse(feedEntries)),
+        });
+        return;
+      }
+      await route.continue();
+    });
+
+    await page.route(JOURNAL_TEXT_URL, async (route) => {
+      const request = route.request();
+      if (request.method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+
+      const payload = JSON.parse(request.postData() ?? '{}');
+      const id = `entry-${feedEntries.length + 1}`;
+      const ts = new Date().toISOString();
+      const tags = extractTags(payload);
+
+      feedEntries.unshift({
+        id,
+        ts,
+        type: 'text',
+        text_raw: payload.text_raw,
+        preview: payload.preview,
+        summary: payload.preview,
+        tags,
+        tag_set: tags,
+        meta: { tags },
+        valence: payload.valence ?? 0,
+      });
+
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, data: { id, ts } }),
+      });
+    });
+
+    await page.goto('/login?segment=b2c');
+    await page.getByLabel(/Adresse email/i).fill(process.env.PW_B2C_EMAIL!);
+    await page.getByLabel(/Mot de passe/i).fill(process.env.PW_B2C_PASSWORD!);
+    await page.getByRole('button', { name: /Se connecter/i }).click();
+    await expect(page.getByText(/Connexion réussie/i)).toBeVisible({ timeout: 20000 });
+
+    await page.goto('/app/journal');
+    await expect(page.getByRole('heading', { name: /Journal/i })).toBeVisible();
+    await expect(page.getByText('Ancienne note')).toBeVisible();
+
+    await page.getByTestId('journal-input').fill('Nouvelle entrée <img src="x" onerror="alert(1)"> #Gratitude');
+    await page.getByLabel(/Tags/i).fill('Gratitude énergie');
+    await page.getByRole('button', { name: /Enregistrer/i }).click();
+
+    await expect.poll(() => feedEntries.length).toBeGreaterThan(1);
+    await expect(page.locator('img[src="x"]')).toHaveCount(0);
+    await expect(page.getByText(/Nouvelle entrée/)).toBeVisible();
+
+    const search = page.getByLabel(/Recherche/i);
+    await search.fill('gratitude');
+    await expect(page.getByText(/Nouvelle entrée/)).toBeVisible();
+    await search.fill('');
+
+    await page.getByRole('button', { name: '#gratitude' }).click();
+    await expect(page.getByText(/Nouvelle entrée/)).toBeVisible();
+    await page.getByRole('button', { name: 'Tous' }).click();
+
+    await page.goto('/app/dashboard');
+    const summaryCard = page.getByRole('heading', { name: 'Journal récent' }).locator('..').locator('..');
+    await expect(summaryCard).toBeVisible();
+    await expect(summaryCard).toContainText('Nouvelle entrée');
+    await expect(summaryCard).toContainText('#gratitude', { timeout: 5000 });
+  });
+});

--- a/tests/e2e/mood-mixer-crud.spec.ts
+++ b/tests/e2e/mood-mixer-crud.spec.ts
@@ -1,0 +1,151 @@
+import { test, expect } from '@playwright/test';
+
+const SUPABASE_PRESETS_URL = '**/rest/v1/mood_presets*';
+const SUPABASE_AUTH_USER_URL = '**/auth/v1/user';
+
+const credentialsAvailable = Boolean(process.env.PW_B2C_EMAIL && process.env.PW_B2C_PASSWORD);
+
+const extractId = (param: string | null) => {
+  if (!param) return null;
+  const [, value] = param.split('eq.');
+  return value ?? null;
+};
+
+test.describe('Mood Mixer — gestion des presets', () => {
+  test.skip(({}, testInfo) => testInfo.project.name !== 'b2c-chromium');
+
+  test('permet de créer, modifier et supprimer une ambiance personnalisée', async ({ page }) => {
+    test.skip(!credentialsAvailable, 'Identifiants B2C manquants pour valider le CRUD Mood Mixer.');
+
+    const records: any[] = [];
+
+    await page.route(SUPABASE_AUTH_USER_URL, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'stub-user-id',
+          aud: 'authenticated',
+          role: 'authenticated',
+          email: process.env.PW_B2C_EMAIL,
+          app_metadata: { provider: 'email' },
+          user_metadata: {},
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        }),
+      });
+    });
+
+    await page.route(SUPABASE_PRESETS_URL, async (route) => {
+      const request = route.request();
+      const method = request.method();
+
+      if (method === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(records),
+        });
+        return;
+      }
+
+      if (method === 'POST') {
+        const payload = JSON.parse(request.postData() ?? '{}');
+        const created = {
+          id: `preset-${Date.now()}`,
+          user_id: 'stub-user-id',
+          slug: payload.slug ?? null,
+          name: payload.name,
+          description: payload.description ?? null,
+          icon: payload.icon ?? null,
+          gradient: payload.gradient ?? null,
+          tags: payload.tags ?? [],
+          softness: payload.softness ?? 50,
+          clarity: payload.clarity ?? 50,
+          blend: payload.blend ?? {},
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        };
+        records.unshift(created);
+        await route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify(created),
+        });
+        return;
+      }
+
+      if (method === 'PATCH') {
+        const url = new URL(request.url());
+        const targetId = extractId(url.searchParams.get('id'));
+        const payload = JSON.parse(request.postData() ?? '{}');
+        const index = targetId ? records.findIndex((record) => record.id === targetId) : -1;
+        if (index >= 0) {
+          records[index] = {
+            ...records[index],
+            ...payload,
+            updated_at: new Date().toISOString(),
+          };
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(records[index]),
+          });
+          return;
+        }
+        await route.fulfill({ status: 404, body: '' });
+        return;
+      }
+
+      if (method === 'DELETE') {
+        const url = new URL(request.url());
+        const targetId = extractId(url.searchParams.get('id'));
+        if (targetId) {
+          const index = records.findIndex((record) => record.id === targetId);
+          if (index >= 0) {
+            records.splice(index, 1);
+          }
+        }
+        await route.fulfill({ status: 204, body: '' });
+        return;
+      }
+
+      await route.continue();
+    });
+
+    await page.goto('/login?segment=b2c');
+    await page.getByLabel(/Adresse email/i).fill(process.env.PW_B2C_EMAIL!);
+    await page.getByLabel(/Mot de passe/i).fill(process.env.PW_B2C_PASSWORD!);
+    await page.getByRole('button', { name: /Se connecter/i }).click();
+    await expect(page.getByText(/Connexion réussie/i)).toBeVisible({ timeout: 20000 });
+
+    await page.goto('/app/mood-mixer');
+    await expect(page.getByRole('heading', { name: /Mood Mixer/i })).toBeVisible();
+
+    await page.getByRole('button', { name: /Sauvegarder la vibe/i }).click();
+    await expect(page.getByText(/Ambiance sauvegardée/i)).toBeVisible();
+
+    const savedCard = page.locator('div', { hasText: 'Mix personnel 50% doux, 50% clair' }).first();
+    await expect(savedCard).toBeVisible();
+
+    const sliders = page.getByRole('slider');
+    await sliders.first().focus();
+    for (let i = 0; i < 8; i += 1) {
+      await sliders.first().press('ArrowRight');
+    }
+    await sliders.nth(1).focus();
+    for (let i = 0; i < 5; i += 1) {
+      await sliders.nth(1).press('ArrowRight');
+    }
+
+    await page.getByRole('button', { name: /Mettre à jour la vibe sélectionnée/i }).click();
+    await expect(page.getByText(/Ambiance mise à jour/i)).toBeVisible();
+    await expect(page.getByText('Mix personnel 58% doux, 55% clair')).toBeVisible();
+
+    page.once('dialog', (dialog) => dialog.accept());
+    await savedCard.locator('button[aria-label^="Supprimer"]').click();
+    await expect(page.getByText(/Ambiance supprimée/i)).toBeVisible();
+    await expect(page.getByText('Mix personnel 58% doux, 55% clair')).not.toBeVisible();
+    await expect.poll(() => records.length).toBe(0);
+  });
+});

--- a/tests/e2e/scores-dashboard.spec.ts
+++ b/tests/e2e/scores-dashboard.spec.ts
@@ -1,0 +1,178 @@
+import { test, expect } from '@playwright/test';
+
+const EMOTION_SCANS_ENDPOINT = '**/rest/v1/emotion_scans*';
+const FLASH_GLOW_ENDPOINT = '**/rest/v1/metrics_flash_glow*';
+const BREATHWORK_ENDPOINT = '**/rest/v1/breathwork_sessions*';
+const JOURNAL_ENDPOINT = '**/rest/v1/journal_entries*';
+const MUSIC_ENDPOINT = '**/rest/v1/music_sessions*';
+const VR_BREATH_ENDPOINT = '**/rest/v1/metrics_vr_breath*';
+const VR_GALAXY_ENDPOINT = '**/rest/v1/metrics_vr_galaxy*';
+
+function isoDaysAgo(daysAgo: number, hours: number) {
+  const date = new Date();
+  date.setHours(hours, 0, 0, 0);
+  date.setDate(date.getDate() - daysAgo);
+  return date.toISOString();
+}
+
+function isoWeeksAgo(weeksAgo: number, hours: number) {
+  const date = new Date();
+  date.setHours(hours, 0, 0, 0);
+  date.setDate(date.getDate() - weeksAgo * 7);
+  return date.toISOString();
+}
+
+test.describe('Scores & Heatmap — visualisation et export', () => {
+  test.skip(({}, testInfo) => testInfo.project.name !== 'b2c-chromium');
+
+  test('affiche les graphiques et déclenche un export PNG', async ({ page }) => {
+    await page.addInitScript(() => {
+      (window as unknown as { __downloadSpy: Array<{ download: string; href: string }> }).__downloadSpy = [];
+      const anchorProto = HTMLAnchorElement.prototype;
+      const originalClick = anchorProto.click;
+      anchorProto.click = function patchedClick(this: HTMLAnchorElement) {
+        const spy = (window as unknown as { __downloadSpy: Array<{ download: string; href: string }> }).__downloadSpy;
+        spy.push({ download: this.download, href: this.href });
+        return originalClick.call(this);
+      };
+    });
+
+    const emotionScans = Array.from({ length: 10 }, (_, index) => {
+      const daysAgo = 9 - index;
+      return {
+        created_at: isoDaysAgo(daysAgo, 9),
+        emotional_balance: 58 + index * 3,
+        emotions: {
+          scores: {
+            joie: 6 + index * 0.2,
+            anticipation: 5 + index * 0.15,
+            surprise: 3 + index * 0.1,
+            tristesse: 1.1,
+            colere: 0.7,
+            peur: 0.5,
+            degout: 0.3,
+          },
+        },
+        insights: [`Perspective ${index + 1}`],
+        summary: `Synthèse ${index + 1}`,
+        mood: index % 2 === 0 ? 'confiant' : 'apaise',
+      };
+    });
+
+    const flashGlowMetrics = [
+      ...Array.from({ length: 6 }, (_, week) => ({ ts: isoWeeksAgo(week, 18) })),
+      { ts: isoDaysAgo(1, 8) },
+      { ts: isoDaysAgo(3, 20) },
+    ];
+
+    const breathworkSessions = [
+      ...Array.from({ length: 6 }, (_, week) => ({
+        created_at: isoWeeksAgo(week, 7),
+        technique_type: week % 2 === 0 ? 'coherence_cardiaque' : '4-7-8',
+        session_data: { density: 0.58 + week * 0.05 },
+      })),
+      {
+        created_at: isoDaysAgo(2, 6),
+        technique_type: '4-7-8',
+        session_data: { density: 0.72 },
+      },
+    ];
+
+    const journalEntries = [
+      { date: isoWeeksAgo(0, 12), ai_feedback: 'Focus du jour' },
+      { date: isoWeeksAgo(1, 12), ai_feedback: 'Respiration profonde' },
+      { date: isoDaysAgo(0, 15), ai_feedback: 'Réflexion calme' },
+    ];
+
+    const musicSessions = [
+      { created_at: isoDaysAgo(0, 8), mood_tag: 'focus' },
+      { created_at: isoDaysAgo(3, 19), mood_tag: 'calm' },
+    ];
+
+    const vrBreathMetrics = [
+      { ts: isoWeeksAgo(0, 16) },
+      { ts: isoWeeksAgo(1, 17) },
+    ];
+
+    const vrGalaxyMetrics = [
+      { ts: isoWeeksAgo(1, 21) },
+      { ts: isoWeeksAgo(2, 22) },
+    ];
+
+    await page.route(EMOTION_SCANS_ENDPOINT, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(emotionScans),
+      });
+    });
+
+    await page.route(FLASH_GLOW_ENDPOINT, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(flashGlowMetrics),
+      });
+    });
+
+    await page.route(BREATHWORK_ENDPOINT, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(breathworkSessions),
+      });
+    });
+
+    await page.route(JOURNAL_ENDPOINT, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(journalEntries),
+      });
+    });
+
+    await page.route(MUSIC_ENDPOINT, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(musicSessions),
+      });
+    });
+
+    await page.route(VR_BREATH_ENDPOINT, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(vrBreathMetrics),
+      });
+    });
+
+    await page.route(VR_GALAXY_ENDPOINT, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(vrGalaxyMetrics),
+      });
+    });
+
+    await page.goto('/app/scores');
+
+    const panel = page.getByRole('region', { name: /Scores V2/i });
+    await expect(panel.getByRole('heading', { name: /Évolution de l'humeur/i })).toBeVisible();
+    await expect(panel.getByRole('heading', { name: /Séances par semaine/i })).toBeVisible();
+    await expect(panel.getByRole('heading', { name: /Heatmap Vibes/i })).toBeVisible();
+    await expect(panel.getByText(/Humeur moyenne/)).toBeVisible();
+
+    await expect(panel).toHaveScreenshot('scores-dashboard.png', {
+      animations: 'disabled',
+      caret: 'hide',
+      maxDiffPixelRatio: 0.05,
+    });
+
+    const exportButton = panel.getByRole('button', { name: /Exporter l'évolution de l'humeur/i });
+    await exportButton.click();
+
+    const downloads = await page.evaluate(() => (window as unknown as { __downloadSpy?: Array<{ download: string; href: string }> }).__downloadSpy ?? []);
+    expect(downloads.some(entry => entry.download === 'scores-humeur.png' && entry.href.startsWith('data:image/png;base64,'))).toBeTruthy();
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,3 +1,4 @@
+import tsconfigPaths from 'vite-tsconfig-paths';
 // Configuration Vite en JavaScript pur - Évite complètement TypeScript
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
@@ -13,12 +14,12 @@ export default defineConfig(({ mode }) => ({
     host: "::",
     port: 8080,
   },
-  plugins: [
+  plugins: [tsconfigPaths(), 
     react({
       // Configuration React sans TypeScript du tout
       typescript: false,
       babel: {
-        plugins: []
+        plugins: [tsconfigPaths(), ]
       }
     }),
     mode === 'development' && componentTagger(),


### PR DESCRIPTION
## Summary
- expand the Sentry client helpers with initialization safeguards, DOM monitoring and user context tracking from the root provider
- tighten Emotion Scan form validation with an exported schema, accessible error feedback and dedicated unit coverage
- validate Mood Mixer presets through shared zod schemas, add regression tests, and optimise the hero fallback with a `<picture>` element

## Testing
- npm run lint
- npx vitest run src/__tests__/emotion-scan.snapshot.spec.tsx --update
- npx vitest run src/services/__tests__/moodPresets.validation.test.ts src/modules/emotion-scan/__tests__/emotionScan.validation.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cbaff5cc7c832d9d05d4adf419b0d6