### PR TITLE
Add automated data validation SQL and documentation

### DIFF
--- a/.github/workflows/validate-data.yml
+++ b/.github/workflows/validate-data.yml
@@ -1,0 +1,43 @@
+name: Validate Data (D.1)
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - "sql/**"
+      - ".github/workflows/validate-data.yml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    env:
+      DB_URL: ${{ secrets.DB_URL_STAGING }}  # ex: postgres://user:pass@host:5432/dbname
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install psql
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
+      - name: Run validation SQL
+        id: runsql
+        run: |
+          set -e
+          # Exécute et capture la sortie en TSV (facile à parser)
+          psql "$DB_URL" -f sql/007_validation_data.sql -v ON_ERROR_STOP=1 -P pager=off -A -F $'\t' > validation.tsv || true
+          echo "---- Result lines ----"
+          cat validation.tsv || true
+          lines=$(wc -l < validation.tsv | tr -d ' ')
+          echo "lines=$lines" >> $GITHUB_OUTPUT
+
+      - name: Fail if anomalies
+        if: steps.runsql.outputs.lines != '0'
+        run: |
+          echo "::error::Data validation found anomalies:"
+          cat validation.tsv
+          exit 1
+
+      - name: Success note
+        if: steps.runsql.outputs.lines == '0'
+        run: echo "Data validation passed (no anomalies)."

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -1,0 +1,88 @@
+# Validation des données (D.1)
+
+Ce dossier décrit la procédure de contrôle des données métier attendues pour les items, compétences, pistes générées et segments de paroles. L'objectif est de détecter toute anomalie structurelle avant d'exécuter les étapes d'orchestration (RPC, backfill, etc.).
+
+## Contenu
+
+- [`sql/007_validation_data.sql`](../sql/007_validation_data.sql) : script SQL principal. Il regroupe l'ensemble des requêtes de vérification et **ne renvoie aucune ligne si la base est conforme**. Toute ligne retournée correspond à une anomalie dont le code figure dans la première colonne.
+- [`/.github/workflows/validate-data.yml`](../.github/workflows/validate-data.yml) *(optionnel mais recommandé)* : workflow GitHub Actions exécutant automatiquement le script sur chaque Pull Request.
+
+## Pré-requis
+
+- Accès à la base ciblée (local, staging) exposée en PostgreSQL.
+- Variable d'environnement contenant l'URL de connexion. Les exemples ci-dessous utilisent `SUPABASE_DB_URL` en local et `DB_URL_STAGING` en CI.
+- Client `psql` installé.
+
+## Exécution locale
+
+1. Exporter l'URL de connexion :
+   ```bash
+   export SUPABASE_DB_URL="postgres://user:pass@host:5432/dbname"
+   ```
+2. Lancer le script :
+   ```bash
+   psql "$SUPABASE_DB_URL" -f sql/007_validation_data.sql -v ON_ERROR_STOP=1 -P pager=off
+   ```
+3. Interprétation :
+   - **0 ligne retournée** → la base est conforme.
+   - **≥1 ligne** → chaque ligne correspond à une anomalie à corriger (voir colonne `code`).
+
+### Via Supabase SQL Editor
+
+1. Ouvrir le SQL Editor.
+2. Copier/coller le contenu du fichier [`sql/007_validation_data.sql`](../sql/007_validation_data.sql).
+3. Exécuter le script :
+   - 0 ligne = conforme.
+   - Sinon, corriger les anomalies indiquées.
+
+> Le script contient plusieurs requêtes `SELECT`. Si l'éditeur ne supporte pas l'exécution multi-statement, exécuter chaque bloc `SELECT` séparément.
+
+### Via PostgREST
+
+Le fichier comporte plusieurs requêtes. PostgREST n'étant pas adapté à l'exécution multi-statement, préférer `psql`. En cas de besoin, exécuter les blocs `SELECT` séparément.
+
+## Exécution sur l'environnement de staging
+
+1. Vérifier que l'URL de connexion staging est disponible (ex. `postgres://user:pass@staging-host:5432/dbname`).
+2. Exécuter :
+   ```bash
+   psql "$SUPABASE_DB_URL" -f sql/007_validation_data.sql -v ON_ERROR_STOP=1 -P pager=off
+   ```
+   (Remplacer `SUPABASE_DB_URL` par la variable adéquate, p. ex. `STAGING_DB_URL`).
+3. Valider que la sortie est vide.
+
+## Intégration continue
+
+Le workflow GitHub Actions fourni s'exécute automatiquement sur chaque Pull Request qui modifie les fichiers SQL ou le workflow lui-même. Il échoue si le script retourne au moins une ligne.
+
+### Création du secret
+
+1. Aller dans **Settings → Secrets and variables → Actions**.
+2. Créer le secret `DB_URL_STAGING` contenant l'URL PostgreSQL de l'environnement de staging.
+
+### Personnalisation
+
+- Ajuster le nom du secret si nécessaire (et mettre à jour le workflow).
+- Ajouter d'autres déclencheurs (`push`, cron, etc.) selon vos besoins.
+
+## Résolution des anomalies
+
+Le code de chaque anomalie est rappelé ci-dessous :
+
+| Code | Signification | Action recommandée |
+| ---- | ------------- | ------------------ |
+| `A_TOTAL_ITEMS_NOT_367` | Nombre d'items différent de 367 | Synchroniser le référentiel des items |
+| `B_ITEM_WITHOUT_ANY_COMPETENCE` | Item sans compétence associée | Compléter les compétences (Rang A/B) |
+| `C_ITEM_MISSING_A_OR_B` | Item sans compétence Rang A ou Rang B | Ajouter les compétences manquantes ou documenter l'exception |
+| `D_DUPLICATE_ITEM_SLUG` | `slug` dupliqué | Corriger les doublons (contrainte unique recommandée) |
+| `E_INCOMPLETE_TRACK_FIELDS` | Piste générée avec champ obligatoire manquant | Compléter les informations de la piste |
+| `F_ORPHAN_TRACK_ITEM` | Piste référencée sur un item inexistant | Purger ou rattacher à un item valide |
+| `G_INVALID_SEG_TIMECODE` | Segment avec `end_ms <= start_ms` | Corriger les timecodes |
+| `H_DUP_SEG_IDX` | Indice `(track_id, idx)` dupliqué | Renuméroter ou supprimer les doublons |
+| `I_ORPHAN_SEG_TRACK` | Segment référencé sur un track inexistant | Purger ou corriger le `track_id` |
+| `J_SEG_ITEM_MISMATCH` | `item_id` segment ≠ `item_id` track | Ré-aligner les segments sur le bon item |
+| `K_TRACK_STATUS_INVALID` | Statut de track en dehors des valeurs attendues | Normaliser le statut (enum recommandée) |
+| `L_TRACK_MODE_INVALID` | Mode de track invalide | Corriger la valeur (`A`, `B` ou `AB`) |
+| `M_EMPTY_SEG_TEXT` | Segment sans texte | Fournir le texte manquant ou supprimer le segment |
+
+Maintenir la base dans un état sain avant d'exécuter les traitements suivants (génération, backfill, etc.) garantit la fiabilité du pipeline de production.

