### PR TITLE
feat(b2b): add privacy-first heatmap reports page

### DIFF
--- a/docs/B2B_REPORTS.md
+++ b/docs/B2B_REPORTS.md
@@ -1,0 +1,46 @@
+# Heatmap RH B2B — Notes de mise en œuvre
+
+## Flux de données et contraintes
+
+- **Source unique** : toutes les synthèses proviennent de la table `org_assess_rollups` exposée via l’Edge Function `assess-aggregate` (voir ECC-DATA-02 / ECC-EDGE-01).
+- **Filtrage min_n ≥ 5** :
+  - La fonction Edge ne renvoie que des agrégats respectant le seuil.
+  - Le service `getHeatmap` filtre à nouveau côté front lorsque `n` est présent dans la réponse.
+- **Zéro données individuelles** : le front n’interroge jamais les tables d’assessments brutes.
+- **JWT obligatoire** : l’appel Edge est signé avec le token Supabase de l’utilisateur manager (RLS + CORS déjà appliqués côté Edge).
+
+## Composants principaux
+
+- `src/services/b2b/reportsApi.ts` — wrapper typé qui appelle l’Edge Function et produit des cellules textuelles.
+- `src/features/b2b/reports/B2BHeatmap.tsx` — grille accessible (ARIA, clavier, contraste) présentant une carte par instrument/équipe.
+- `src/features/b2b/reports/ActionSuggestion.tsx` — transforme chaque synthèse en « action concrète » textuelle (mapping local en attendant la génération Edge).
+- `src/features/b2b/reports/ExportButton.tsx` — export PNG via `html2canvas`, import dynamique pour éviter de charger la librairie inutilement.
+- `src/pages/b2b/reports/index.tsx` — page complète : filtres (équipe, instrument, période), heatmap, actions, impression, instrumentation Sentry et métriques simples.
+- `src/styles/print-b2b.css` — styles dédiés à l’impression, fond clair et lisibilité renforcée.
+
+## Privacy & observabilité
+
+- Breadcrumbs Sentry : `b2b:agg:fetch:start|success|error`, `b2b:export:png`, `b2b:print` (sans texte utilisateur, seules les métadonnées techniques sont remontées).
+- Aucun numéro ni score n’est rendu dans les cellules : uniquement le résumé textuel + l’action suggérée.
+- Mesures locales via `performanceMonitor` :
+  - `b2b_reports.fetch_latency` (durée de l’appel agrégé)
+  - `b2b_reports.visible_cells` (nombre de cartes affichées après filtre)
+- Les logs front (`logger`) sont redigés automatiquement et n’incluent jamais le texte des synthèses.
+
+## Accessibilité et motion
+
+- Respect de `prefers-reduced-motion` : transitions neutralisées si l’utilisateur le demande.
+- Navigation clavier sur toute la grille (`role="grid"`, `role="gridcell"`, focus visible).
+- Version impression dédiée : fond blanc, texte sombre, suppression des contrôles interactifs (`.no-print`).
+
+## Tests
+
+- **Unitaires (Vitest)** : mapping `summaries[] → cells`, filtrage `min_n`, génération d’action concrète, regroupement par instrument.
+- **E2E (Playwright)** : scénario manager authentifié `/b2b/reports` couvrant chargement mocké, filtres, export PNG, appel impression, contrôle console sans avertissement.
+- **Contrats Edge** : vérifiés séparément via `supabase/tests/assess-functions.test.ts`.
+
+## Points d’attention produit
+
+- La philosophie « texte uniquement + min_n ≥ 5 » est matérialisée dans l’UI et rappelée dans le footer.
+- Aucun lien vers des vues individuelles ; pas de tri par équipe « meilleure/pire ».
+- Le bouton Export génère un PNG autonome respectant le thème impression (fond blanc). `window.print()` applique les styles CSS d’impression.

--- a/src/features/b2b/reports/ActionSuggestion.tsx
+++ b/src/features/b2b/reports/ActionSuggestion.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { deriveActionSuggestion } from './utils';
+
+interface ActionSuggestionProps {
+  summary: string;
+  backendSuggestion?: string;
+}
+
+export function ActionSuggestion({ summary, backendSuggestion }: ActionSuggestionProps) {
+  const suggestion = React.useMemo(
+    () => deriveActionSuggestion(summary, backendSuggestion),
+    [summary, backendSuggestion],
+  );
+
+  return (
+    <div
+      className="mt-3 rounded-lg border border-dashed border-slate-200 bg-slate-50 p-3 text-sm text-slate-700"
+      role="note"
+      aria-label="Action concrète suggérée"
+    >
+      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Action concrète</p>
+      <p className="mt-1 leading-relaxed line-clamp-2" data-testid="action-suggestion">
+        {suggestion}
+      </p>
+    </div>
+  );
+}

