### PR TITLE
refactor: enforce immutable zustand app store

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,10 @@ npm run storybook        # Interface composants
 - Centraliser les stores dans `src/store` et exposer des sélecteurs nommés (`export const selectX = (state) => state.x`).
 - Éviter d'accéder directement à `useStore.getState()` dans les composants : préférer `useStore(selectX)` pour profiter de la comparaison par référence.
 - Chaque ajout de logique store doit s'accompagner d'une suite de tests unitaires ciblant actions et sélecteurs.
+- Pour les sélecteurs qui retournent plusieurs clés ou des objets, utiliser `useAppStore(selector, shallow)` afin d'éviter les rerenders inutiles.
+- Les actions doivent rester pures et immuables : pas de mutation in-place ni d'effets secondaires implicites.
+- Utiliser `subscribeWithSelector` pour les écoutes sans rerender (analytics, logging) et garder `devtools` activé uniquement en développement.
+- Documenter toute nouvelle branche persistée et l'ajouter au `partialize` associé afin de conserver une hydratation minimale.
 
 ### Styling
 - **Tailwind CSS** pour tout le styling

--- a/src/hooks/useGlobalState.ts
+++ b/src/hooks/useGlobalState.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useAppStore } from '@/store/appStore';
+import { useAppStore, shallow } from '@/store/appStore';
 import { useErrorHandler } from '@/contexts/ErrorContext';
 import { useCache } from '@/contexts/CacheContext';
 