--- a/sql/007_validation_data.sql
+++ b/sql/007_validation_data.sql
@@ -1,0 +1,92 @@
+-- ===========================================
+-- VALIDATIONS COUVERTURE & INTÉGRITÉ (D.1)
+-- Retourne des lignes SEULEMENT si anomalie
+-- ===========================================
+
+-- A. Comptage items (attendu : 367)
+WITH total AS (
+  SELECT COUNT(*) AS n FROM public.items
+)
+SELECT 'A_TOTAL_ITEMS_NOT_367' AS code, n AS observed, 367 AS expected
+FROM total WHERE n <> 367;
+
+-- B. Items sans AUCUNE compétence
+SELECT 'B_ITEM_WITHOUT_ANY_COMPETENCE' AS code, i.id AS item_id, i.slug
+FROM public.items i
+LEFT JOIN public.item_competences c ON c.item_id = i.id
+GROUP BY i.id, i.slug
+HAVING COUNT(c.id) = 0;
+
+-- C. Items sans Rang A OU sans Rang B (signale les trous de couverture)
+SELECT 'C_ITEM_MISSING_A_OR_B' AS code, i.id AS item_id, i.slug,
+  SUM((c.rang='A')::int) AS a_count,
+  SUM((c.rang='B')::int) AS b_count
+FROM public.items i
+LEFT JOIN public.item_competences c ON c.item_id = i.id
+GROUP BY i.id, i.slug
+HAVING SUM((c.rang='A')::int)=0 OR SUM((c.rang='B')::int)=0;
+
+-- D. Duplicats de slug (doit être unique)
+SELECT 'D_DUPLICATE_ITEM_SLUG' AS code, slug, COUNT(*) AS cnt
+FROM public.items
+GROUP BY slug
+HAVING COUNT(*) > 1;
+
+-- E. Tracks incomplets (owner_id / item_id / mode / style manquants)
+SELECT 'E_INCOMPLETE_TRACK_FIELDS' AS code, id AS track_id, owner_id, item_id, mode, style
+FROM public.generated_music_tracks
+WHERE owner_id IS NULL OR item_id IS NULL OR mode IS NULL OR style IS NULL;
+
+-- F. Tracks orphelins (item_id qui ne correspond à aucun item)
+SELECT 'F_ORPHAN_TRACK_ITEM' AS code, t.id AS track_id, t.item_id
+FROM public.generated_music_tracks t
+LEFT JOIN public.items i ON i.id = t.item_id
+WHERE i.id IS NULL;
+
+-- G. Segments invalides (timecode non croissant)
+SELECT 'G_INVALID_SEG_TIMECODE' AS code, id AS segment_id, track_id, idx, start_ms, end_ms
+FROM public.lyrics_segments
+WHERE end_ms <= start_ms;
+
+-- H. Duplicats d’index `(track_id, idx)`
+SELECT 'H_DUP_SEG_IDX' AS code, track_id, idx, COUNT(*) AS cnt
+FROM public.lyrics_segments
+GROUP BY track_id, idx
+HAVING COUNT(*) > 1;
+
+-- I. Segments orphelins (track_id inconnu)
+SELECT 'I_ORPHAN_SEG_TRACK' AS code, s.id AS segment_id, s.track_id
+FROM public.lyrics_segments s
+LEFT JOIN public.generated_music_tracks t ON t.id = s.track_id
+WHERE t.id IS NULL;
+
+-- J. Segments vs item (cohérence item_id)
+SELECT 'J_SEG_ITEM_MISMATCH' AS code, s.id AS segment_id, s.track_id, s.item_id AS seg_item_id, t.item_id AS track_item_id
+FROM public.lyrics_segments s
+JOIN public.generated_music_tracks t ON t.id = s.track_id
+WHERE s.item_id <> t.item_id;
+
+-- K. Statut de track invalide (si check pas déjà en contrainte)
+SELECT 'K_TRACK_STATUS_INVALID' AS code, id AS track_id, status
+FROM public.generated_music_tracks
+WHERE status NOT IN ('pending','processing','ready','failed');
+
+-- L. Mode invalide (si la colonne n’utilise pas l’enum 'music_mode')
+SELECT 'L_TRACK_MODE_INVALID' AS code, id AS track_id, mode::text
+FROM public.generated_music_tracks
+WHERE mode::text NOT IN ('A','B','AB');
+
+-- M. Segments vides (text manquant ou vide)
+SELECT 'M_EMPTY_SEG_TEXT' AS code, id AS segment_id, track_id, idx
+FROM public.lyrics_segments
+WHERE text IS NULL OR length(trim(text)) = 0;
+
+-- N. Résumé utile (ne fait pas échouer, juste info si besoin)
+-- SELECT 'N_INFO_COUNTS' AS code,
+--   (SELECT COUNT(*) FROM public.items) AS items,
+--   (SELECT COUNT(*) FROM public.item_competences) AS competences,
+--   (SELECT COUNT(*) FROM public.generated_music_tracks) AS tracks,
+--   (SELECT COUNT(*) FROM public.lyrics_segments) AS segments;
+
+-- Interprétation : SI la requête ne retourne AUCUNE ligne, c’est “tout bon”.
+-- Toute ligne retournée est une anomalie à corriger (code en première colonne).


### PR DESCRIPTION
## Summary
- add comprehensive SQL validation script for items, generated tracks, and lyrics segments
- document how to execute the validation locally and in staging
- configure a GitHub Actions workflow to run the validation on pull requests

## Testing
- not run (SQL-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cd2cfdfc14832dac92fe7b4d4a95f9