--- a/src/features/b2b/reports/B2BHeatmap.tsx
+++ b/src/features/b2b/reports/B2BHeatmap.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import clsx from 'clsx';
+import { ActionSuggestion } from './ActionSuggestion';
+import { groupCellsByInstrument, labelInstrument, type HeatmapCell } from './utils';
+
+interface B2BHeatmapProps {
+  cells: HeatmapCell[];
+  reducedMotion?: boolean;
+}
+
+export const B2BHeatmap = React.forwardRef<HTMLDivElement, B2BHeatmapProps>(
+  ({ cells, reducedMotion = false }, ref) => {
+    const grouped = React.useMemo(() => groupCellsByInstrument(cells), [cells]);
+    const instruments = React.useMemo(() => Object.keys(grouped), [grouped]);
+
+    if (cells.length === 0) {
+      return (
+        <p className="rounded-lg border border-dashed border-slate-200 bg-white p-6 text-sm text-slate-600" role="status">
+          Aucune synthèse disponible pour cette période avec le seuil de confidentialité en vigueur.
+        </p>
+      );
+    }
+
+    return (
+      <div ref={ref} className="space-y-8" role="region" aria-live="polite" aria-label="Heatmap des ressentis d'équipe">
+        {instruments.map((instrumentKey) => {
+          const instrumentCells = grouped[instrumentKey] ?? [];
+          const label = labelInstrument(instrumentKey);
+          return (
+            <section key={instrumentKey} aria-label={`Synthèse ${label}`} className="space-y-3">
+              <header className="flex items-center justify-between gap-2">
+                <h3 className="text-base font-semibold text-slate-800">{label}</h3>
+                <span className="text-xs uppercase tracking-wide text-slate-400">Confidentiel · Texte uniquement</span>
+              </header>
+              <div
+                role="grid"
+                aria-readonly
+                className={clsx(
+                  'grid gap-3',
+                  reducedMotion ? 'motion-reduce:transition-none motion-reduce:hover:shadow-none' : '',
+                  instrumentCells.some((cell) => cell.team) ? 'md:grid-cols-3' : 'md:grid-cols-2',
+                )}
+                data-testid={`heatmap-${instrumentKey.toLowerCase()}`}
+              >
+                {instrumentCells.map((cell, index) => {
+                  const audience = cell.team ?? 'Organisation';
+                  return (
+                    <article
+                      key={`${instrumentKey}-${audience}-${index}`}
+                      role="gridcell"
+                      tabIndex={0}
+                      aria-label={`${label} — ${audience}`}
+                      className={clsx(
+                        'flex flex-col justify-between rounded-xl border border-slate-200 bg-white p-4 text-left shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-500',
+                        'transition-shadow duration-150 ease-out hover:shadow-md',
+                        reducedMotion && 'transition-none hover:shadow-none',
+                      )}
+                    >
+                      <div>
+                        <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{audience}</p>
+                        <p className="mt-2 text-sm leading-relaxed text-slate-800 line-clamp-3" data-testid="heatmap-text">
+                          {cell.text}
+                        </p>
+                      </div>
+                      <ActionSuggestion summary={cell.text} backendSuggestion={cell.action} />
+                    </article>
+                  );
+                })}
+              </div>
+            </section>
+          );
+        })}
+      </div>
+    );
+  },
+);
+
+B2BHeatmap.displayName = 'B2BHeatmap';