@@ -8,7 +8,43 @@ import { useCache } from '@/contexts/CacheContext';
  * Combine Zustand store, gestion d'erreurs et cache
  */
 export const useGlobalState = () => {
-  const store = useAppStore();
+  const stateSlice = useAppStore(
+    (state) => ({
+      user: state.user,
+      isAuthenticated: state.isAuthenticated,
+      isLoading: state.isLoading,
+      theme: state.theme,
+      sidebarCollapsed: state.sidebarCollapsed,
+      activeModule: state.activeModule,
+      cache: state.cache,
+      cacheTimestamps: state.cacheTimestamps,
+      preferences: state.preferences,
+      modules: state.modules,
+    }),
+    shallow
+  );
+
+  const actions = useAppStore(
+    (state) => ({
+      setUser: state.setUser,
+      setTheme: state.setTheme,
+      setAuthenticated: state.setAuthenticated,
+      setLoading: state.setLoading,
+      toggleSidebar: state.toggleSidebar,
+      setActiveModule: state.setActiveModule,
+      updatePreferences: state.updatePreferences,
+      updateMusicState: state.updateMusicState,
+      updateEmotionState: state.updateEmotionState,
+      updateJournalState: state.updateJournalState,
+      updateCoachState: state.updateCoachState,
+      setCache: state.setCache,
+      getCache: state.getCache,
+      clearCache: state.clearCache,
+      isCacheValid: state.isCacheValid,
+      reset: state.reset,
+    }),
+    shallow
+  );
   const errorHandler = useErrorHandler();
   const cache = useCache();
 
@@ -32,23 +68,26 @@ export const useGlobalState = () => {
 
   // Wrapper pour les actions du store avec gestion d'erreurs
   const wrappedActions = {
-    setUser: (user: any) => safeAction(() => store.setUser(user), 'Erreur lors de la mise à jour de l\'utilisateur'),
-    setTheme: (theme: any) => safeAction(() => store.setTheme(theme), 'Erreur lors du changement de thème'),
-    updatePreferences: (prefs: any) => safeAction(() => store.updatePreferences(prefs), 'Erreur lors de la mise à jour des préférences'),
-    updateMusicState: (state: any) => safeAction(() => store.updateMusicState(state), 'Erreur lors de la mise à jour de la musique'),
-    updateEmotionState: (state: any) => safeAction(() => store.updateEmotionState(state), 'Erreur lors de la mise à jour des émotions'),
-    updateJournalState: (state: any) => safeAction(() => store.updateJournalState(state), 'Erreur lors de la mise à jour du journal'),
-    updateCoachState: (state: any) => safeAction(() => store.updateCoachState(state), 'Erreur lors de la mise à jour du coach'),
+    setUser: (user: any) => safeAction(() => actions.setUser(user), 'Erreur lors de la mise à jour de l\'utilisateur'),
+    setTheme: (theme: any) => safeAction(() => actions.setTheme(theme), 'Erreur lors du changement de thème'),
+    updatePreferences: (prefs: any) => safeAction(() => actions.updatePreferences(prefs), 'Erreur lors de la mise à jour des préférences'),
+    updateMusicState: (state: any) => safeAction(() => actions.updateMusicState(state), 'Erreur lors de la mise à jour de la musique'),
+    updateEmotionState: (state: any) => safeAction(() => actions.updateEmotionState(state), 'Erreur lors de la mise à jour des émotions'),
+    updateJournalState: (state: any) => safeAction(() => actions.updateJournalState(state), 'Erreur lors de la mise à jour du journal'),
+    updateCoachState: (state: any) => safeAction(() => actions.updateCoachState(state), 'Erreur lors de la mise à jour du coach'),
   };
 
   return {
     // État du store
-    ...store,
-    
+    ...stateSlice,
+
+    // Actions exposées en direct
+    ...actions,
+
     // Actions wrappées
     actions: {
       ...wrappedActions,
-      ...store,
+      ...actions,
     },
     
     // Gestion d'erreurs

--- a/src/pages/B2CAICoachPage.tsx
+++ b/src/pages/B2CAICoachPage.tsx
@@ -10,7 +10,7 @@ import { ArrowLeft, Send, Mic, MicOff, Bot, User, Heart, Brain, Lightbulb, BookO
 import { useToast } from '@/hooks/use-toast';
 import { supabase } from '@/integrations/supabase/client';
 import { useMood } from '@/contexts/MoodContext';
-import { useAppStore } from '@/store/appStore';
+import { useAppStore, selectUserRole } from '@/store/appStore';
 import B2BCoachPage from '@/pages/b2b/user/CoachPage';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
@@ -726,7 +726,7 @@ const B2CCoachExperience: React.FC = () => {
 };
 
 const B2CAICoachPage: React.FC = () => {
-  const userRole = useAppStore((state) => state.user?.role);
+  const userRole = useAppStore(selectUserRole);
   const isB2B = userRole === 'b2b_user' || userRole === 'b2b_admin';
 
   if (isB2B) {

--- a/src/store/__tests__/appStore.actions.spec.ts
+++ b/src/store/__tests__/appStore.actions.spec.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest';
+
+import { useAppStore } from '@/store/appStore';
+
+describe('appStore actions', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useAppStore.getState().reset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('setUser met à jour l\'état sans muter les autres branches', () => {
+    const previousState = useAppStore.getState();
+    const previousPreferences = previousState.preferences;
+    const previousCache = previousState.cache;
+
+    useAppStore.getState().setUser({
+      id: 'user-1',
+      email: 'user@example.com',
+      role: 'b2c',
+    });
+
+    const currentState = useAppStore.getState();
+
+    expect(currentState).not.toBe(previousState);
+    expect(currentState.user).toEqual({
+      id: 'user-1',
+      email: 'user@example.com',
+      role: 'b2c',
+    });
+    expect(previousState.user).toBeNull();
+    expect(currentState.preferences).toBe(previousPreferences);
+    expect(currentState.cache).toBe(previousCache);
+  });
+
+  it('updateMusicState fusionne sans écraser les autres modules', () => {
+    const initialState = useAppStore.getState();
+    const previousModules = initialState.modules;
+    const previousEmotion = initialState.modules.emotion;
+
+    useAppStore.getState().updateMusicState({
+      isPlaying: true,
+      playlist: ['track-1'],
+    });
+
+    const currentState = useAppStore.getState();
+
+    expect(currentState.modules).not.toBe(previousModules);
+    expect(currentState.modules.music).not.toBe(previousModules.music);
+    expect(currentState.modules.music).toEqual({
+      ...previousModules.music,
+      isPlaying: true,
+      playlist: ['track-1'],
+    });
+    expect(currentState.modules.emotion).toBe(previousEmotion);
+    expect(initialState.modules.music.isPlaying).toBe(false);
+  });
+
+  it('clearCache supprime une entrée sans muter les autres', () => {
+    const store = useAppStore.getState();
+    store.setCache('alpha', 'value-a');
+    store.setCache('beta', 'value-b');
+
+    const withCache = useAppStore.getState();
+    const previousCache = withCache.cache;
+    const previousTimestamps = withCache.cacheTimestamps;
+
+    withCache.clearCache('alpha');
+
+    const afterClear = useAppStore.getState();
+
+    expect(afterClear.cache).not.toBe(previousCache);
+    expect(afterClear.cacheTimestamps).not.toBe(previousTimestamps);
+    expect(afterClear.cache.alpha).toBeUndefined();
+    expect(afterClear.cache.beta).toBe('value-b');
+    expect(previousCache.alpha).toBe('value-a');
+
+    afterClear.clearCache();
+
+    const afterReset = useAppStore.getState();
+    expect(afterReset.cache).toEqual({});
+    expect(afterReset.cacheTimestamps).toEqual({});
+  });
+
+  it('isCacheValid respecte le paramètre maxAge', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
+
+    const store = useAppStore.getState();
+    store.setCache('report', { foo: 'bar' });
+
+    expect(useAppStore.getState().isCacheValid('report', 2000)).toBe(true);
+
+    vi.advanceTimersByTime(2500);
+
+    expect(useAppStore.getState().isCacheValid('report', 2000)).toBe(false);
+  });
+});

--- a/src/store/__tests__/appStore.persistence.spec.ts
+++ b/src/store/__tests__/appStore.persistence.spec.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useAppStore } from '@/store/appStore';
+
+const STORAGE_KEY = 'ec-app-store';
+
+describe('appStore persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useAppStore.getState().reset();
+  });
+
+  it('partialize ne persiste que les branches prévues', () => {
+    const store = useAppStore.getState();
+    store.setTheme('dark');
+    store.setUser({ id: 'u-1', email: 'user@example.com', role: 'b2c' });
+    store.updatePreferences({ notifications: false });
+    store.updateMusicState({ isPlaying: true });
+    store.updateEmotionState({ currentMood: 'joyful' });
+    store.updateJournalState({ currentEntry: { id: 'draft-1' } });
+
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).toBeTruthy();
+
+    const persisted = JSON.parse(raw!);
+
+    expect(persisted.version).toBe(1);
+    expect(persisted.state.theme).toBe('dark');
+    expect(persisted.state.preferences.notifications).toBe(false);
+    expect(persisted.state.modules.music.isPlaying).toBe(true);
+    expect(persisted.state.modules.emotion.currentMood).toBe('joyful');
+    expect(persisted.state.user).toBeUndefined();
+    expect(persisted.state.modules.journal).toBeUndefined();
+  });
+
+  it('migrate fusionne les valeurs persistées avec les valeurs par défaut', () => {
+    const migrate = useAppStore.persist.getOptions().migrate;
+    expect(migrate).toBeTypeOf('function');
+
+    const migrated = migrate?.(
+      {
+        theme: 'dark',
+        preferences: {
+          notifications: false,
+        },
+        modules: {
+          music: {
+            isPlaying: true,
+          },
+        },
+      },
+      0
+    ) as any;
+
+    const defaults = useAppStore.getState();
+
+    expect(migrated.theme).toBe('dark');
+    expect(migrated.preferences.notifications).toBe(false);
+    expect(migrated.preferences.autoSave).toBe(defaults.preferences.autoSave);
+    expect(migrated.preferences.analyticsEnabled).toBe(defaults.preferences.analyticsEnabled);
+    expect(migrated.modules.music.volume).toBe(defaults.modules.music.volume);
+    expect(migrated.modules.music.isPlaying).toBe(true);
+    expect(migrated.modules.emotion).toEqual(defaults.modules.emotion);
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
-import { persist, createJSONStorage } from 'zustand/middleware';
+import { devtools, persist, createJSONStorage, subscribeWithSelector } from 'zustand/middleware';
+import { shallow } from 'zustand/shallow';
 
 // Types pour le store global
 export interface User {
@@ -17,16 +18,16 @@ export interface AppState {
   user: User | null;
   isAuthenticated: boolean;
   isLoading: boolean;
-  
+
   // UI State
   theme: 'light' | 'dark' | 'system';
   sidebarCollapsed: boolean;
   activeModule: string | null;
-  
+
   // Cache
-  cache: Record<string, any>;
+  cache: Record<string, unknown>;
   cacheTimestamps: Record<string, number>;
-  
+
   // Préférences utilisateur
   preferences: {
     language: 'fr' | 'en';
@@ -34,29 +35,29 @@ export interface AppState {
     autoSave: boolean;
     analyticsEnabled: boolean;
   };
-  
+
   // État des modules
   modules: {
     music: {
-      currentTrack: any | null;
+      currentTrack: unknown | null;
       isPlaying: boolean;
       volume: number;
-      playlist: any[];
+      playlist: unknown[];
     };
     emotion: {
       currentMood: string | null;
-      lastScan: any | null;
-      history: any[];
+      lastScan: unknown | null;
+      history: unknown[];
     };
     journal: {
-      entries: any[];
-      currentEntry: any | null;
+      entries: unknown[];
+      currentEntry: unknown | null;
       unsavedChanges: boolean;
     };
     coach: {
-      conversations: any[];
+      conversations: unknown[];
       activeConversation: string | null;
-      suggestions: any[];
+      suggestions: unknown[];
     };
   };
 }
@@ -66,35 +67,34 @@ export interface AppActions {
   setUser: (user: User | null) => void;
   setAuthenticated: (isAuthenticated: boolean) => void;
   setLoading: (isLoading: boolean) => void;
-  
+
   // UI Actions
   setTheme: (theme: 'light' | 'dark' | 'system') => void;
   toggleSidebar: () => void;
   setActiveModule: (module: string | null) => void;
-  
+
   // Cache Actions
-  setCache: (key: string, value: any) => void;
-  getCache: (key: string) => any;
+  setCache: (key: string, value: unknown) => void;
+  getCache: (key: string) => unknown;
   clearCache: (key?: string) => void;
   isCacheValid: (key: string, maxAge?: number) => boolean;
-  
+
   // Préférences
   updatePreferences: (preferences: Partial<AppState['preferences']>) => void;
-  
+
   // Modules Actions
   updateMusicState: (state: Partial<AppState['modules']['music']>) => void;
   updateEmotionState: (state: Partial<AppState['modules']['emotion']>) => void;
   updateJournalState: (state: Partial<AppState['modules']['journal']>) => void;
   updateCoachState: (state: Partial<AppState['modules']['coach']>) => void;
-  
+
   // Reset
   reset: () => void;
 }
 
 export type AppStore = AppState & AppActions;
 
-// Configuration par défaut
-const defaultState: AppState = {
+const createDefaultState = (): AppState => ({
   user: null,
   isAuthenticated: false,
   isLoading: true,
@@ -132,133 +132,190 @@ const defaultState: AppState = {
       suggestions: [],
     },
   },
-};
+});
 
-// Store principal avec persistance
-export const useAppStore = create<AppStore>()(
-  persist(
-    (set, get) => ({
-      ...defaultState,
-      
-      // Authentification Actions
-      setUser: (user) => set((state) => ({ ...state, user })),
-      
-      setAuthenticated: (isAuthenticated) => set((state) => ({ ...state, isAuthenticated })),
-      
-      setLoading: (isLoading) => set((state) => ({ ...state, isLoading })),
-      
-      // UI Actions
-      setTheme: (theme) => set((state) => ({ ...state, theme })),
-      
-      toggleSidebar: () => set((state) => ({ 
-        ...state, 
-        sidebarCollapsed: !state.sidebarCollapsed 
+const store = persist<AppStore>(
+  (set, get) => ({
+    ...createDefaultState(),
+
+    // Authentification Actions
+    setUser: (user) =>
+      set((state) => ({
+        ...state,
+        user,
       })),
-      
-      setActiveModule: (module) => set((state) => ({ ...state, activeModule: module })),
-      
-      // Cache Actions
-      setCache: (key, value) => set((state) => ({
+
+    setAuthenticated: (isAuthenticated) =>
+      set((state) => ({
+        ...state,
+        isAuthenticated,
+      })),
+
+    setLoading: (isLoading) =>
+      set((state) => ({
+        ...state,
+        isLoading,
+      })),
+
+    // UI Actions
+    setTheme: (theme) =>
+      set((state) => ({
+        ...state,
+        theme,
+      })),
+
+    toggleSidebar: () =>
+      set((state) => ({
+        ...state,
+        sidebarCollapsed: !state.sidebarCollapsed,
+      })),
+
+    setActiveModule: (module) =>
+      set((state) => ({
+        ...state,
+        activeModule: module,
+      })),
+
+    // Cache Actions
+    setCache: (key, value) =>
+      set((state) => ({
         ...state,
         cache: { ...state.cache, [key]: value },
-        cacheTimestamps: { ...state.cacheTimestamps, [key]: Date.now() }
+        cacheTimestamps: { ...state.cacheTimestamps, [key]: Date.now() },
       })),
-      
-      getCache: (key) => {
-        const state = get();
-        return state.cache[key];
-      },
-      
-      clearCache: (key) => set((state) => {
-        if (key) {
-          const { [key]: _, ...restCache } = state.cache;
-          const { [key]: __, ...restTimestamps } = state.cacheTimestamps;
-          return {
-            ...state,
-            cache: restCache,
-            cacheTimestamps: restTimestamps
-          };
-        } else {
+
+    getCache: (key) => get().cache[key],
+
+    clearCache: (key) =>
+      set((state) => {
+        if (!key) {
           return {
             ...state,
             cache: {},
-            cacheTimestamps: {}
+            cacheTimestamps: {},
           };
         }
+
+        const { [key]: _, ...restCache } = state.cache;
+        const { [key]: __, ...restTimestamps } = state.cacheTimestamps;
+
+        return {
+          ...state,
+          cache: restCache,
+          cacheTimestamps: restTimestamps,
+        };
       }),
-      
-      isCacheValid: (key, maxAge = 5 * 60 * 1000) => { // 5 minutes par défaut
-        const state = get();
-        const timestamp = state.cacheTimestamps[key];
-        if (!timestamp) return false;
-        return Date.now() - timestamp < maxAge;
+
+    isCacheValid: (key, maxAge = 5 * 60 * 1000) => {
+      const timestamp = get().cacheTimestamps[key];
+      return typeof timestamp === 'number' && Date.now() - timestamp < maxAge;
+    },
+
+    // Préférences
+    updatePreferences: (preferences) =>
+      set((state) => ({
+        ...state,
+        preferences: { ...state.preferences, ...preferences },
+      })),
+
+    // Modules Actions
+    updateMusicState: (musicState) =>
+      set((state) => ({
+        ...state,
+        modules: {
+          ...state.modules,
+          music: { ...state.modules.music, ...musicState },
+        },
+      })),
+
+    updateEmotionState: (emotionState) =>
+      set((state) => ({
+        ...state,
+        modules: {
+          ...state.modules,
+          emotion: { ...state.modules.emotion, ...emotionState },
+        },
+      })),
+
+    updateJournalState: (journalState) =>
+      set((state) => ({
+        ...state,
+        modules: {
+          ...state.modules,
+          journal: { ...state.modules.journal, ...journalState },
+        },
+      })),
+
+    updateCoachState: (coachState) =>
+      set((state) => ({
+        ...state,
+        modules: {
+          ...state.modules,
+          coach: { ...state.modules.coach, ...coachState },
+        },
+      })),
+
+    // Reset
+    reset: () => set(() => createDefaultState()),
+  }),
+  {
+    name: 'ec-app-store',
+    storage: createJSONStorage(() => localStorage),
+    version: 1,
+    migrate: (persistedState, _version) => {
+      const defaults = createDefaultState();
+      const state = (persistedState ?? {}) as Partial<AppState>;
+
+      return {
+        theme: state.theme ?? defaults.theme,
+        preferences: {
+          ...defaults.preferences,
+          ...(state.preferences ?? {}),
+        },
+        modules: {
+          music: {
+            ...defaults.modules.music,
+            ...(state.modules?.music ?? {}),
+          },
+          emotion: {
+            ...defaults.modules.emotion,
+            ...(state.modules?.emotion ?? {}),
+          },
+        },
+      } as Partial<AppStore>;
+    },
+    partialize: (state) => ({
+      theme: state.theme,
+      preferences: state.preferences,
+      modules: {
+        music: state.modules.music,
+        emotion: state.modules.emotion,
       },
-      
-      // Préférences
-      updatePreferences: (preferences) => set((state) => ({
-        ...state,
-        preferences: { ...state.preferences, ...preferences }
-      })),
-      
-      // Modules Actions
-      updateMusicState: (musicState) => set((state) => ({
-        ...state,
-        modules: {
-          ...state.modules,
-          music: { ...state.modules.music, ...musicState }
-        }
-      })),
-      
-      updateEmotionState: (emotionState) => set((state) => ({
-        ...state,
-        modules: {
-          ...state.modules,
-          emotion: { ...state.modules.emotion, ...emotionState }
-        }
-      })),
-      
-      updateJournalState: (journalState) => set((state) => ({
-        ...state,
-        modules: {
-          ...state.modules,
-          journal: { ...state.modules.journal, ...journalState }
-        }
-      })),
-      
-      updateCoachState: (coachState) => set((state) => ({
-        ...state,
-        modules: {
-          ...state.modules,
-          coach: { ...state.modules.coach, ...coachState }
-        }
-      })),
-      
-      // Reset
-      reset: () => set(() => ({ ...defaultState })),
     }),
-    {
-      name: 'emotionscare-store',
-      storage: createJSONStorage(() => localStorage),
-      partialize: (state) => ({
-        theme: state.theme,
-        sidebarCollapsed: state.sidebarCollapsed,
-        preferences: state.preferences,
-        // Ne pas persister l'état d'authentification et les données sensibles
-      }),
-    }
-  )
+  }
+);
+
+const enhancedStore = subscribeWithSelector(store);
+const devtoolsEnabled = process.env.NODE_ENV !== 'production';
+
+export const useAppStore = create<AppStore>()(
+  devtoolsEnabled ? devtools(enhancedStore, { name: 'EC App Store' }) : enhancedStore
 );
 
 // Sélecteurs pour optimiser les re-renders
-export const useUser = () => useAppStore((state) => state.user);
-export const useAuth = () => useAppStore((state) => ({
+export const selectUser = (state: AppState) => state.user;
+export const selectAuthState = (state: AppState) => ({
   user: state.user,
   isAuthenticated: state.isAuthenticated,
   isLoading: state.isLoading,
-}));
-export const useTheme = () => useAppStore((state) => state.theme);
-export const usePreferences = () => useAppStore((state) => state.preferences);
-export const useMusicModule = () => useAppStore((state) => state.modules.music);
-export const useEmotionModule = () => useAppStore((state) => state.modules.emotion);
-export const useJournalModule = () => useAppStore((state) => state.modules.journal);
-export const useCoachModule = () => useAppStore((state) => state.modules.coach);
+});
+export const selectTheme = (state: AppState) => state.theme;
+export const selectPreferences = (state: AppState) => state.preferences;
+export const selectMusicModule = (state: AppState) => state.modules.music;
+export const selectEmotionModule = (state: AppState) => state.modules.emotion;
+export const selectJournalModule = (state: AppState) => state.modules.journal;
+export const selectCoachModule = (state: AppState) => state.modules.coach;
+export const selectUserRole = (state: AppState) => state.user?.role ?? null;
+export const selectCacheEntry = (key: string) => (state: AppState) => state.cache[key];
+
+export { shallow };


### PR DESCRIPTION
## Summary
- rewrite the global app store with explicit immutable updates, subscribeWithSelector, devtools, and selective persistence
- refactor consumers to rely on memoized selectors with shallow comparison and document the expected patterns in CONTRIBUTING
- add Vitest coverage to guard action immutability, cache validity, and persistence partialization

## Testing
- `npx vitest run src/store/__tests__/appStore.actions.spec.ts src/store/__tests__/appStore.persistence.spec.ts`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68cd543820fc832d9f29858ee6e1405b