--- a/src/features/b2b/reports/ExportButton.tsx
+++ b/src/features/b2b/reports/ExportButton.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import * as Sentry from '@sentry/react';
+import { Download } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { exportNodeToPng } from '@/features/export/exportPng';
+
+interface ExportButtonProps {
+  targetRef: React.RefObject<HTMLElement>;
+  fileName?: string;
+  className?: string;
+}
+
+export function ExportButton({ targetRef, fileName = 'heatmap.png', className }: ExportButtonProps) {
+  const [isExporting, setIsExporting] = React.useState(false);
+
+  const handleExport = async () => {
+    if (!targetRef.current || isExporting) {
+      return;
+    }
+    setIsExporting(true);
+    Sentry.addBreadcrumb({ category: 'b2b:export:png', message: 'trigger', level: 'info' });
+    try {
+      await exportNodeToPng(targetRef.current, fileName);
+    } catch (error) {
+      Sentry.addBreadcrumb({ category: 'b2b:export:png', message: 'error', level: 'error' });
+      console.error('[b2b-export] PNG export failed', error);
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      className={className}
+      onClick={handleExport}
+      disabled={isExporting || !targetRef.current}
+    >
+      <Download className="mr-2 h-4 w-4" aria-hidden="true" />
+      {isExporting ? 'Export en cours…' : 'Exporter en PNG'}
+    </Button>
+  );
+}

--- a/src/features/b2b/reports/__tests__/utils.test.ts
+++ b/src/features/b2b/reports/__tests__/utils.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  deriveActionSuggestion,
+  groupCellsByInstrument,
+  mapSummariesToCells,
+  type HeatmapCellInput,
+} from '../utils';
+
+describe('mapSummariesToCells', () => {
+  it('filters out entries below confidentiality threshold', () => {
+    const input: HeatmapCellInput[] = [
+      { instrument: 'WEMWBS', period: '2024-W10', text: 'Tonalité positive', n: 7 },
+      { instrument: 'CBI', period: '2024-W10', text: 'Tension à surveiller', n: 4 },
+    ];
+
+    const cells = mapSummariesToCells(input);
+    expect(cells).toHaveLength(1);
+    expect(cells[0]).toMatchObject({ instrument: 'WEMWBS', text: 'Tonalité positive' });
+  });
+
+  it('removes empty summaries and trims whitespace', () => {
+    const input: HeatmapCellInput[] = [
+      { instrument: 'UWES', period: '2024-W11', text: '  Engagement en progression  ', n: 8 },
+      { instrument: 'UWES', period: '2024-W11', text: '   ' },
+    ];
+
+    const cells = mapSummariesToCells(input);
+    expect(cells).toHaveLength(1);
+    expect(cells[0].text).toBe('Engagement en progression');
+  });
+});
+
+describe('deriveActionSuggestion', () => {
+  it('returns backend suggestion when provided', () => {
+    expect(deriveActionSuggestion('texte', 'action dédiée')).toBe('action dédiée');
+  });
+
+  it('maps fatigue keyword to cocon pause recommendation', () => {
+    expect(deriveActionSuggestion('Sentiment de fatigue partagé par l’équipe')).toContain('pause cocon');
+  });
+
+  it('falls back to neutral check-in suggestion', () => {
+    expect(deriveActionSuggestion('Ambiance stable')).toBe('check-in court sans agenda');
+  });
+});
+
+describe('groupCellsByInstrument', () => {
+  it('groups cells by instrument key', () => {
+    const cells = mapSummariesToCells([
+      { instrument: 'CBI', period: '2024-W10', text: 'Fatigue latente', n: 7 },
+      { instrument: 'CBI', period: '2024-W10', text: 'Stress canalisé', n: 5 },
+      { instrument: 'UWES', period: '2024-W10', text: 'Engagement solidaire', n: 6 },
+    ]);
+
+    const groups = groupCellsByInstrument(cells);
+    expect(Object.keys(groups)).toEqual(['CBI', 'UWES']);
+    expect(groups.CBI).toHaveLength(2);
+    expect(groups.UWES[0].text).toBe('Engagement solidaire');
+  });
+});

--- a/src/features/b2b/reports/utils.ts
+++ b/src/features/b2b/reports/utils.ts
@@ -1,0 +1,81 @@
+export interface HeatmapCellInput {
+  instrument: string;
+  period: string;
+  text: string;
+  team?: string;
+  action?: string;
+  n?: number | null;
+}
+
+export interface HeatmapCell {
+  instrument: string;
+  period: string;
+  text: string;
+  team?: string;
+  action?: string;
+}
+
+const INSTRUMENT_LABELS: Record<string, string> = {
+  WEMWBS: 'Bien-être',
+  CBI: 'Burnout',
+  UWES: 'Engagement',
+};
+
+export function labelInstrument(key: string): string {
+  return INSTRUMENT_LABELS[key] ?? key;
+}
+
+export function mapSummariesToCells(entries: HeatmapCellInput[]): HeatmapCell[] {
+  return entries
+    .filter((entry) => {
+      if (typeof entry.n === 'number') {
+        return entry.n >= 5;
+      }
+      return true;
+    })
+    .map((entry) => ({
+      instrument: entry.instrument,
+      period: entry.period,
+      text: entry.text.trim(),
+      team: entry.team?.trim() || undefined,
+      action: entry.action?.trim() || undefined,
+    }))
+    .filter((entry) => entry.text.length > 0);
+}
+
+export function deriveActionSuggestion(summaryText: string, backendSuggestion?: string | null): string {
+  if (backendSuggestion && backendSuggestion.trim().length > 0) {
+    return backendSuggestion.trim();
+  }
+
+  const normalized = summaryText.toLowerCase();
+
+  if (normalized.includes('fatigue')) {
+    return 'proposer pause cocon 10 min';
+  }
+
+  if (normalized.includes('tendu') || normalized.includes('tension')) {
+    return 'respiration 1 min en équipe';
+  }
+
+  if (normalized.includes('isolement') || normalized.includes('solitude')) {
+    return 'organiser un temps de pairage bienveillant';
+  }
+
+  if (normalized.includes('stress')) {
+    return 'proposer un rituel de clôture apaisant';
+  }
+
+  return 'check-in court sans agenda';
+}
+
+export function groupCellsByInstrument(cells: HeatmapCell[]): Record<string, HeatmapCell[]> {
+  return cells.reduce<Record<string, HeatmapCell[]>>((acc, cell) => {
+    const key = cell.instrument;
+    if (!acc[key]) {
+      acc[key] = [];
+    }
+    acc[key].push(cell);
+    return acc;
+  }, {});
+}

--- a/src/features/export/exportPng.ts
+++ b/src/features/export/exportPng.ts
@@ -1,0 +1,13 @@
+export async function exportNodeToPng(node: HTMLElement, filename: string) {
+  const { default: html2canvas } = await import('html2canvas');
+  const canvas = await html2canvas(node, {
+    backgroundColor: '#ffffff',
+    scale: window.devicePixelRatio || 1,
+    useCORS: true,
+  });
+
+  const link = document.createElement('a');
+  link.download = filename;
+  link.href = canvas.toDataURL('image/png');
+  link.click();
+}

--- a/src/pages/b2b/reports/index.tsx
+++ b/src/pages/b2b/reports/index.tsx
@@ -1,0 +1,243 @@
+import React from 'react';
+import * as Sentry from '@sentry/react';
+import dayjs from 'dayjs';
+import isoWeek from 'dayjs/plugin/isoWeek';
+import { useQuery } from '@tanstack/react-query';
+import { Printer } from 'lucide-react';
+import { useAuth } from '@/contexts/AuthContext';
+import { B2BHeatmap } from '@/features/b2b/reports/B2BHeatmap';
+import { ExportButton } from '@/features/b2b/reports/ExportButton';
+import { DEFAULT_INSTRUMENTS, getHeatmap } from '@/services/b2b/reportsApi';
+import { type HeatmapCell } from '@/features/b2b/reports/utils';
+import { performanceMonitor } from '@/lib/performance/performanceMonitor';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import '@/styles/print-b2b.css';
+
+dayjs.extend(isoWeek);
+
+const PERIOD_OPTIONS = Array.from({ length: 8 }).map((_, index) =>
+  dayjs().subtract(index, 'week').format('YYYY-[W]WW'),
+);
+
+const DEFAULT_PERIOD = PERIOD_OPTIONS[0];
+
+const TEAM_OPTION_ALL = 'all';
+const INSTRUMENT_OPTION_ALL = 'all';
+
+function formatPeriodLabel(value: string): string {
+  if (!value.includes('W')) {
+    return value;
+  }
+  const [year, week] = value.split('-');
+  return `Semaine ${week.replace('W', '')} — ${year}`;
+}
+
+export default function B2BReportsHeatmapPage() {
+  const { user } = useAuth();
+  const heatmapRef = React.useRef<HTMLDivElement>(null);
+  const [period, setPeriod] = React.useState<string>(DEFAULT_PERIOD);
+  const [selectedTeam, setSelectedTeam] = React.useState<string>(TEAM_OPTION_ALL);
+  const [selectedInstrument, setSelectedInstrument] = React.useState<string>(INSTRUMENT_OPTION_ALL);
+  const [prefersReducedMotion, setPrefersReducedMotion] = React.useState(false);
+
+  const orgId = user?.user_metadata?.org_id as string | undefined;
+  const orgName = (user?.user_metadata?.org_name as string | undefined) ?? 'Votre organisation';
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handleChange = () => setPrefersReducedMotion(mediaQuery.matches);
+    handleChange();
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  const query = useQuery<HeatmapCell[]>({
+    queryKey: ['b2b-heatmap', orgId, period, selectedInstrument],
+    enabled: Boolean(orgId && period),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+    queryFn: async () => {
+      if (!orgId) {
+        return [];
+      }
+      const start = typeof performance !== 'undefined' ? performance.now() : null;
+      const cells = await getHeatmap({
+        orgId,
+        period,
+        instruments: selectedInstrument === INSTRUMENT_OPTION_ALL ? undefined : [selectedInstrument],
+      });
+      if (start != null && typeof performance !== 'undefined') {
+        performanceMonitor.recordMetric('b2b_reports.fetch_latency', performance.now() - start);
+      }
+      return cells;
+    },
+  });
+
+  const teamOptions = React.useMemo(() => {
+    const teams = new Set<string>();
+    (query.data ?? []).forEach((cell) => {
+      if (cell.team) {
+        teams.add(cell.team);
+      }
+    });
+    return Array.from(teams).sort();
+  }, [query.data]);
+
+  const filteredCells = React.useMemo(() => {
+    if (!query.data) return [];
+    return query.data.filter((cell) => {
+      if (selectedTeam !== TEAM_OPTION_ALL) {
+        return cell.team === selectedTeam;
+      }
+      return true;
+    });
+  }, [query.data, selectedTeam]);
+
+  React.useEffect(() => {
+    performanceMonitor.recordMetric('b2b_reports.visible_cells', filteredCells.length);
+  }, [filteredCells.length]);
+
+  const handlePrint = React.useCallback(() => {
+    Sentry.addBreadcrumb({ category: 'b2b:print', message: 'trigger', level: 'info' });
+    window.print();
+  }, []);
+
+  if (!orgId) {
+    return (
+      <main className="mx-auto max-w-5xl space-y-6 p-6">
+        <header className="space-y-2">
+          <h1 className="text-2xl font-semibold text-slate-900">Heatmap RH</h1>
+          <p className="text-sm text-slate-600">
+            Aucun identifiant d’organisation détecté. Merci de contacter le support pour activer l’accès PeopleOps.
+          </p>
+        </header>
+      </main>
+    );
+  }
+
+  const isLoading = query.isLoading || query.isFetching;
+  const hasError = Boolean(query.error);
+
+  return (
+    <main className="mx-auto max-w-6xl space-y-6 p-6" aria-labelledby="b2b-reports-title">
+      <header className="space-y-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-slate-400">Rapport collectif</p>
+            <h1 id="b2b-reports-title" className="text-3xl font-semibold text-slate-900">
+              Heatmap RH — {orgName}
+            </h1>
+            <p className="text-sm text-slate-600">
+              Synthèse textuelle du bien-être, de l’engagement et du risque de burnout. Les agrégats respectent un minimum de cinq réponses.
+            </p>
+          </div>
+          <div className="no-print flex flex-wrap gap-2">
+            <ExportButton targetRef={heatmapRef as React.RefObject<HTMLElement>} fileName={`heatmap-${period}.png`} />
+            <Button type="button" variant="outline" onClick={handlePrint}>
+              <Printer className="mr-2 h-4 w-4" aria-hidden="true" />
+              Imprimer
+            </Button>
+          </div>
+        </div>
+        <p className="text-xs text-slate-500">
+          Période sélectionnée : {formatPeriodLabel(period)} · Confidentialité renforcée
+        </p>
+      </header>
+
+      <section className="no-print rounded-xl border border-slate-200 bg-white p-4 shadow-sm" aria-label="Filtres">
+        <div className="grid gap-4 md:grid-cols-3">
+          <div>
+            <label htmlFor="period-select" className="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Période
+            </label>
+            <Select value={period} onValueChange={setPeriod}>
+              <SelectTrigger id="period-select" aria-label="Sélectionner la période">
+                <SelectValue placeholder="Choisir une période" />
+              </SelectTrigger>
+              <SelectContent>
+                {PERIOD_OPTIONS.map((option) => (
+                  <SelectItem key={option} value={option}>
+                    {formatPeriodLabel(option)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <label htmlFor="team-select" className="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Équipe
+            </label>
+            <Select
+              value={selectedTeam}
+              onValueChange={setSelectedTeam}
+              disabled={teamOptions.length === 0}
+            >
+              <SelectTrigger id="team-select" aria-label="Filtrer par équipe">
+                <SelectValue placeholder="Toutes les équipes" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={TEAM_OPTION_ALL}>Organisation complète</SelectItem>
+                {teamOptions.map((team) => (
+                  <SelectItem key={team} value={team}>
+                    {team}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <label
+              htmlFor="instrument-select"
+              className="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-500"
+            >
+              Instrument
+            </label>
+            <Select value={selectedInstrument} onValueChange={setSelectedInstrument}>
+              <SelectTrigger id="instrument-select" aria-label="Filtrer par instrument">
+                <SelectValue placeholder="Tous les instruments" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={INSTRUMENT_OPTION_ALL}>Tous</SelectItem>
+                {DEFAULT_INSTRUMENTS.map((instrument) => (
+                  <SelectItem key={instrument} value={instrument}>
+                    {instrument}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </section>
+
+      {hasError && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700" role="alert">
+          Impossible de charger les synthèses. Merci de réessayer plus tard.
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="space-y-4" role="status" aria-live="polite">
+          <div className="h-24 rounded-xl bg-slate-100" />
+          <div className="h-24 rounded-xl bg-slate-100" />
+          <div className="h-24 rounded-xl bg-slate-100" />
+        </div>
+      ) : (
+        <B2BHeatmap ref={heatmapRef} cells={filteredCells} reducedMotion={prefersReducedMotion} />
+      )}
+
+      <footer className="border-t border-dashed border-slate-200 pt-4 text-xs text-slate-500">
+        Données agrégées issues d’org_assess_rollups. Aucun score individuel n’est accessible. Minimum cinq réponses par cellule.
+      </footer>
+    </main>
+  );
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -57,6 +57,7 @@ export { default as B2BSelectionPage } from './B2BSelectionPage';
 export { default as B2BEntreprisePage } from './B2BEntreprisePage';
 export { default as B2BSocialCoconPage } from './B2BSocialCoconPage';
 export { default as B2BReportsPage } from './B2BReportsPage';
+export { default as B2BReportsHeatmapPage } from './b2b/reports';
 export { default as B2BEventsPage } from './B2BEventsPage';
 export { default as B2BUserCoachPage } from './b2b/user/CoachPage';
 

--- a/src/routerV2/index.tsx
+++ b/src/routerV2/index.tsx
@@ -74,6 +74,7 @@ const B2CNotificationsPage = lazy(() => import('@/pages/B2CNotificationsPage'));
 const B2BTeamsPage = lazy(() => import('@/pages/B2BTeamsPage'));
 const B2BSocialCoconPage = lazy(() => import('@/pages/B2BSocialCoconPage'));
 const B2BReportsPage = lazy(() => import('@/pages/B2BReportsPage'));
+const B2BReportsHeatmapPage = lazy(() => import('@/pages/b2b/reports'));
 const B2BEventsPage = lazy(() => import('@/pages/B2BEventsPage'));
 
 // Additional B2B pages - use correct paths
@@ -216,6 +217,7 @@ const componentMap: Record<string, React.LazyExoticComponent<React.ComponentType
   B2BTeamsPage,
   B2BSocialCoconPage,
   B2BReportsPage,
+  B2BReportsHeatmapPage,
   B2BEventsPage,
   B2BOptimisationPage,
   B2BSecurityPage,

--- a/src/routerV2/registry.ts
+++ b/src/routerV2/registry.ts
@@ -94,6 +94,15 @@ export const ROUTES_REGISTRY: RouteMeta[] = [
     component: 'B2BSelectionPage',
   },
   {
+    name: 'b2b-reports-heatmap',
+    path: '/b2b/reports',
+    segment: 'manager',
+    role: 'manager',
+    layout: 'app',
+    guard: true,
+    component: 'B2BReportsHeatmapPage',
+  },
+  {
     name: 'login',
     path: '/login',
     segment: 'public',

--- a/src/routerV2/router.tsx
+++ b/src/routerV2/router.tsx
@@ -72,6 +72,7 @@ const B2CNotificationsPage = lazy(() => import('@/pages/B2CNotificationsPage'));
 const B2BTeamsPage = lazy(() => import('@/pages/B2BTeamsPage'));
 const B2BSocialCoconPage = lazy(() => import('@/pages/B2BSocialCoconPage'));
 const B2BReportsPage = lazy(() => import('@/pages/B2BReportsPage'));
+const B2BReportsHeatmapPage = lazy(() => import('@/pages/b2b/reports'));
 const B2BEventsPage = lazy(() => import('@/pages/B2BEventsPage'));
 
 // Additional B2B pages - use correct paths
@@ -214,6 +215,7 @@ const componentMap: Record<string, React.LazyExoticComponent<React.ComponentType
   B2BTeamsPage,
   B2BSocialCoconPage,
   B2BReportsPage,
+  B2BReportsHeatmapPage,
   B2BEventsPage,
   B2BOptimisationPage,
   B2BSecurityPage,

--- a/src/services/b2b/reportsApi.ts
+++ b/src/services/b2b/reportsApi.ts
@@ -1,0 +1,98 @@
+import * as Sentry from '@sentry/react';
+import { z } from 'zod';
+import { supabase } from '@/integrations/supabase/client';
+import { invokeSupabaseEdge } from '@/lib/network/supabaseEdge';
+import { logger } from '@/lib/logger';
+import type { HeatmapCell, HeatmapCellInput } from '@/features/b2b/reports/utils';
+import { mapSummariesToCells } from '@/features/b2b/reports/utils';
+
+const DEFAULT_INSTRUMENTS = ['WEMWBS', 'CBI', 'UWES'] as const;
+
+const aggregateSummarySchema = z.object({
+  instrument: z.string(),
+  period: z.string(),
+  text: z.string(),
+  team: z.string().optional(),
+  action: z.string().optional(),
+  n: z.number().optional(),
+});
+
+const aggregateResponseSchema = z.object({
+  summaries: z.array(aggregateSummarySchema),
+});
+
+interface GetHeatmapParams {
+  orgId: string;
+  period: string;
+  instruments?: string[];
+}
+
+export async function getHeatmap({ orgId, period, instruments }: GetHeatmapParams): Promise<HeatmapCell[]> {
+  const payload = {
+    org_id: orgId,
+    period,
+    instruments: instruments && instruments.length > 0 ? instruments : [...DEFAULT_INSTRUMENTS],
+  };
+
+  Sentry.addBreadcrumb({
+    category: 'b2b:agg:fetch',
+    message: 'start',
+    level: 'info',
+  });
+
+  const { data: sessionData } = await supabase.auth.getSession();
+  const accessToken = sessionData.session?.access_token ?? null;
+  const start = typeof performance !== 'undefined' ? performance.now() : null;
+
+  try {
+    const raw = await invokeSupabaseEdge<typeof payload, unknown>('assess-aggregate', {
+      payload,
+      accessToken,
+      timeoutMs: 12_000,
+      retries: 1,
+      retryDelayMs: 750,
+    });
+
+    const parsed = aggregateResponseSchema.safeParse(raw);
+    if (!parsed.success) {
+      logger.error('Invalid aggregate payload', { issue: parsed.error.flatten().formErrors }, 'b2b.reports');
+      throw new Error('aggregate_payload_invalid');
+    }
+
+    const summaries: HeatmapCellInput[] = parsed.data.summaries.map(summary => ({
+      instrument: summary.instrument,
+      period: summary.period,
+      text: summary.text,
+      team: summary.team,
+      action: summary.action,
+      n: summary.n,
+    }));
+
+    const cells = mapSummariesToCells(summaries);
+
+    Sentry.addBreadcrumb({
+      category: 'b2b:agg:fetch',
+      message: 'success',
+      level: 'info',
+      data: { instruments: cells.map(cell => cell.instrument), teams: Array.from(new Set(cells.map(cell => cell.team ?? 'org'))) },
+    });
+
+    if (start != null && typeof performance !== 'undefined') {
+      const duration = performance.now() - start;
+      logger.debug('b2b_heatmap_fetch_latency', { duration }, 'b2b.reports');
+    }
+
+    return cells;
+  } catch (error) {
+    Sentry.addBreadcrumb({
+      category: 'b2b:agg:fetch',
+      message: 'error',
+      level: 'error',
+    });
+    logger.error('Failed to load aggregate summaries', { error: error instanceof Error ? error.message : 'unknown' }, 'b2b.reports');
+    throw error;
+  }
+}
+
+export { DEFAULT_INSTRUMENTS };
+export type { HeatmapCell };

--- a/src/styles/print-b2b.css
+++ b/src/styles/print-b2b.css
@@ -1,0 +1,35 @@
+@media print {
+  :root {
+    color-scheme: light;
+  }
+
+  body {
+    background: #ffffff !important;
+    color: #1f2937 !important;
+    font: 12pt/1.4 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
+  }
+
+  .no-print {
+    display: none !important;
+  }
+
+  main {
+    box-shadow: none !important;
+    background: #ffffff !important;
+  }
+
+  h1,
+  h2,
+  h3 {
+    color: #111827 !important;
+  }
+
+  a {
+    color: #111827 !important;
+    text-decoration: none !important;
+  }
+
+  article {
+    break-inside: avoid;
+  }
+}

--- a/tests/e2e/b2b-reports-heatmap.spec.ts
+++ b/tests/e2e/b2b-reports-heatmap.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+
+test('B2B reports heatmap — chargement, filtres, export et impression', async ({ page }, testInfo) => {
+  if (!testInfo.project.name.includes('b2b_admin')) {
+    test.skip();
+  }
+
+  const consoleWarnings: string[] = [];
+  page.on('console', (message) => {
+    if (message.type() === 'warning' || message.type() === 'error') {
+      consoleWarnings.push(message.text());
+    }
+  });
+
+  await page.addInitScript(() => {
+    window.print = () => {
+      (window as unknown as { __printed?: boolean }).__printed = true;
+    };
+    // eslint-disable-next-line no-extend-native
+    HTMLCanvasElement.prototype.toDataURL = () => 'data:image/png;base64,AAAA';
+  });
+
+  await page.route('**/functions/v1/assess-aggregate', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        summaries: [
+          { instrument: 'WEMWBS', period: '2024-W11', text: 'Ton collectif apaisé', team: 'Produit' },
+          { instrument: 'CBI', period: '2024-W11', text: 'Fatigue résiduelle mais partagée', team: 'Produit' },
+          { instrument: 'UWES', period: '2024-W11', text: 'Élan d’engagement constaté' },
+        ],
+      }),
+    });
+  });
+
+  await page.goto('/b2b/reports');
+
+  await expect(page.getByRole('heading', { name: /Heatmap RH/i })).toBeVisible();
+  await expect(page.getByTestId('heatmap-text').first()).toContainText('Ton collectif');
+  await expect(page.getByTestId('action-suggestion').first()).toBeVisible();
+
+  await page.getByLabel('Instrument').click();
+  await page.getByRole('option', { name: 'CBI' }).click();
+  await expect(page.getByTestId('heatmap-text').first()).toContainText('Fatigue');
+
+  await page.getByLabel('Équipe').click();
+  await page.getByRole('option', { name: 'Organisation complète' }).click();
+  await expect(page.getByTestId('heatmap-text').nth(0)).toContainText('Ton collectif');
+
+  await page.getByRole('button', { name: /Exporter en PNG/i }).click();
+  await page.getByRole('button', { name: /Imprimer/i }).click();
+  const printed = await page.evaluate(() => (window as unknown as { __printed?: boolean }).__printed ?? false);
+  expect(printed).toBeTruthy();
+
+  expect(consoleWarnings).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- implement B2B heatmap reports service calling the assess-aggregate edge function with min_n filtering and Sentry breadcrumbs
- add accessible text-only heatmap UI with action suggestions, export to PNG, print styles, and filtering controls on /b2b/reports
- document the privacy constraints and provide unit and e2e coverage for data mapping, action suggestions, and manager flows

## Testing
- `npx vitest run src/features/b2b/reports/__tests__/utils.test.ts`
- `npx playwright test tests/e2e/b2b-reports-heatmap.spec.ts --project=b2b_admin-chromium` *(fails: playwright binary not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd685e3b14832db8536e59e4726da9