### PR TITLE
Integrate shared session engine and polish session persistence

### DIFF
--- a/docs/MODULES_LISTING.md
+++ b/docs/MODULES_LISTING.md
@@ -30,24 +30,26 @@
 
 ### ⚡ Flash Glow & Ultra — 🟢 Livré
 - **Entrées** : `src/modules/flash-glow/useFlashGlowMachine.ts`, `src/modules/flash-glow/journal.ts`, `src/modules/flash-glow-ultra/FlashGlowUltraPage.tsx`.
-- **Services** : `src/modules/flash-glow/flash-glowService.ts`, intégration journal via `createFlashGlowJournalEntry`.
+- **Services** : `src/modules/flash-glow/flash-glowService.ts`, intégration journal via `createFlashGlowJournalEntry`, moteur partagé `src/services/sessions/sessionsApi.ts`.
 - **Persistance Supabase** : table `public.sessions` (type, durée, `mood_delta`, `meta` JSONB) avec indexes sur `user_id`, `created_at desc`, `type` + RLS owner-only.
 - **Fonctionnalités clés** :
-  - Machine d'état asynchrone (idle → active → ending) gérant timers, extensions et haptique.  
-  - Suivi des humeurs (`moodBaseline`, `moodAfter`, `moodDelta`) avec clamp et calcul auto.  
-  - Journalisation automatique en fin de session (contenu enrichi, tags, sauvegarde Supabase + toast de feedback).  
+  - Machine d'état asynchrone couplée au hook commun `useSessionClock` (start/pause/resume/complete) avec breadcrumbs Sentry `session:*`.
+  - Suivi des humeurs (`moodBaseline`, `moodAfter`) et calcul directionnel via `computeMoodDelta` sérialisé dans `meta`.
+  - Journalisation automatique Supabase via `logAndJournal` (insert `sessions` + entrée `journal_entries` bienveillante) et fallback local.
+  - Interface Flash Glow Ultra migrée sur le moteur partagé (`useSessionClock`) avec région `aria-live`, focus conservé et auto-journal `logAndJournal` (couverture `flashGlowUltraSession.test.tsx`).
   - Statistiques locales (nombre/temps moyen) et toasts en cas d'interruption.
   - ✅ QA 06/2025 : scénario e2e `flash-glow-ultra-session.spec.ts` + tests `useGlowStore` (5 cas) couvrant start/pause/resume/reset.
 
 ### 🌌 Breath Constellation — 🟢 Livré
 - **Entrée** : `src/modules/breath-constellation/BreathConstellationPage.tsx` via `/app/breath`.
-- **Services** : `src/services/breathworkSessions.service.ts` (persistance) et `@/ui/hooks/useBreathPattern`.
+- **Services** : `src/services/breathworkSessions.service.ts`, moteur partagé `src/services/sessions/sessionsApi.ts`, hook `@/ui/hooks/useBreathPattern`.
 - **Persistance Supabase** : mutualise `public.sessions` (log des séances Breath/FlashGlow) sous RLS owner-only, indexes `user_id`, `created_at`, `type`.
 - **Fonctionnalités clés** :
-  - Protocoles nommés (cohérence 5-5, 4-7-8, box, triangle) avec cadence calculée et bénéfices contextualisés.  
-  - Support `prefers-reduced-motion` : désactive animations complexes et affiche instructions textuelles.  
-  - Options audio/haptique via `useSound` + enregistrement Supabase des sessions (gestion erreurs auth/persistance).  
+  - Protocoles nommés (cohérence, sommeil profond, carré, triangle) avec cadence calculée et bénéfices contextualisés.
+  - Horloge partagée `useSessionClock` respectant `prefers-reduced-motion` (aria-live, focus conservé, pause/reprise instrumentées Sentry).
+  - Options audio/haptique via `useSound`, enregistrement Supabase (`logBreathworkSession`) + insertion automatique journal via `logAndJournal`.
   - Émissions d'events analytics facultatifs (`recordEvent`).
+  - ✅ Tests accessibilité : `BreathConstellationStatus.test.tsx` (annonces `aria-live`) en complément du smoke e2e.
   - ✅ QA 06/2025 : régression manuelle post build, couverture e2e générale `breath-constellation-session.spec.ts`.
 
 ### 📝 Journal — 🟢 Livré

--- a/e2e/breath-constellation.smoke.spec.ts
+++ b/e2e/breath-constellation.smoke.spec.ts
@@ -3,8 +3,12 @@ import { test, expect } from "@playwright/test";
 test("breath constellation smoke", async ({ page }) => {
   await page.goto("/modules/breath-constellation");
   await expect(page).toHaveURL(/\/modules\/breath-constellation/);
+  const status = page.locator('main[aria-label="Breath Constellation"]').getByRole("status").first();
   await page.getByRole("button", { name: /Démarrer/i }).click();
-  await page.waitForTimeout(800);
+  await expect(status).toHaveText(/séance en cours/i);
   await page.getByRole("button", { name: /Pause/i }).click();
-  await expect(page.getByText(/Cycle/i)).toBeVisible();
+  await expect(status).toHaveText(/pause/i);
+  await page.getByRole("button", { name: /Reprendre/i }).click();
+  await page.getByRole("button", { name: /Terminer/i }).click();
+  await expect(status).toHaveText(/séance terminée/i);
 });

--- a/src/__tests__/__snapshots__/flash-glow-ultra.snapshot.spec.tsx.snap
+++ b/src/__tests__/__snapshots__/flash-glow-ultra.snapshot.spec.tsx.snap
@@ -5,10 +5,15 @@ exports[`FlashGlowUltraPage > rend la page et le CTA Démarrer 1`] = `
   <main
     aria-label="Flash Glow Ultra"
   >
-    <div>
-      Flash Glow Ultra
-    </div>
-    <div>
+    <header>
+      <h1>
+        Flash Glow Ultra
+      </h1>
+      <p>
+        Glow respiratoire avancé, sûr et personnalisable
+      </p>
+    </header>
+    <section>
       <section
         style="display: grid; gap: 16px;"
       >
@@ -107,6 +112,34 @@ exports[`FlashGlowUltraPage > rend la page et le CTA Démarrer 1`] = `
               step="1"
               type="range"
               value="2"
+            />
+          </label>
+        </div>
+        <div
+          style="display: grid; gap: 8px; background: rgba(255, 255, 255, 0.02); border-radius: 16px; padding: 16px;"
+        >
+          <label>
+            Humeur avant séance : 
+            50
+            /100
+            <input
+              max="100"
+              min="0"
+              step="1"
+              type="range"
+              value="50"
+            />
+          </label>
+          <label>
+            Humeur après séance : 
+            50
+            /100
+            <input
+              max="100"
+              min="0"
+              step="1"
+              type="range"
+              value="50"
             />
           </label>
         </div>
@@ -316,13 +349,24 @@ exports[`FlashGlowUltraPage > rend la page et le CTA Démarrer 1`] = `
           glow
         </div>
         <div
-          style="display: flex; gap: 8px;"
+          style="display: grid; gap: 4px;"
         >
-          <button
-            data-ui="primary-cta"
+          <div
+            aria-live="polite"
+            role="status"
+            style="font-size: 12px; opacity: 0.85;"
           >
-            Démarrer
-          </button>
+            Séance prête.
+          </div>
+          <div
+            style="display: flex; gap: 8px;"
+          >
+            <button
+              data-ui="primary-cta"
+            >
+              Démarrer
+            </button>
+          </div>
         </div>
         <small
           style="opacity: 0.75;"
@@ -330,7 +374,7 @@ exports[`FlashGlowUltraPage > rend la page et le CTA Démarrer 1`] = `
           Sécurité anti-flash activée (≤3 Hz). Si tu utilises “Réduction des animations” sur ton appareil, l’animation devient très douce.
         </small>
       </section>
-    </div>
+    </section>
   </main>
 </div>
 `;

--- a/src/modules/breath-constellation/BreathConstellationPage.tsx
+++ b/src/modules/breath-constellation/BreathConstellationPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import * as Sentry from "@sentry/react";
 import { useReducedMotion } from "framer-motion";
 import { PageHeader, Card, Button } from "@/COMPONENTS.reg";
 import { ConstellationCanvas } from "@/COMPONENTS.reg";
@@ -13,6 +14,8 @@ import {
   BreathworkSessionAuthError,
   BreathworkSessionPersistError,
 } from "@/services/breathworkSessions.service";
+import { useSessionClock } from "@/modules/sessions/hooks/useSessionClock";
+import { logAndJournal } from "@/services/sessions/sessionsApi";
 
 type BreathProtocolId = "coherence-5-5" | "4-7-8" | "box-4-4-4-4" | "triangle-4-6-8";
 
@@ -141,6 +144,13 @@ const PROTOCOL_SEQUENCE = PROTOCOL_DEFINITIONS.map(definition => PROTOCOLS_BY_ID
 
 const DEFAULT_PROTOCOL_ID: BreathProtocolId = "coherence-5-5";
 
+const PROTOCOL_JOURNAL_SUMMARY: Record<BreathProtocolId, string> = {
+  "coherence-5-5": "Respiration cohérence cardiaque terminée, souffle plus stable.",
+  "4-7-8": "Respiration sommeil profond terminée, esprit apaisé.",
+  "box-4-4-4-4": "Respiration carré terminée, concentration renforcée.",
+  "triangle-4-6-8": "Respiration triangle terminée, tensions relâchées."
+};
+
 const formatDuration = (seconds: number): string => {
   if (!Number.isFinite(seconds) || seconds <= 0) return "0 s";
   if (seconds >= 120) {
@@ -166,6 +176,7 @@ export default function BreathConstellationPage() {
   const [saveStatus, setSaveStatus] = React.useState<SaveStatus>("idle");
   const [saveMessage, setSaveMessage] = React.useState<string | null>(null);
 
+  const clock = useSessionClock({ durationMs: cycles > 0 ? cycles * protocol.cycleDuration * 1000 : undefined });
   const bp = useBreathPattern(protocol.pattern, cycles);
   const { current, phaseProgress, running, cycle, start, stop, toggle } = bp;
   const phaseDuration = bp.phaseDuration;
@@ -173,8 +184,22 @@ export default function BreathConstellationPage() {
   const audioEnabled = ff?.("new-audio-engine") ?? false;
   const cue = useSound?.("/audio/tick.mp3", { volume: 0.45 }) ?? null;
 
-  const sessionStartRef = React.useRef<number | null>(null);
+  const sessionStartRef = React.useRef<Date | null>(null);
+  const primaryButtonRef = React.useRef<HTMLButtonElement | null>(null);
   const lastPhaseRef = React.useRef<Phase | null>(null);
+
+  const clockState = clock.state;
+  const clockElapsedSeconds = Math.max(0, Math.round(clock.elapsedMs / 1000));
+  const plannedSeconds = cycles > 0 ? cycles * protocol.cycleDuration : 0;
+  const clockProgress = plannedSeconds > 0
+    ? Math.min(1, clock.progress ?? clockElapsedSeconds / plannedSeconds)
+    : undefined;
+  const sessionStatusMessage = React.useMemo(() => {
+    if (running) return "Séance en cours.";
+    if (clockState === "paused") return "Séance en pause.";
+    if (clockState === "completed") return "Séance terminée.";
+    return "Séance prête à démarrer.";
+  }, [clockState, running]);
 
   const resetFeedback = React.useCallback(() => {
     setSaveStatus("idle");
@@ -192,13 +217,6 @@ export default function BreathConstellationPage() {
   }, [isReducedMotion]);
 
   React.useEffect(() => {
-    if (running && sessionStartRef.current === null) {
-      sessionStartRef.current = Date.now();
-      resetFeedback();
-    }
-  }, [running, resetFeedback]);
-
-  React.useEffect(() => {
     const phase = current.phase;
     if (phase !== lastPhaseRef.current) {
       lastPhaseRef.current = phase;
@@ -213,11 +231,9 @@ export default function BreathConstellationPage() {
 
   const logSession = React.useCallback(
     async (cyclesCompleted: number, completed: boolean) => {
-      const startedAt = sessionStartRef.current;
-      if (!startedAt) return;
-
-      const endedAt = Date.now();
-      const durationSec = Math.max(1, Math.round((endedAt - startedAt) / 1000));
+      const startedAt = sessionStartRef.current ?? new Date();
+      const endedAt = new Date();
+      const durationSec = Math.max(1, clockElapsedSeconds || 0);
       const normalizedCycles = Math.max(0, cyclesCompleted);
       const cadence = durationSec > 0
         ? Number.parseFloat(((normalizedCycles * 60) / durationSec).toFixed(2))
@@ -226,8 +242,8 @@ export default function BreathConstellationPage() {
       try {
         recordEvent?.({
           module: "breath-constellation",
-          startedAt: new Date(startedAt).toISOString(),
-          endedAt: new Date(endedAt).toISOString(),
+          startedAt: startedAt.toISOString(),
+          endedAt: endedAt.toISOString(),
           durationSec,
           score: Math.min(10, Math.round((completed ? cycles : normalizedCycles) * 1.25)),
           meta: {
@@ -252,8 +268,8 @@ export default function BreathConstellationPage() {
         await logBreathworkSession({
           technique: patternKey,
           durationSec,
-          startedAt: new Date(startedAt).toISOString(),
-          endedAt: new Date(endedAt).toISOString(),
+          startedAt: startedAt.toISOString(),
+          endedAt: endedAt.toISOString(),
           cyclesPlanned: cycles,
           cyclesCompleted: normalizedCycles,
           density,
@@ -262,8 +278,31 @@ export default function BreathConstellationPage() {
           soundCues,
           haptics: hapticsEnabled && !isReducedMotion,
         });
+        await logAndJournal({
+          type: "breath",
+          duration_sec: durationSec,
+          mood_delta: null,
+          journalText: PROTOCOL_JOURNAL_SUMMARY[patternKey] ?? "Respiration terminée, souffle plus fluide.",
+          meta: {
+            protocol: patternKey,
+            density,
+            cycles_planned: cycles,
+            cycles_completed: normalizedCycles,
+            cadence,
+            completed,
+            soundCues,
+            haptics: hapticsEnabled && !isReducedMotion,
+            reduced_motion: isReducedMotion
+          }
+        });
         setSaveStatus("saved");
-        setSaveMessage("Session enregistrée dans votre historique Supabase et votre journal d'activité.");
+        setSaveMessage("Session enregistrée et ajoutée automatiquement au journal.");
+        Sentry.addBreadcrumb({
+          category: "session",
+          message: "session:complete",
+          level: "info",
+          data: { module: "breath_constellation", duration_sec: durationSec, completed }
+        });
       } catch (error) {
         if (error instanceof BreathworkSessionAuthError) {
           setSaveStatus("unauthenticated");
@@ -276,8 +315,10 @@ export default function BreathConstellationPage() {
           setSaveStatus("error");
           setSaveMessage("Impossible d'enregistrer la session pour le moment.");
         }
+        Sentry.captureException(error);
       } finally {
         sessionStartRef.current = null;
+        clock.reset();
       }
     },
     [
@@ -289,14 +330,18 @@ export default function BreathConstellationPage() {
       hapticsEnabled,
       isReducedMotion,
       logBreathworkSession,
+      clock,
+      clockElapsedSeconds,
+      logAndJournal,
     ],
   );
 
   const finalizeSession = React.useCallback(
     (cyclesCompleted: number, completed: boolean) => {
+      clock.complete();
       void logSession(cyclesCompleted, completed);
     },
-    [logSession],
+    [clock, logSession],
   );
 
   React.useEffect(() => {
@@ -314,17 +359,19 @@ export default function BreathConstellationPage() {
       setCycles(nextProtocol.recommendedCycles);
       setDensity(nextProtocol.recommendedDensity);
       sessionStartRef.current = null;
+      clock.reset();
       resetFeedback();
     },
-    [resetFeedback],
+    [clock, resetFeedback],
   );
 
   const handleCycleChange = React.useCallback(
     (value: number) => {
       setCycles(value);
+      clock.reset();
       resetFeedback();
     },
-    [resetFeedback],
+    [clock, resetFeedback],
   );
 
   const handleDensityChange = React.useCallback(
@@ -336,29 +383,66 @@ export default function BreathConstellationPage() {
   );
 
   const handleToggle = React.useCallback(() => {
-    if (!running && sessionStartRef.current === null) {
-      sessionStartRef.current = Date.now();
+    if (!running) {
+      if (clockState === "idle" || clockState === "completed") {
+        sessionStartRef.current = new Date();
+        clock.reset();
+        clock.start();
+        Sentry.addBreadcrumb({
+          category: "session",
+          message: "session:start",
+          level: "info",
+          data: { module: "breath_constellation" }
+        });
+      } else if (clockState === "paused") {
+        clock.resume();
+        Sentry.addBreadcrumb({
+          category: "session",
+          message: "session:resume",
+          level: "info",
+          data: { module: "breath_constellation" }
+        });
+      }
       resetFeedback();
+    } else {
+      clock.pause();
+      Sentry.addBreadcrumb({
+        category: "session",
+        message: "session:pause",
+        level: "info",
+        data: { module: "breath_constellation" }
+      });
     }
     toggle();
-  }, [running, toggle, resetFeedback]);
+    primaryButtonRef.current?.focus({ preventScroll: true });
+  }, [running, clockState, clock, toggle, resetFeedback]);
 
   const handleResume = React.useCallback(() => {
-    if (sessionStartRef.current === null) {
-      sessionStartRef.current = Date.now();
-    }
+    sessionStartRef.current = new Date();
+    clock.reset();
+    clock.start();
+    Sentry.addBreadcrumb({
+      category: "session",
+      message: "session:start",
+      level: "info",
+      data: { module: "breath_constellation" }
+    });
     resetFeedback();
     start();
-  }, [start, resetFeedback]);
+    primaryButtonRef.current?.focus({ preventScroll: true });
+  }, [clock, start, resetFeedback]);
 
   const handleStop = React.useCallback(() => {
     const completedCycles = Math.min(cycle, cycles);
     const completed = cycles > 0 && completedCycles >= cycles;
+    clock.complete();
     if (sessionStartRef.current) {
       finalizeSession(completedCycles, completed);
     }
     stop();
-  }, [cycle, cycles, finalizeSession, stop]);
+    sessionStartRef.current = null;
+    primaryButtonRef.current?.focus({ preventScroll: true });
+  }, [cycle, cycles, finalizeSession, stop, clock]);
 
   const phaseLabel = PHASE_LABELS[current.phase];
   const phaseDescription = PHASE_DESCRIPTIONS[current.phase];
@@ -366,10 +450,13 @@ export default function BreathConstellationPage() {
   const phaseRemaining = Math.max(0, Math.round((phaseDuration ?? 0) * (1 - phaseProgress)));
 
   const sessionProgress = React.useMemo(() => {
+    if (typeof clockProgress === "number") {
+      return clockProgress;
+    }
     if (cycles <= 0) return 0;
     const effective = Math.min(cycle, cycles) + Math.min(1, Math.max(0, phaseProgress));
     return Math.min(1, Math.max(0, effective / cycles));
-  }, [cycle, cycles, phaseProgress]);
+  }, [clockProgress, cycle, cycles, phaseProgress]);
 
   const sessionEstimate = React.useMemo(() => {
     const expectedSeconds = cycles * protocol.cycleDuration;
@@ -395,7 +482,24 @@ export default function BreathConstellationPage() {
   }, [saveStatus]);
 
   return (
-    <main aria-label="Breath Constellation">
+    <main aria-label="Breath Constellation" style={{ position: "relative" }}>
+      <div
+        role="status"
+        aria-live="polite"
+        style={{
+          position: "absolute",
+          width: 1,
+          height: 1,
+          padding: 0,
+          margin: -1,
+          overflow: "hidden",
+          clip: "rect(0, 0, 0, 0)",
+          whiteSpace: "nowrap",
+          border: 0,
+        }}
+      >
+        {sessionStatusMessage}
+      </div>
       <PageHeader
         title="Breath Constellation"
         subtitle="Respiration guidée par une constellation vivante"
@@ -565,7 +669,7 @@ export default function BreathConstellationPage() {
           </div>
 
           <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-            <Button onClick={handleToggle} data-ui="primary-cta">
+            <Button ref={primaryButtonRef} onClick={handleToggle} data-ui="primary-cta">
               {running ? "Pause" : "Démarrer"}
             </Button>
             {!running && cycle > 0 && cycle < cycles && (

--- a/src/modules/breath-constellation/__tests__/BreathConstellationStatus.test.tsx
+++ b/src/modules/breath-constellation/__tests__/BreathConstellationStatus.test.tsx
@@ -1,0 +1,142 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import BreathConstellationPage from "@/modules/breath-constellation/BreathConstellationPage";
+
+const mockClockState = {
+  state: "idle" as "idle" | "running" | "paused" | "completed",
+  elapsedMs: 0,
+  progress: 0,
+};
+
+const mockBreathState = {
+  running: false,
+};
+
+vi.mock("@sentry/react", () => ({
+  addBreadcrumb: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+vi.mock("framer-motion", () => ({
+  useReducedMotion: () => false,
+}));
+
+vi.mock("@/COMPONENTS.reg", () => ({
+  PageHeader: ({ title, subtitle }: any) => (
+    <header>
+      <h1>{title}</h1>
+      {subtitle ? <p>{subtitle}</p> : null}
+    </header>
+  ),
+  Card: ({ children }: any) => <section>{children}</section>,
+  Button: React.forwardRef<HTMLButtonElement, any>(({ children, ...props }, ref) => (
+    <button ref={ref} {...props}>
+      {children}
+    </button>
+  )),
+  ConstellationCanvas: () => <div data-testid="constellation" />,
+  useSound: () => null,
+}));
+
+vi.mock("@/modules/sessions/hooks/useSessionClock", () => ({
+  useSessionClock: () => ({
+    state: mockClockState.state,
+    elapsedMs: mockClockState.elapsedMs,
+    progress: mockClockState.progress,
+    start: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    complete: vi.fn(),
+    reset: vi.fn(),
+    onTick: vi.fn(() => () => {}),
+  }),
+}));
+
+vi.mock("@/ui/hooks/useBreathPattern", () => ({
+  useBreathPattern: () => ({
+    current: { phase: "inhale", sec: 4 },
+    phaseProgress: 0,
+    running: mockBreathState.running,
+    cycle: 0,
+    start: vi.fn(),
+    stop: vi.fn(),
+    toggle: vi.fn(),
+    phaseDuration: 4,
+  }),
+}));
+
+vi.mock("@/services/breathworkSessions.service", () => ({
+  logBreathworkSession: vi.fn(),
+  BreathworkSessionAuthError: class extends Error {},
+  BreathworkSessionPersistError: class extends Error {},
+}));
+
+vi.mock("@/services/sessions/sessionsApi", () => ({
+  logAndJournal: vi.fn().mockResolvedValue({
+    id: "session-1",
+    type: "breath",
+    duration_sec: 120,
+    mood_delta: null,
+    meta: {},
+    created_at: new Date().toISOString(),
+  }),
+}));
+
+vi.mock("@/lib/scores/events", () => ({
+  recordEvent: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  toast: vi.fn(),
+}));
+
+vi.mock("@/lib/flags/ff", () => ({
+  ff: () => false,
+}));
+
+vi.mock("@/services/sessions/moodDelta", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/services/sessions/moodDelta")>();
+  return actual;
+});
+
+const extractStatusText = (container: HTMLElement) => {
+  const region = container.querySelector('main [role="status"][aria-live="polite"]');
+  return region?.textContent?.trim();
+};
+
+describe("BreathConstellationPage status messaging", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClockState.state = "idle";
+    mockClockState.elapsedMs = 0;
+    mockClockState.progress = 0;
+    mockBreathState.running = false;
+  });
+
+  it("annonce la préparation de séance à l'état initial", () => {
+    const { container } = render(<BreathConstellationPage />);
+    expect(extractStatusText(container)).toBe("Séance prête à démarrer.");
+  });
+
+  it("annonce une séance en cours lorsque la respiration est active", () => {
+    mockClockState.state = "running";
+    mockBreathState.running = true;
+    const { container } = render(<BreathConstellationPage />);
+    expect(extractStatusText(container)).toBe("Séance en cours.");
+  });
+
+  it("annonce une pause lorsque le minuteur est en pause", () => {
+    mockClockState.state = "paused";
+    mockBreathState.running = false;
+    const { container } = render(<BreathConstellationPage />);
+    expect(extractStatusText(container)).toBe("Séance en pause.");
+  });
+
+  it("annonce la fin de séance lorsque la session est terminée", () => {
+    mockClockState.state = "completed";
+    mockBreathState.running = false;
+    const { container } = render(<BreathConstellationPage />);
+    expect(extractStatusText(container)).toBe("Séance terminée.");
+  });
+});

--- a/src/modules/flash-glow-ultra/FlashGlowUltraPage.tsx
+++ b/src/modules/flash-glow-ultra/FlashGlowUltraPage.tsx
@@ -1,10 +1,12 @@
 "use client";
+
 import React from "react";
+import * as Sentry from "@sentry/react";
 import { PageHeader, Card, Button, ProgressBar } from "@/COMPONENTS.reg";
 import { GlowSurface } from "@/COMPONENTS.reg";
 import { usePulseClock } from "@/COMPONENTS.reg";
 import { ff } from "@/lib/flags/ff";
-import { useSound } from "@/COMPONENTS.reg";       // si P5 dispo
+import { useSound } from "@/COMPONENTS.reg"; // si P5 dispo
 import { recordEvent } from "@/lib/scores/events"; // si P6 dispo
 import { createFlashGlowJournalEntry } from "@/modules/flash-glow/journal";
 import type { JournalEntry } from "@/modules/journal/journalService";
@@ -12,10 +14,15 @@ import { toast } from "@/hooks/use-toast";
 import { flashGlowService } from "@/modules/flash-glow/flash-glowService";
 import type { FlashGlowSession } from "@/modules/flash-glow/flash-glowService";
 import { routes } from "@/routerV2/routes";
+import { useSessionClock } from "@/modules/sessions/hooks/useSessionClock";
+import { logAndJournal } from "@/services/sessions/sessionsApi";
+import { computeMoodDelta } from "@/services/sessions/moodDelta";
 
 type Theme = "cyan" | "violet" | "amber" | "emerald";
 type PresetKey = "calme" | "focus" | "recovery";
 type StageKey = "prepare" | "boost" | "radiate" | "integrate";
+
+type LogStatus = "idle" | "saving" | "saved" | "error" | "unauthenticated";
 
 interface StageDefinition {
   key: StageKey;
@@ -94,33 +101,91 @@ const buildStageSummaries = (elapsedSeconds: number, totalSeconds: number): Stag
   });
 };
 
+const clampMoodValue = (value: number) => Math.max(0, Math.min(100, Math.round(value)));
+
+const buildJournalSummary = (
+  label: "gain" | "léger" | "incertain",
+  moodDelta: number | null,
+  preset: PresetKey
+) => {
+  const base =
+    label === "gain"
+      ? "FlashGlow Ultra terminée, je me sens plus rayonnant·e."
+      : label === "léger"
+        ? "FlashGlow Ultra terminée, je reste enveloppé·e d'une douceur lumineuse."
+        : "FlashGlow Ultra terminée, j'intègre calmement les sensations ressenties.";
+
+  const presetNote =
+    preset === "focus"
+      ? "Je garde ce cap lumineux pour soutenir ma concentration."
+      : preset === "recovery"
+        ? "Je laisse la lumière réparer et apaiser mon corps."
+        : "Je demeure ancré·e dans cette clarté paisible.";
+
+  const deltaNote =
+    moodDelta == null
+      ? "Je reste à l'écoute des sensations qui émergent."
+      : moodDelta > 0
+        ? "Je perçois plus d'espace intérieur qu'au départ."
+        : moodDelta < 0
+          ? "J'accueille ce qui se présente avec bienveillance."
+          : "Je sens une stabilité douce, sans contraste marqué.";
+
+  return `${base} ${presetNote} ${deltaNote}`.trim();
+};
+
+type FinalizationSnapshot = {
+  reason: "manual_stop" | "auto_complete";
+  elapsedSec: number;
+  targetSeconds: number;
+  safeBpm: number;
+  preset: PresetKey;
+  intensity: number;
+  intensityPercent: number;
+  theme: Theme;
+  shape: "ring" | "full";
+  targetMinutes: number;
+  moodBaseline: number;
+  moodAfter: number;
+  rawMoodDelta: number;
+  aggregatedMoodDelta: number | null;
+  moodLabel: "gain" | "léger" | "incertain";
+  recommendation: string;
+  startedAtIso: string;
+  endedAtIso: string;
+  stageSummaries: StageSummary[];
+  satisfactionScore: number | null;
+  summaryText: string;
+};
+
 export default function FlashGlowUltraPage() {
   const [preset, setPreset] = React.useState<PresetKey>("calme");
   const [bpm, setBpm] = React.useState(PRESETS.calme.bpm);
-  const [intensity, setInt] = React.useState(PRESETS.calme.intensity);
+  const [intensity, setIntensity] = React.useState(PRESETS.calme.intensity);
   const [theme, setTheme] = React.useState<Theme>(PRESETS.calme.theme);
   const [shape, setShape] = React.useState<"ring" | "full">(PRESETS.calme.shape);
-  const [running, setRunning] = React.useState(false);
-  const [isSessionActive, setSessionActive] = React.useState(false);
-  const [durationMin, setDur] = React.useState(2);
+  const [durationMin, setDurationMin] = React.useState(2);
   const [sessionTargetMinutes, setSessionTargetMinutes] = React.useState<number>(2);
-  const [elapsedSeconds, setElapsedSeconds] = React.useState(0);
-  const [sessionStartedAt, setSessionStartedAt] = React.useState<number | null>(null);
-  const [autoSaveStatus, setAutoSaveStatus] = React.useState<
-    "idle" | "saving" | "saved" | "error" | "unauthenticated"
-  >("idle");
-  const [autoSaveError, setAutoSaveError] = React.useState<string | null>(null);
-  const [sessionRecordId, setSessionRecordId] = React.useState<string | null>(null);
-  const [lastSessionReason, setLastSessionReason] = React.useState<"manual_stop" | "auto_complete" | null>(null);
   const [moodBaseline, setMoodBaseline] = React.useState<number>(50);
   const [moodAfterSession, setMoodAfterSession] = React.useState<number | null>(null);
   const [moodDelta, setMoodDelta] = React.useState<number | null>(null);
+  const [logStatus, setLogStatus] = React.useState<LogStatus>("idle");
+  const [logError, setLogError] = React.useState<string | null>(null);
+  const [sessionRecordId, setSessionRecordId] = React.useState<string | null>(null);
+  const [lastSessionReason, setLastSessionReason] = React.useState<"manual_stop" | "auto_complete" | null>(null);
+  const [statusAnnouncement, setStatusAnnouncement] = React.useState<string>("Séance prête.");
 
   const reduced =
     typeof window !== "undefined" && window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
 
+  const clock = useSessionClock({
+    durationMs: sessionTargetMinutes > 0 ? sessionTargetMinutes * 60_000 : undefined
+  });
+  const isRunning = clock.state === "running";
+  const isSessionActive = clock.state === "running" || clock.state === "paused";
+
   const SAFE_BPM = Math.min(Math.max(1, bpm), 12);
-  const rawPhase = usePulseClock(SAFE_BPM, running);
+  const rawPhase = usePulseClock(SAFE_BPM, isRunning);
   const phase01 = Math.min(1, rawPhase * Math.max(1, SAFE_BPM / 6));
 
   const useNewAudio = ff?.("new-audio-engine") ?? false;
@@ -128,10 +193,56 @@ export default function FlashGlowUltraPage() {
 
   const lastZone = React.useRef<number>(-1);
   const eventLoggedRef = React.useRef(false);
-  const sessionActiveRef = React.useRef(isSessionActive);
+  const primaryButtonRef = React.useRef<HTMLButtonElement | null>(null);
+  const sessionStartRef = React.useRef<number | null>(null);
+  const completionReasonRef = React.useRef<"manual_stop" | "auto_complete" | null>(null);
+  const finalizingRef = React.useRef(false);
+  const lastCompletionRef = React.useRef<FinalizationSnapshot | null>(null);
 
   React.useEffect(() => {
-    if (!running) {
+    if (!isSessionActive && clock.state === "idle") {
+      setSessionTargetMinutes(durationMin);
+    }
+  }, [durationMin, isSessionActive, clock.state]);
+
+  React.useEffect(() => {
+    if ((clock.progress ?? 0) >= 0.999 && isSessionActive && completionReasonRef.current == null) {
+      completionReasonRef.current = "auto_complete";
+    }
+  }, [clock.progress, isSessionActive]);
+
+  React.useEffect(() => {
+    if (logStatus === "saving") {
+      setStatusAnnouncement("Enregistrement automatique en cours…");
+      return;
+    }
+    if (logStatus === "saved") {
+      setStatusAnnouncement("Session enregistrée automatiquement.");
+      return;
+    }
+    if (logStatus === "error" || logStatus === "unauthenticated") {
+      setStatusAnnouncement("Enregistrement de la séance indisponible.");
+      return;
+    }
+
+    switch (clock.state) {
+      case "running":
+        setStatusAnnouncement("Séance en cours…");
+        break;
+      case "paused":
+        setStatusAnnouncement("Séance en pause.");
+        break;
+      case "completed":
+        setStatusAnnouncement("Séance terminée.");
+        break;
+      default:
+        setStatusAnnouncement("Séance prête.");
+        break;
+    }
+  }, [clock.state, logStatus]);
+
+  React.useEffect(() => {
+    if (!isRunning) {
       lastZone.current = -1;
       return;
     }
@@ -142,225 +253,385 @@ export default function FlashGlowUltraPage() {
       if (tick?.play) tick.play().catch(() => {});
       if ("vibrate" in navigator && !reduced) navigator.vibrate?.(8);
     }
-  }, [phase01, running, tick, reduced]);
+  }, [phase01, isRunning, tick, reduced]);
 
-  React.useEffect(() => {
-    if (!running) return;
-    const targetSeconds = Math.max(1, Math.round(sessionTargetMinutes * 60));
-    const interval = setInterval(() => {
-      setElapsedSeconds((prev) => {
-        if (!isSessionActive) return prev;
-        if (prev >= targetSeconds) return targetSeconds;
-        return Math.min(prev + 1, targetSeconds);
-      });
-    }, 1000);
-    return () => clearInterval(interval);
-  }, [running, sessionTargetMinutes, isSessionActive]);
-  const finalizeSession = React.useCallback(
-    async (reason: "manual_stop" | "auto_complete") => {
-      if (!sessionStartedAt) return;
-
-      const actualDurationSec = elapsedSeconds;
-      const targetMinutes = sessionTargetMinutes || durationMin;
-      const targetSeconds = Math.max(1, Math.round(targetMinutes * 60));
-      const safeBpm = Math.min(Math.max(1, bpm), 12);
-
-      const normalizedBaseline = Math.max(0, Math.min(100, Math.round(moodBaseline)));
-      const normalizedAfter = typeof moodAfterSession === "number"
-        ? Math.max(0, Math.min(100, Math.round(moodAfterSession)))
-        : normalizedBaseline;
-      const computedMoodDelta = normalizedAfter !== null ? normalizedAfter - normalizedBaseline : null;
-      setMoodAfterSession(normalizedAfter);
-      setMoodDelta(computedMoodDelta);
-
-      const moodLabel: "gain" | "léger" | "incertain" = computedMoodDelta !== null
-        ? computedMoodDelta >= 10
-          ? "gain"
-          : computedMoodDelta >= 3
-            ? "léger"
-            : "incertain"
-        : "incertain";
-
-      const recommendationMessage = computedMoodDelta !== null
-        ? computedMoodDelta >= 10
-          ? "Progression spectaculaire ! Gardez ce rythme lumineux."
-          : computedMoodDelta >= 3
-            ? "Belle progression, continuez sur cette cadence."
-            : "Les micro-changements nourrissent votre constance, respirez profondément."
-        : "Prenez un instant pour écouter vos ressentis avant de consigner la séance.";
+  const persistSession = React.useCallback(
+    async (snapshot: FinalizationSnapshot) => {
+      setLogStatus("saving");
+      setLogError(null);
 
       let journalEntry: JournalEntry | null = null;
       try {
         journalEntry = await createFlashGlowJournalEntry({
-          label: moodLabel,
-          duration: actualDurationSec,
-          intensity: Math.round(Math.max(0, Math.min(1, intensity)) * 100),
-          glowType: preset,
-          recommendation: recommendationMessage,
+          label: snapshot.moodLabel,
+          duration: snapshot.elapsedSec,
+          intensity: snapshot.intensityPercent,
+          glowType: snapshot.preset,
+          recommendation: snapshot.recommendation,
           context: "Flash Glow Ultra",
-          moodBefore: normalizedBaseline,
-          moodAfter: normalizedAfter,
-          moodDelta: computedMoodDelta
+          moodBefore: snapshot.moodBaseline,
+          moodAfter: snapshot.moodAfter,
+          moodDelta: snapshot.rawMoodDelta
         });
-      } catch (err) {
-        console.warn("flash-glow-ultra journal", err);
-      }
-
-      if (!eventLoggedRef.current) {
-        try {
-          recordEvent?.({
-            module: "flash-glow-ultra",
-            startedAt: new Date(sessionStartedAt).toISOString(),
-            endedAt: new Date().toISOString(),
-            durationSec: actualDurationSec,
-            score: Math.min(10, 2 + Math.round(actualDurationSec / 120)),
-            meta: {
-              preset,
-              bpm,
-              intensity,
-              theme,
-              shape,
-              targetMinutes,
-              reason
-            }
-          });
-        } catch (err) {
-          console.warn("flash-glow-ultra event", err);
-        }
-        eventLoggedRef.current = true;
+      } catch (error) {
+        console.warn("flash-glow-ultra journal", error);
       }
 
       try {
-        setAutoSaveStatus("saving");
-        setAutoSaveError(null);
-
-        const summaries = buildStageSummaries(actualDurationSec, targetSeconds);
-
-        const satisfactionScore = computedMoodDelta !== null
-          ? computedMoodDelta >= 10
-            ? 5
-            : computedMoodDelta >= 3
-              ? 4
-              : computedMoodDelta >= 0
-                ? 3
-                : computedMoodDelta >= -3
-                  ? 2
-                  : 1
-          : null;
-
-        const intensityPercent = Math.round(Math.max(0, Math.min(1, intensity)) * 100);
-
         const sessionPayload: FlashGlowSession = {
-          duration_s: actualDurationSec,
-          label: moodLabel,
-          glow_type: preset,
-          intensity: intensityPercent,
-          result: reason === "auto_complete" ? "completed" : "interrupted",
+          duration_s: snapshot.elapsedSec,
+          label: snapshot.moodLabel,
+          glow_type: snapshot.preset,
+          intensity: snapshot.intensityPercent,
+          result: snapshot.reason === "auto_complete" ? "completed" : "interrupted",
           metadata: {
-            preset,
-            bpm,
-            theme,
-            shape,
-            mode: 'ultra',
-            context: 'Flash Glow Ultra',
-            target_minutes: targetMinutes,
-            actual_minutes: Number((actualDurationSec / 60).toFixed(2)),
-            stages: summaries.map((stage) => ({
+            preset: snapshot.preset,
+            bpm: snapshot.safeBpm,
+            theme: snapshot.theme,
+            shape: snapshot.shape,
+            mode: "ultra",
+            context: "Flash Glow Ultra",
+            target_minutes: snapshot.targetMinutes,
+            actual_minutes: Number((snapshot.elapsedSec / 60).toFixed(2)),
+            stages: snapshot.stageSummaries.map((stage) => ({
               key: stage.key,
               label: stage.label,
               planned_seconds: stage.plannedSeconds,
               actual_seconds: stage.actualSeconds,
               portion: stage.portion
             })),
-            safe_bpm: safeBpm,
-            reason,
-            started_at: new Date(sessionStartedAt).toISOString(),
-            ended_at: new Date().toISOString(),
-            recommendation: recommendationMessage,
-            satisfactionScore,
+            safe_bpm: snapshot.safeBpm,
+            reason: snapshot.reason,
+            started_at: snapshot.startedAtIso,
+            ended_at: snapshot.endedAtIso,
+            recommendation: snapshot.recommendation,
+            satisfactionScore: snapshot.satisfactionScore,
             journalEntryId: journalEntry?.id ?? null,
-            moodBefore: normalizedBaseline,
-            moodAfter: normalizedAfter,
-            moodDelta: computedMoodDelta
+            moodBefore: snapshot.moodBaseline,
+            moodAfter: snapshot.moodAfter,
+            moodDelta: snapshot.rawMoodDelta
           }
         };
 
         const response = await flashGlowService.endSession(sessionPayload);
 
-        if (journalEntry) {
-          toast({
-            title: "Journal mis à jour ✨",
-            description: recommendationMessage
-          });
-        }
+        const sessionRecord = await logAndJournal({
+          type: "flash_glow",
+          duration_sec: snapshot.elapsedSec,
+          mood_delta: snapshot.aggregatedMoodDelta ?? null,
+          journalText: snapshot.summaryText,
+          meta: {
+            preset: snapshot.preset,
+            theme: snapshot.theme,
+            shape: snapshot.shape,
+            bpm: snapshot.safeBpm,
+            intensity_percent: snapshot.intensityPercent,
+            target_minutes: snapshot.targetMinutes,
+            reason: snapshot.reason,
+            started_at: snapshot.startedAtIso,
+            ended_at: snapshot.endedAtIso,
+            satisfaction_score: snapshot.satisfactionScore,
+            mood_before: snapshot.moodBaseline,
+            mood_after: snapshot.moodAfter,
+            mood_delta_raw: snapshot.rawMoodDelta,
+            mood_delta_index: snapshot.aggregatedMoodDelta,
+            journal_entry_id: journalEntry?.id ?? null,
+            recommendation: snapshot.recommendation,
+            flash_glow_mode: "ultra",
+            stage_summaries: snapshot.stageSummaries.map((stage) => ({
+              key: stage.key,
+              planned_seconds: stage.plannedSeconds,
+              actual_seconds: stage.actualSeconds
+            })),
+            service_session_id: response?.activity_session_id ?? null
+          }
+        });
 
         if (response?.activity_session_id) {
           setSessionRecordId(response.activity_session_id);
+        } else if (sessionRecord?.id) {
+          setSessionRecordId(sessionRecord.id);
         } else {
           setSessionRecordId(null);
         }
 
         if (typeof response?.mood_delta === "number") {
           setMoodDelta(response.mood_delta);
+        } else {
+          setMoodDelta(snapshot.rawMoodDelta);
         }
 
-        setAutoSaveStatus("saved");
-      } catch (err: any) {
-        console.error("Auto-save Flash Glow Ultra session failed", err);
-        const message = err?.message ?? "Erreur inattendue lors de l'enregistrement de la session";
-        const isAuthError = /authent/i.test(message) || /unauthor/i.test(message);
-        setAutoSaveStatus(isAuthError ? "unauthenticated" : "error");
-        setAutoSaveError(message);
+        toast({
+          title: "Session terminée ! ✨",
+          description: [
+            snapshot.recommendation,
+            snapshot.aggregatedMoodDelta == null
+              ? null
+              : `Δ humeur : ${snapshot.aggregatedMoodDelta > 0 ? "+" : ""}${snapshot.aggregatedMoodDelta}`,
+            "📝 Votre expérience a été ajoutée automatiquement au journal."
+          ]
+            .filter(Boolean)
+            .join("\n")
+        });
+
+        setLogStatus("saved");
+        Sentry.addBreadcrumb({
+          category: "session",
+          message: "session:complete",
+          level: "info",
+          data: { module: "flash_glow_ultra", duration_sec: snapshot.elapsedSec, reason: snapshot.reason }
+        });
+      } catch (error: any) {
+        const message = error?.message ?? "Erreur inattendue lors de l'enregistrement de la session";
+        const isAuthError = /auth/i.test(message) || /unauthor/i.test(message) || /401/.test(message);
+        setLogStatus(isAuthError ? "unauthenticated" : "error");
+        setLogError(message);
+        Sentry.captureException(error);
+        toast({
+          title: "Enregistrement impossible",
+          description: message,
+          variant: "destructive"
+        });
+        throw error;
       }
     },
-    [sessionStartedAt, elapsedSeconds, sessionTargetMinutes, durationMin, bpm, preset, intensity, theme, shape]
+    [flashGlowService, logAndJournal, toast, createFlashGlowJournalEntry]
+  );
+
+  const finalizeSession = React.useCallback(
+    async (reason: "manual_stop" | "auto_complete") => {
+      if (!sessionStartRef.current) {
+        return;
+      }
+
+      const startedAt = new Date(sessionStartRef.current);
+      sessionStartRef.current = null;
+      const endedAt = new Date();
+
+      const elapsedSec = Math.max(1, Math.round(clock.elapsedMs / 1000));
+      const targetMinutes = sessionTargetMinutes || durationMin;
+      const targetSeconds = Math.max(1, Math.round(targetMinutes * 60));
+      const safeBpm = Math.min(Math.max(1, bpm), 12);
+      const safeIntensity = Math.max(0, Math.min(1, intensity));
+
+      const baseline = clampMoodValue(moodBaseline);
+      const resolvedAfter = typeof moodAfterSession === "number" ? clampMoodValue(moodAfterSession) : baseline;
+
+      setMoodAfterSession(resolvedAfter);
+
+      const rawMoodDelta = resolvedAfter - baseline;
+      setMoodDelta(rawMoodDelta);
+
+      const baselineSnapshot = { valence: baseline / 50 - 1, arousal: 0 };
+      const afterSnapshot = { valence: resolvedAfter / 50 - 1, arousal: 0 };
+      const aggregatedMoodDelta = computeMoodDelta(baselineSnapshot, afterSnapshot);
+
+      const moodLabel: "gain" | "léger" | "incertain" = rawMoodDelta >= 10
+        ? "gain"
+        : rawMoodDelta >= 3
+          ? "léger"
+          : "incertain";
+
+      const recommendation = rawMoodDelta >= 10
+        ? "Progression spectaculaire ! Gardez ce rythme lumineux."
+        : rawMoodDelta >= 3
+          ? "Belle progression, continuez sur cette cadence."
+          : "Les micro-changements nourrissent votre constance, respirez profondément.";
+
+      const satisfactionScore = rawMoodDelta >= 10
+        ? 5
+        : rawMoodDelta >= 3
+          ? 4
+          : rawMoodDelta >= 0
+            ? 3
+            : rawMoodDelta >= -3
+              ? 2
+              : 1;
+
+      const stageSummaries = buildStageSummaries(elapsedSec, targetSeconds);
+
+      const snapshot: FinalizationSnapshot = {
+        reason,
+        elapsedSec,
+        targetSeconds,
+        safeBpm,
+        preset,
+        intensity: safeIntensity,
+        intensityPercent: Math.round(safeIntensity * 100),
+        theme,
+        shape,
+        targetMinutes,
+        moodBaseline: baseline,
+        moodAfter: resolvedAfter,
+        rawMoodDelta,
+        aggregatedMoodDelta,
+        moodLabel,
+        recommendation,
+        startedAtIso: startedAt.toISOString(),
+        endedAtIso: endedAt.toISOString(),
+        stageSummaries,
+        satisfactionScore,
+        summaryText: buildJournalSummary(moodLabel, aggregatedMoodDelta, preset)
+      };
+
+      lastCompletionRef.current = snapshot;
+      setLastSessionReason(reason);
+
+      if (!eventLoggedRef.current) {
+        try {
+          recordEvent?.({
+            module: "flash-glow-ultra",
+            startedAt: snapshot.startedAtIso,
+            endedAt: snapshot.endedAtIso,
+            durationSec: snapshot.elapsedSec,
+            meta: {
+              preset,
+              bpm,
+              intensity: safeIntensity,
+              theme,
+              shape,
+              targetMinutes,
+              reason
+            }
+          });
+        } catch (error) {
+          console.warn("flash-glow-ultra event", error);
+        }
+        eventLoggedRef.current = true;
+      }
+
+      await persistSession(snapshot).finally(() => {
+        primaryButtonRef.current?.focus({ preventScroll: true });
+      });
+    },
+    [clock.elapsedMs, sessionTargetMinutes, durationMin, bpm, intensity, theme, shape, preset, moodBaseline, moodAfterSession, persistSession, recordEvent]
   );
 
   React.useEffect(() => {
-    if (!isSessionActive || !running) return;
-    const targetSeconds = Math.max(1, Math.round(sessionTargetMinutes * 60));
-    if (elapsedSeconds >= targetSeconds) {
-      setRunning(false);
-      setSessionActive(false);
+    if (clock.state !== "completed") {
+      return;
     }
-  }, [elapsedSeconds, running, isSessionActive, sessionTargetMinutes]);
-
-  React.useEffect(() => {
-    if (!isSessionActive && sessionActiveRef.current) {
-      const targetMinutes = sessionTargetMinutes || durationMin;
-      const targetSeconds = Math.max(1, Math.round(targetMinutes * 60));
-      const reason: "manual_stop" | "auto_complete" =
-        elapsedSeconds >= targetSeconds ? "auto_complete" : "manual_stop";
-      setLastSessionReason(reason);
-      finalizeSession(reason);
+    if (finalizingRef.current) {
+      return;
     }
-    sessionActiveRef.current = isSessionActive;
-  }, [isSessionActive, finalizeSession, elapsedSeconds, sessionTargetMinutes, durationMin]);
-
-  React.useEffect(() => {
-    if (!isSessionActive && elapsedSeconds === 0 && sessionTargetMinutes !== durationMin) {
-      setSessionTargetMinutes(durationMin);
+    if (!sessionStartRef.current) {
+      return;
     }
-  }, [durationMin, isSessionActive, elapsedSeconds, sessionTargetMinutes]);
 
+    finalizingRef.current = true;
+    const reason = completionReasonRef.current ?? "auto_complete";
+    finalizeSession(reason)
+      .catch((error) => {
+        console.error("Auto-save Flash Glow Ultra session failed", error);
+      })
+      .finally(() => {
+        completionReasonRef.current = null;
+        finalizingRef.current = false;
+      });
+  }, [clock.state, finalizeSession]);
+
+  const startSession = React.useCallback(() => {
+    sessionStartRef.current = Date.now();
+    completionReasonRef.current = null;
+    finalizingRef.current = false;
+    lastCompletionRef.current = null;
+    eventLoggedRef.current = false;
+    setSessionTargetMinutes(durationMin);
+    setMoodDelta(null);
+    setMoodAfterSession(moodBaseline);
+    setLogStatus("idle");
+    setLogError(null);
+    setSessionRecordId(null);
+    setLastSessionReason(null);
+    lastZone.current = -1;
+
+    Sentry.addBreadcrumb({
+      category: "session",
+      message: "session:start",
+      level: "info",
+      data: { module: "flash_glow_ultra", duration_min: durationMin, bpm }
+    });
+
+    try {
+      recordEvent?.({
+        module: "flash-glow-ultra",
+        startedAt: new Date(sessionStartRef.current).toISOString(),
+        meta: { preset, bpm, intensity, theme, shape, durationMin }
+      });
+    } catch (error) {
+      console.warn("flash-glow-ultra start", error);
+    }
+
+    clock.reset();
+    clock.start();
+  }, [clock, durationMin, moodBaseline, bpm, preset, intensity, theme, shape, recordEvent]);
+
+  const handlePause = React.useCallback(() => {
+    if (!isRunning) return;
+    clock.pause();
+    Sentry.addBreadcrumb({
+      category: "session",
+      message: "session:pause",
+      level: "info",
+      data: { module: "flash_glow_ultra" }
+    });
+    primaryButtonRef.current?.focus({ preventScroll: true });
+  }, [clock, isRunning]);
+
+  const handlePrimaryAction = React.useCallback(() => {
+    if (clock.state === "idle" || clock.state === "completed") {
+      startSession();
+      return;
+    }
+
+    if (clock.state === "running") {
+      completionReasonRef.current = "manual_stop";
+      setStatusAnnouncement("Clôture de la séance…");
+      clock.complete();
+      return;
+    }
+
+    if (clock.state === "paused") {
+      clock.resume();
+      Sentry.addBreadcrumb({
+        category: "session",
+        message: "session:resume",
+        level: "info",
+        data: { module: "flash_glow_ultra" }
+      });
+      primaryButtonRef.current?.focus({ preventScroll: true });
+    }
+  }, [clock, startSession]);
+
+  const retrySave = React.useCallback(() => {
+    const snapshot = lastCompletionRef.current;
+    if (!snapshot) return;
+    persistSession(snapshot).catch(() => {});
+  }, [persistSession]);
+
+  const clockElapsedSeconds = Math.max(0, Math.round(clock.elapsedMs / 1000));
   const targetSecondsForSession = Math.max(1, Math.round(sessionTargetMinutes * 60));
   const previewSeconds = Math.max(1, Math.round(durationMin * 60));
   const displayTotalSeconds =
-    isSessionActive || elapsedSeconds > 0 ? targetSecondsForSession : previewSeconds;
-  const progress = displayTotalSeconds ? Math.min(1, elapsedSeconds / displayTotalSeconds) : 0;
+    isSessionActive || clock.state === "completed" || clockElapsedSeconds > 0
+      ? targetSecondsForSession
+      : previewSeconds;
+  const progress = displayTotalSeconds
+    ? Math.min(1, (clock.progress ?? clockElapsedSeconds / displayTotalSeconds))
+    : 0;
   const progressPercent = Math.min(100, Math.max(0, Math.round(progress * 100)));
 
   const stageSummaries = React.useMemo(
-    () => buildStageSummaries(elapsedSeconds, displayTotalSeconds),
-    [elapsedSeconds, displayTotalSeconds]
+    () => buildStageSummaries(clockElapsedSeconds, displayTotalSeconds),
+    [clockElapsedSeconds, displayTotalSeconds]
   );
 
   const currentStageIndex = React.useMemo(() => {
     if (stageSummaries.length === 0) return 0;
     if (progress >= 1) return stageSummaries.length - 1;
-    const idx = stageSummaries.findIndex((stage) => elapsedSeconds < stage.endSeconds);
+    const idx = stageSummaries.findIndex((stage) => clockElapsedSeconds < stage.endSeconds);
     return idx === -1 ? stageSummaries.length - 1 : idx;
-  }, [stageSummaries, progress, elapsedSeconds]);
+  }, [stageSummaries, progress, clockElapsedSeconds]);
 
   const currentStage = stageSummaries[currentStageIndex] ?? stageSummaries[0];
   const stageRemainingSeconds = currentStage
@@ -368,67 +639,17 @@ export default function FlashGlowUltraPage() {
     : 0;
   const totalRemainingSeconds = Math.max(
     0,
-    displayTotalSeconds - Math.min(elapsedSeconds, displayTotalSeconds)
+    displayTotalSeconds - Math.min(clockElapsedSeconds, displayTotalSeconds)
   );
   const stageProgressValues = stageSummaries.map((stage) =>
     stage.plannedSeconds ? Math.min(1, stage.actualSeconds / stage.plannedSeconds) : 0
   );
 
-  function applyPreset(k: PresetKey) {
-    const p = PRESETS[k];
-    setPreset(k);
-    setBpm(p.bpm);
-    setInt(p.intensity);
-    setTheme(p.theme);
-    setShape(p.shape);
-  }
-  function onPrimaryAction() {
-    const now = Date.now();
-
-    if (!isSessionActive) {
-      setElapsedSeconds(0);
-      setSessionTargetMinutes(durationMin);
-      setSessionStartedAt(now);
-      setAutoSaveStatus("idle");
-      setAutoSaveError(null);
-      setSessionRecordId(null);
-      setLastSessionReason(null);
-      setMoodAfterSession(moodBaseline);
-      setMoodDelta(null);
-      eventLoggedRef.current = false;
-      lastZone.current = -1;
-      setSessionActive(true);
-      setRunning(true);
-
-      try {
-        recordEvent?.({
-          module: "flash-glow-ultra",
-          startedAt: new Date(now).toISOString(),
-          meta: { preset, bpm, intensity, theme, shape, durationMin }
-        });
-      } catch (err) {
-        console.warn("flash-glow-ultra start", err);
-      }
-
-      return;
-    }
-
-    if (!running) {
-      setRunning(true);
-      return;
-    }
-
-    setRunning(false);
-    setSessionActive(false);
-  }
-
-  const retrySave = React.useCallback(() => {
-    if (lastSessionReason) {
-      finalizeSession(lastSessionReason);
-    }
-  }, [lastSessionReason, finalizeSession]);
-
-  const primaryLabel = !isSessionActive ? "Démarrer" : running ? "Terminer" : "Reprendre";
+  const primaryLabel = clock.state === "running"
+    ? "Terminer"
+    : clock.state === "paused"
+      ? "Reprendre"
+      : "Démarrer";
 
   return (
     <main aria-label="Flash Glow Ultra">
@@ -441,7 +662,15 @@ export default function FlashGlowUltraPage() {
           <div style={{ display: "grid", gap: 8 }}>
             <label>
               Preset
-              <select value={preset} onChange={(e) => applyPreset(e.target.value as PresetKey)}>
+              <select value={preset} onChange={(e) => {
+                const key = e.target.value as PresetKey;
+                const next = PRESETS[key];
+                setPreset(key);
+                setBpm(next.bpm);
+                setIntensity(next.intensity);
+                setTheme(next.theme);
+                setShape(next.shape);
+              }}>
                 <option value="calme">Calme (6 bpm, emerald)</option>
                 <option value="focus">Focus (8 bpm, cyan)</option>
                 <option value="recovery">Recovery (4 bpm, violet)</option>
@@ -468,7 +697,7 @@ export default function FlashGlowUltraPage() {
                 max={1}
                 step={0.05}
                 value={intensity}
-                onChange={(e) => setInt(parseFloat(e.target.value))}
+                onChange={(e) => setIntensity(parseFloat(e.target.value))}
               />
             </label>
 
@@ -498,7 +727,7 @@ export default function FlashGlowUltraPage() {
                 max={10}
                 step={1}
                 value={durationMin}
-                onChange={(e) => setDur(parseInt(e.target.value, 10))}
+                onChange={(e) => setDurationMin(parseInt(e.target.value, 10))}
               />
             </label>
           </div>
@@ -512,7 +741,7 @@ export default function FlashGlowUltraPage() {
                 max={100}
                 step={1}
                 value={moodBaseline}
-                onChange={(e) => setMoodBaseline(parseInt(e.target.value, 10))}
+                onChange={(e) => setMoodBaseline(clampMoodValue(parseInt(e.target.value, 10)))}
                 disabled={isSessionActive}
               />
             </label>
@@ -524,7 +753,7 @@ export default function FlashGlowUltraPage() {
                 max={100}
                 step={1}
                 value={moodAfterSession ?? moodBaseline}
-                onChange={(e) => setMoodAfterSession(parseInt(e.target.value, 10))}
+                onChange={(e) => setMoodAfterSession(clampMoodValue(parseInt(e.target.value, 10)))}
               />
             </label>
             {moodDelta !== null && (
@@ -575,7 +804,7 @@ export default function FlashGlowUltraPage() {
                 opacity: 0.8
               }}
             >
-              <span>Écoulé : {formatTime(elapsedSeconds)}</span>
+              <span>Écoulé : {formatTime(clockElapsedSeconds)}</span>
               <span>{progressPercent}%</span>
               <span>Objectif : {formatTime(displayTotalSeconds)}</span>
             </div>
@@ -660,15 +889,28 @@ export default function FlashGlowUltraPage() {
 
           <GlowSurface phase01={phase01} theme={theme} intensity={intensity} shape={shape} />
 
-          <div style={{ display: "flex", gap: 8 }}>
-            <Button onClick={onPrimaryAction} data-ui="primary-cta">
-              {primaryLabel}
-            </Button>
-            {isSessionActive && running && (
-              <Button onClick={() => setRunning(false)} type="button">
-                Pause
+          <div style={{ display: "grid", gap: 4 }}>
+            <div
+              role="status"
+              aria-live="polite"
+              style={{ fontSize: 12, opacity: 0.85 }}
+            >
+              {statusAnnouncement}
+            </div>
+            <div style={{ display: "flex", gap: 8 }}>
+              <Button
+                ref={primaryButtonRef}
+                onClick={handlePrimaryAction}
+                data-ui="primary-cta"
+              >
+                {primaryLabel}
               </Button>
-            )}
+              {isSessionActive && isRunning && (
+                <Button onClick={handlePause} type="button">
+                  Pause
+                </Button>
+              )}
+            </div>
           </div>
 
           <small style={{ opacity: 0.75 }}>
@@ -676,18 +918,18 @@ export default function FlashGlowUltraPage() {
             l’animation devient très douce.
           </small>
 
-          {autoSaveStatus !== "idle" && (
+          {logStatus !== "idle" && (
             <div
               role="status"
               aria-live="polite"
               style={{ display: "grid", gap: 8, fontSize: 12, lineHeight: 1.5 }}
             >
-              {autoSaveStatus === "saving" && (
+              {logStatus === "saving" && (
                 <div style={{ color: "var(--accent, #f97316)" }}>
                   Enregistrement automatique en cours...
                 </div>
               )}
-              {autoSaveStatus === "saved" && (
+              {logStatus === "saved" && (
                 <div style={{ color: "var(--success, #22c55e)" }}>
                   Session enregistrée automatiquement
                   {sessionRecordId ? ` (#${sessionRecordId.slice(0, 8)})` : ""}.
@@ -698,7 +940,7 @@ export default function FlashGlowUltraPage() {
                   )}
                 </div>
               )}
-              {autoSaveStatus === "unauthenticated" && (
+              {logStatus === "unauthenticated" && (
                 <div
                   style={{
                     display: "flex",
@@ -713,7 +955,7 @@ export default function FlashGlowUltraPage() {
                   }}
                 >
                   <span style={{ flex: "1 1 240px" }}>
-                    {autoSaveError ?? "Connectez-vous pour enregistrer vos sessions Flash Glow Ultra."}
+                    {logError ?? "Connectez-vous pour enregistrer vos sessions Flash Glow Ultra."}
                   </span>
                   <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
                     <Button asChild variant="warning" size="sm" data-ui="login-cta">
@@ -729,9 +971,9 @@ export default function FlashGlowUltraPage() {
                   </div>
                 </div>
               )}
-              {autoSaveStatus === "error" && (
+              {logStatus === "error" && (
                 <div style={{ color: "var(--destructive, #ef4444)" }}>
-                  Enregistrement impossible{autoSaveError ? ` : ${autoSaveError}` : ""}.
+                  Enregistrement impossible{logError ? ` : ${logError}` : ""}.
                   {lastSessionReason && (
                     <button
                       type="button"

--- a/src/modules/flash-glow/__tests__/flashGlowUltraSession.test.tsx
+++ b/src/modules/flash-glow/__tests__/flashGlowUltraSession.test.tsx
@@ -1,0 +1,192 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, waitFor, screen, act } from "@testing-library/react";
+import FlashGlowUltraPage from "@/modules/flash-glow-ultra/FlashGlowUltraPage";
+
+const clockControls: {
+  setElapsed: (ms: number) => void;
+  complete: () => void;
+  reset: () => void;
+} = {
+  setElapsed: () => {},
+  complete: () => {},
+  reset: () => {},
+};
+
+vi.mock("@/COMPONENTS.reg", () => ({
+  PageHeader: ({ title, subtitle }: any) => (
+    <header>
+      <h1>{title}</h1>
+      {subtitle ? <p>{subtitle}</p> : null}
+    </header>
+  ),
+  Card: ({ children }: any) => <section>{children}</section>,
+  Button: React.forwardRef<HTMLButtonElement, any>(({ children, ...props }, ref) => (
+    <button ref={ref} {...props}>
+      {children}
+    </button>
+  )),
+  GlowSurface: () => <div data-testid="glow-surface" />,
+  ProgressBar: ({ value }: any) => <div data-testid="progress">{value}</div>,
+  usePulseClock: () => 0,
+  useSound: () => null,
+}));
+
+vi.mock("@/modules/sessions/hooks/useSessionClock", () => {
+  return {
+    useSessionClock: (options?: { durationMs?: number }) => {
+      const [state, setState] = React.useState<"idle" | "running" | "paused" | "completed">("idle");
+      const [elapsedMs, setElapsedMs] = React.useState(0);
+      const callbacksRef = React.useRef(new Set<(ms: number) => void>());
+
+      const start = () => setState("running");
+      const pause = () => setState("paused");
+      const resume = () => setState("running");
+      const complete = () => setState("completed");
+      const reset = () => {
+        setState("idle");
+        setElapsedMs(0);
+      };
+
+      clockControls.setElapsed = (ms: number) => {
+        setElapsedMs(ms);
+        callbacksRef.current.forEach((cb) => cb(ms));
+      };
+      clockControls.complete = () => complete();
+      clockControls.reset = reset;
+
+      const progress = options?.durationMs
+        ? Math.min(1, elapsedMs / options.durationMs)
+        : 0;
+
+      return {
+        state,
+        elapsedMs,
+        progress,
+        start,
+        pause,
+        resume,
+        complete,
+        reset,
+        onTick: (cb: (ms: number) => void) => {
+          callbacksRef.current.add(cb);
+          return () => {
+            callbacksRef.current.delete(cb);
+          };
+        },
+      };
+    },
+  };
+});
+
+const mockLogAndJournal = vi.fn().mockResolvedValue({
+  id: "session-xyz",
+  type: "flash_glow",
+  duration_sec: 65,
+  mood_delta: 6,
+  meta: {},
+  created_at: new Date().toISOString(),
+});
+
+vi.mock("@/services/sessions/sessionsApi", () => ({
+  logAndJournal: (...args: any[]) => mockLogAndJournal(...args),
+}));
+
+const mockEndSession = vi.fn().mockResolvedValue({
+  activity_session_id: "fg-session-1",
+  mood_delta: 7,
+});
+
+vi.mock("@/modules/flash-glow/flash-glowService", () => ({
+  flashGlowService: {
+    endSession: (...args: any[]) => mockEndSession(...args),
+  },
+}));
+
+const mockCreateEntry = vi.fn().mockResolvedValue({ id: "journal-123" });
+
+vi.mock("@/modules/flash-glow/journal", () => ({
+  createFlashGlowJournalEntry: (...args: any[]) => mockCreateEntry(...args),
+}));
+
+vi.mock("@/lib/scores/events", () => ({
+  recordEvent: vi.fn(),
+}));
+
+const mockToast = vi.fn();
+
+vi.mock("@/hooks/use-toast", () => ({
+  toast: (...args: any[]) => mockToast(...args),
+}));
+
+vi.mock("@/lib/flags/ff", () => ({
+  ff: () => false,
+}));
+
+vi.mock("@/routerV2/routes", () => ({
+  routes: {
+    auth: {
+      login: () => "/login",
+    },
+  },
+}));
+
+vi.mock("@sentry/react", () => ({
+  addBreadcrumb: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+describe("FlashGlowUltraPage integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clockControls.reset();
+  });
+
+  afterEach(() => {
+    clockControls.reset();
+  });
+
+  it("enregistre une session complète avec journal automatique", async () => {
+    const { getByText, getByLabelText } = render(<FlashGlowUltraPage />);
+
+    fireEvent.click(getByText(/Démarrer/i));
+
+    fireEvent.change(getByLabelText(/Humeur après séance/i), { target: { value: "76" } });
+
+    await act(async () => {
+      clockControls.setElapsed(65_000);
+    });
+
+    fireEvent.click(getByText(/Terminer/i));
+
+    await act(async () => {
+      clockControls.complete();
+    });
+
+    await waitFor(() => {
+      expect(mockLogAndJournal).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockEndSession).toHaveBeenCalledTimes(1);
+    expect(mockCreateEntry).toHaveBeenCalledTimes(1);
+
+    const logArgs = mockLogAndJournal.mock.calls[0][0];
+    expect(logArgs).toMatchObject({
+      type: "flash_glow",
+      duration_sec: expect.any(Number),
+      meta: expect.objectContaining({ reason: "manual_stop" }),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Session enregistrée automatiquement\s*\(#/i)).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: expect.stringMatching(/Session terminée/),
+        })
+      );
+    });
+  });
+});

--- a/src/modules/sessions/hooks/__tests__/useSessionClock.test.tsx
+++ b/src/modules/sessions/hooks/__tests__/useSessionClock.test.tsx
@@ -1,0 +1,122 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+
+import { useSessionClock } from '../useSessionClock'
+
+describe('useSessionClock', () => {
+  const originalRaf = globalThis.requestAnimationFrame
+  const originalCancelRaf = globalThis.cancelAnimationFrame
+  let now = 0
+  let perfSpy: ReturnType<typeof vi.spyOn>
+
+  const advance = (ms: number) => {
+    now += ms
+    vi.advanceTimersByTime(ms)
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    now = 0
+    perfSpy = vi.spyOn(performance, 'now').mockImplementation(() => now)
+    const timers = new Map<number, ReturnType<typeof setTimeout>>()
+    let rafId = 0
+    globalThis.requestAnimationFrame = vi.fn((cb: FrameRequestCallback) => {
+      const id = ++rafId
+      const timer = setTimeout(() => {
+        cb(now)
+      }, 16)
+      timers.set(id, timer)
+      return id
+    })
+    globalThis.cancelAnimationFrame = vi.fn((id: number) => {
+      const timer = timers.get(id)
+      if (timer) {
+        clearTimeout(timer)
+        timers.delete(id)
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    perfSpy.mockRestore()
+    if (originalRaf) {
+      globalThis.requestAnimationFrame = originalRaf
+    }
+    if (originalCancelRaf) {
+      globalThis.cancelAnimationFrame = originalCancelRaf
+    }
+    vi.restoreAllMocks()
+  })
+
+  it('mesure le temps écoulé avec une dérive minimale', () => {
+    const { result } = renderHook(() => useSessionClock({ durationMs: 5000, tickMs: 100 }))
+
+    act(() => {
+      result.current.start()
+    })
+
+    act(() => {
+      advance(2000)
+    })
+
+    expect(result.current.elapsedMs).toBeGreaterThanOrEqual(1900)
+    expect(result.current.elapsedMs).toBeLessThanOrEqual(2100)
+
+    act(() => {
+      advance(3200)
+    })
+
+    expect(result.current.state).toBe('completed')
+    expect(result.current.elapsedMs).toBeGreaterThanOrEqual(4900)
+    expect(result.current.elapsedMs).toBeLessThanOrEqual(5100)
+  })
+
+  it('gère la pause et la reprise correctement', () => {
+    const { result } = renderHook(() => useSessionClock({ tickMs: 100 }))
+
+    act(() => {
+      result.current.start()
+    })
+
+    act(() => {
+      advance(1500)
+    })
+
+    expect(result.current.elapsedMs).toBeGreaterThanOrEqual(1400)
+
+    act(() => {
+      result.current.pause()
+      advance(1500)
+    })
+
+    expect(result.current.elapsedMs).toBeGreaterThanOrEqual(1400)
+    expect(result.current.elapsedMs).toBeLessThan(1700)
+
+    act(() => {
+      result.current.resume()
+      advance(500)
+    })
+
+    expect(result.current.elapsedMs).toBeGreaterThanOrEqual(1800)
+  })
+
+  it('déclenche les callbacks onTick', () => {
+    const ticks: number[] = []
+    const { result } = renderHook(() => useSessionClock({ durationMs: 1500, tickMs: 200 }))
+
+    act(() => {
+      const unsubscribe = result.current.onTick(ms => {
+        ticks.push(ms)
+      })
+      result.current.start()
+      advance(1600)
+      unsubscribe()
+    })
+
+    expect(ticks.length).toBeGreaterThan(0)
+    expect(ticks[ticks.length - 1]).toBeGreaterThanOrEqual(1400)
+    expect(result.current.state).toBe('completed')
+  })
+})
+

--- a/src/modules/sessions/hooks/useSessionClock.ts
+++ b/src/modules/sessions/hooks/useSessionClock.ts
@@ -1,0 +1,281 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+type ClockState = 'idle' | 'running' | 'paused' | 'completed'
+
+type Options = {
+  tickMs?: number
+  durationMs?: number
+  autoStart?: boolean
+}
+
+type TickCallback = (elapsedMs: number) => void
+
+type Return = {
+  state: ClockState
+  elapsedMs: number
+  progress?: number
+  start: () => void
+  pause: () => void
+  resume: () => void
+  complete: () => void
+  reset: () => void
+  onTick: (cb: TickCallback) => () => void
+}
+
+const MIN_TICK = 16
+
+const now = () => (typeof performance !== 'undefined' && typeof performance.now === 'function' ? performance.now() : Date.now())
+
+export function useSessionClock(options: Options = {}): Return {
+  const { tickMs = 1000, durationMs, autoStart } = options
+  const sanitizedTick = Number.isFinite(tickMs) && tickMs > 0 ? Math.max(MIN_TICK, tickMs) : 1000
+  const durationRef = useRef<number | undefined>(
+    typeof durationMs === 'number' && Number.isFinite(durationMs) && durationMs > 0 ? durationMs : undefined
+  )
+  const tickIntervalRef = useRef(sanitizedTick)
+  const [state, setState] = useState<ClockState>('idle')
+  const [elapsedMs, setElapsedMs] = useState(0)
+
+  const frameRef = useRef<number | null>(null)
+  const lastFrameRef = useRef<number | null>(null)
+  const accumulatorRef = useRef(0)
+  const lastEmitRef = useRef(0)
+  const mountedRef = useRef(true)
+  const stateRef = useRef<ClockState>('idle')
+  const tickCallbacksRef = useRef(new Set<TickCallback>())
+  const fallbackTimersRef = useRef(new Map<number, ReturnType<typeof setTimeout>>())
+  const fallbackIdRef = useRef(0)
+
+  const cancelFrame = useCallback((handle: number | null) => {
+    if (handle == null) {
+      return
+    }
+
+    if (typeof window !== 'undefined' && typeof window.cancelAnimationFrame === 'function') {
+      window.cancelAnimationFrame(handle)
+      return
+    }
+
+    const timer = fallbackTimersRef.current.get(handle)
+    if (timer) {
+      clearTimeout(timer)
+      fallbackTimersRef.current.delete(handle)
+    }
+  }, [])
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      if (frameRef.current != null) {
+        cancelFrame(frameRef.current)
+        frameRef.current = null
+      }
+    }
+  }, [cancelFrame])
+
+  useEffect(() => {
+    tickIntervalRef.current = Math.max(MIN_TICK, sanitizedTick)
+  }, [sanitizedTick])
+
+  useEffect(() => {
+    if (typeof durationMs === 'number' && Number.isFinite(durationMs) && durationMs > 0) {
+      durationRef.current = durationMs
+      if (accumulatorRef.current > durationMs) {
+        accumulatorRef.current = durationMs
+      }
+      if (lastEmitRef.current > durationMs) {
+        lastEmitRef.current = durationMs
+      }
+      setElapsedMs(prev => Math.min(prev, durationMs))
+    } else {
+      durationRef.current = undefined
+    }
+  }, [durationMs])
+
+  const requestFrame = useCallback(
+    (cb: FrameRequestCallback): number => {
+      if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+        return window.requestAnimationFrame(cb)
+      }
+
+      const id = ++fallbackIdRef.current
+      const timer = setTimeout(() => {
+        fallbackTimersRef.current.delete(id)
+        cb(now())
+      }, tickIntervalRef.current) as unknown as number
+      fallbackTimersRef.current.set(id, timer as unknown as ReturnType<typeof setTimeout>)
+      return id
+    },
+    []
+  )
+
+  const emitTick = useCallback((ms: number) => {
+    tickCallbacksRef.current.forEach(cb => {
+      try {
+        cb(ms)
+      } catch (error) {
+        if (typeof process !== 'undefined' && process.env?.NODE_ENV !== 'production') {
+          console.error('useSessionClock tick callback error', error)
+        }
+      }
+    })
+  }, [])
+
+  const finish = useCallback(
+    (status: ClockState, nextElapsed?: number) => {
+      cancelFrame(frameRef.current)
+      frameRef.current = null
+      stateRef.current = status
+      if (mountedRef.current) {
+        setState(status)
+      }
+
+      if (typeof nextElapsed === 'number') {
+        accumulatorRef.current = nextElapsed
+        lastEmitRef.current = nextElapsed
+        if (mountedRef.current) {
+          setElapsedMs(nextElapsed)
+        }
+        emitTick(nextElapsed)
+      }
+    },
+    [cancelFrame, emitTick]
+  )
+
+  const step = useCallback(
+    (timestamp: number) => {
+      if (stateRef.current !== 'running') {
+        return
+      }
+
+      if (lastFrameRef.current == null) {
+        lastFrameRef.current = timestamp
+      }
+
+      const delta = Math.max(0, timestamp - lastFrameRef.current)
+      lastFrameRef.current = timestamp
+      accumulatorRef.current += delta
+
+      const limit = durationRef.current ?? Number.POSITIVE_INFINITY
+      const clampedElapsed = Math.min(accumulatorRef.current, limit)
+
+      if (clampedElapsed - lastEmitRef.current >= tickIntervalRef.current || clampedElapsed >= limit) {
+        lastEmitRef.current = clampedElapsed
+        if (mountedRef.current) {
+          setElapsedMs(clampedElapsed)
+        }
+        emitTick(clampedElapsed)
+      }
+
+      if (durationRef.current != null && accumulatorRef.current >= durationRef.current) {
+        finish('completed', durationRef.current)
+        return
+      }
+
+      frameRef.current = requestFrame(step)
+    },
+    [emitTick, finish, requestFrame]
+  )
+
+  const start = useCallback(() => {
+    if (stateRef.current !== 'idle') {
+      return
+    }
+
+    accumulatorRef.current = 0
+    lastFrameRef.current = now()
+    lastEmitRef.current = 0
+    stateRef.current = 'running'
+    if (mountedRef.current) {
+      setState('running')
+      setElapsedMs(0)
+    }
+    emitTick(0)
+    frameRef.current = requestFrame(step)
+  }, [emitTick, requestFrame, step])
+
+  const pause = useCallback(() => {
+    if (stateRef.current !== 'running') {
+      return
+    }
+
+    cancelFrame(frameRef.current)
+    frameRef.current = null
+    lastFrameRef.current = null
+    stateRef.current = 'paused'
+    if (mountedRef.current) {
+      setState('paused')
+    }
+  }, [cancelFrame])
+
+  const resume = useCallback(() => {
+    if (stateRef.current !== 'paused') {
+      return
+    }
+
+    stateRef.current = 'running'
+    if (mountedRef.current) {
+      setState('running')
+    }
+    lastFrameRef.current = now()
+    frameRef.current = requestFrame(step)
+  }, [requestFrame, step])
+
+  const complete = useCallback(() => {
+    if (stateRef.current === 'completed') {
+      return
+    }
+
+    const limit = durationRef.current ?? accumulatorRef.current
+    const nextElapsed = Math.min(accumulatorRef.current, limit)
+    finish('completed', limit ?? nextElapsed)
+  }, [finish])
+
+  const reset = useCallback(() => {
+    cancelFrame(frameRef.current)
+    frameRef.current = null
+    accumulatorRef.current = 0
+    lastFrameRef.current = null
+    lastEmitRef.current = 0
+    stateRef.current = 'idle'
+    if (mountedRef.current) {
+      setState('idle')
+      setElapsedMs(0)
+    }
+  }, [cancelFrame])
+
+  const onTick = useCallback((cb: TickCallback) => {
+    tickCallbacksRef.current.add(cb)
+    return () => {
+      tickCallbacksRef.current.delete(cb)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (autoStart) {
+      start()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const progress = useMemo(() => {
+    if (!durationRef.current || durationRef.current <= 0) {
+      return undefined
+    }
+    return Math.min(1, elapsedMs / durationRef.current)
+  }, [elapsedMs])
+
+  return {
+    state,
+    elapsedMs,
+    progress,
+    start,
+    pause,
+    resume,
+    complete,
+    reset,
+    onTick
+  }
+}
+

--- a/src/services/sessions/__tests__/moodDelta.test.ts
+++ b/src/services/sessions/__tests__/moodDelta.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeMoodDelta } from '../moodDelta'
+
+describe('computeMoodDelta', () => {
+  it('retourne null quand les snapshots sont incomplets', () => {
+    expect(computeMoodDelta()).toBeNull()
+    expect(computeMoodDelta({ valence: 0.2 }, undefined)).toBeNull()
+  })
+
+  it('calcule un delta borné entre -10 et 10', () => {
+    const delta = computeMoodDelta({ valence: -0.2, arousal: 0 }, { valence: 0.6, arousal: 0.1 })
+    expect(delta).toBe(8)
+  })
+
+  it('applique un amortissement en fonction de la variation d’arousal', () => {
+    const delta = computeMoodDelta({ valence: 0.1, arousal: 0.3 }, { valence: 0.2, arousal: -0.5 })
+    expect(delta).toBeLessThanOrEqual(1)
+  })
+
+  it('clamp le résultat à la plage attendue', () => {
+    const delta = computeMoodDelta({ valence: -1, arousal: -1 }, { valence: 1, arousal: -1 })
+    expect(delta).toBe(10)
+    const negative = computeMoodDelta({ valence: 1, arousal: 1 }, { valence: -1, arousal: 1 })
+    expect(negative).toBe(-10)
+  })
+})
+

--- a/src/services/sessions/__tests__/sessionsApi.test.ts
+++ b/src/services/sessions/__tests__/sessionsApi.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createSession, listMySessions, logAndJournal } from '../sessionsApi'
+import { supabase } from '@/integrations/supabase/client'
+import * as Sentry from '@sentry/react'
+
+type SupabaseMock = typeof supabase & {
+  from: ReturnType<typeof vi.fn>
+  auth: { getUser: ReturnType<typeof vi.fn> }
+}
+
+vi.mock('@sentry/react', () => ({
+  addBreadcrumb: vi.fn(),
+  captureException: vi.fn()
+}))
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: vi.fn(),
+    auth: {
+      getUser: vi.fn()
+    }
+  }
+}))
+
+const mockedSupabase = supabase as SupabaseMock
+
+describe('sessionsApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('insère une session avec les données nettoyées', async () => {
+    const singleMock = vi.fn().mockResolvedValue({
+      data: {
+        id: 'session-1',
+        type: 'breath',
+        duration_sec: 12,
+        mood_delta: null,
+        meta: { foo: 'bar' },
+        created_at: '2024-01-01T00:00:00.000Z'
+      },
+      error: null
+    })
+    const selectMock = vi.fn().mockReturnValue({ single: singleMock })
+    const insertMock = vi.fn().mockReturnValue({ select: selectMock })
+    mockedSupabase.from.mockImplementation((table: string) => {
+      if (table === 'sessions') {
+        return { insert: insertMock }
+      }
+      throw new Error(`unexpected table ${table}`)
+    })
+
+    const result = await createSession({
+      type: 'breath',
+      duration_sec: 12.9,
+      mood_delta: 5.4,
+      meta: { foo: 'bar' }
+    })
+
+    expect(insertMock).toHaveBeenCalledWith({
+      type: 'breath',
+      duration_sec: 12,
+      mood_delta: 5,
+      meta: { foo: 'bar' }
+    })
+    expect(result).toEqual({
+      id: 'session-1',
+      type: 'breath',
+      duration_sec: 12,
+      mood_delta: null,
+      meta: { foo: 'bar' },
+      created_at: '2024-01-01T00:00:00.000Z'
+    })
+  })
+
+  it('liste les sessions paginées', async () => {
+    const rangeMock = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: 'session-2',
+          type: 'flash_glow',
+          duration_sec: 120,
+          mood_delta: 4,
+          meta: { extended: false },
+          created_at: '2024-01-02T00:00:00.000Z'
+        }
+      ],
+      error: null
+    })
+    const eqMock = vi.fn().mockReturnValue({ range: rangeMock })
+    const orderMock = vi.fn().mockReturnValue({ eq: eqMock, range: rangeMock })
+    const selectMock = vi.fn().mockReturnValue({ order: orderMock })
+
+    mockedSupabase.from.mockImplementation((table: string) => {
+      if (table === 'sessions') {
+        return { select: selectMock }
+      }
+      throw new Error(`unexpected table ${table}`)
+    })
+
+    const rows = await listMySessions({ type: 'flash_glow', limit: 2, offset: 1 })
+
+    expect(selectMock).toHaveBeenCalledWith('id, type, duration_sec, mood_delta, meta, created_at')
+    expect(orderMock).toHaveBeenCalledWith('created_at', { ascending: false })
+    expect(eqMock).toHaveBeenCalledWith('type', 'flash_glow')
+    expect(rangeMock).toHaveBeenCalledWith(1, 2)
+    expect(rows).toEqual([
+      {
+        id: 'session-2',
+        type: 'flash_glow',
+        duration_sec: 120,
+        mood_delta: 4,
+        meta: { extended: false },
+        created_at: '2024-01-02T00:00:00.000Z'
+      }
+    ])
+  })
+
+  it('enregistre la session et le journal automatique', async () => {
+    const singleMock = vi.fn().mockResolvedValue({
+      data: {
+        id: 'session-3',
+        type: 'breath',
+        duration_sec: 30,
+        mood_delta: null,
+        meta: {},
+        created_at: '2024-01-03T00:00:00.000Z'
+      },
+      error: null
+    })
+    const selectMock = vi.fn().mockReturnValue({ single: singleMock })
+    const insertSessionMock = vi.fn().mockReturnValue({ select: selectMock })
+    const journalInsertMock = vi.fn().mockResolvedValue({ error: null })
+
+    mockedSupabase.from.mockImplementation((table: string) => {
+      if (table === 'sessions') {
+        return { insert: insertSessionMock }
+      }
+      if (table === 'journal_entries') {
+        return { insert: journalInsertMock }
+      }
+      throw new Error(`unexpected table ${table}`)
+    })
+
+    mockedSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'user-1' } } })
+
+    await logAndJournal({
+      type: 'breath',
+      duration_sec: 30,
+      journalText: 'Respiration calme.',
+      mood_delta: null,
+      meta: { density: 0.5 }
+    })
+
+    expect(insertSessionMock).toHaveBeenCalled()
+    expect(journalInsertMock).toHaveBeenCalledWith(expect.objectContaining({
+      user_id: 'user-1',
+      content: 'Respiration calme.'
+    }))
+  })
+
+  it('capture les erreurs de journalisation sans lever', async () => {
+    const singleMock = vi.fn().mockResolvedValue({ data: { id: 'session-4', type: 'breath', duration_sec: 20, mood_delta: null, meta: {}, created_at: '2024-01-04T00:00:00.000Z' }, error: null })
+    const selectMock = vi.fn().mockReturnValue({ single: singleMock })
+    const insertSessionMock = vi.fn().mockReturnValue({ select: selectMock })
+    const journalInsertMock = vi.fn().mockResolvedValue({ error: new Error('fail') })
+
+    mockedSupabase.from.mockImplementation((table: string) => {
+      if (table === 'sessions') {
+        return { insert: insertSessionMock }
+      }
+      if (table === 'journal_entries') {
+        return { insert: journalInsertMock }
+      }
+      throw new Error(`unexpected table ${table}`)
+    })
+
+    mockedSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'user-2' } } })
+
+    await expect(
+      logAndJournal({ type: 'breath', duration_sec: 20 })
+    ).resolves.toBeDefined()
+
+    expect(Sentry.captureException).toHaveBeenCalled()
+  })
+})
+

--- a/src/services/sessions/moodDelta.ts
+++ b/src/services/sessions/moodDelta.ts
@@ -1,0 +1,36 @@
+export type MoodSnapshot = {
+  valence?: number | null
+  arousal?: number | null
+}
+
+const clampComponent = (value: number | null | undefined) => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return 0
+  }
+  if (!Number.isFinite(value)) {
+    return value > 0 ? 1 : -1
+  }
+  return Math.max(-1, Math.min(1, value))
+}
+
+/**
+ * computeMoodDelta - produit un delta directionnel borné entre -10 et 10
+ * basé sur la variation de valence et la variation absolue d'arousal.
+ */
+export function computeMoodDelta(before?: MoodSnapshot | null, after?: MoodSnapshot | null): number | null {
+  if (!before || !after) {
+    return null
+  }
+
+  const beforeValence = clampComponent(before.valence ?? 0)
+  const afterValence = clampComponent(after.valence ?? 0)
+  const beforeArousal = clampComponent(before.arousal ?? 0)
+  const afterArousal = clampComponent(after.arousal ?? 0)
+
+  const dv = afterValence - beforeValence
+  const da = afterArousal - beforeArousal
+  const aggregate = dv - Math.abs(da) * 0.25
+  const scaled = Math.round(aggregate * 10)
+  return Math.max(-10, Math.min(10, scaled))
+}
+

--- a/src/services/sessions/sessionsApi.ts
+++ b/src/services/sessions/sessionsApi.ts
@@ -1,0 +1,199 @@
+import * as Sentry from '@sentry/react'
+
+import { supabase } from '@/integrations/supabase/client'
+
+export type SessionType = 'flash_glow' | 'breath' | 'music' | 'scan' | 'custom'
+
+export type SessionRecord = {
+  id: string
+  type: SessionType
+  duration_sec: number
+  mood_delta: number | null
+  meta: Record<string, unknown>
+  created_at: string
+}
+
+export type CreateSessionInput = {
+  type: SessionType
+  duration_sec: number
+  mood_delta?: number | null
+  meta?: Record<string, unknown>
+}
+
+export type ListMySessionsParams = {
+  type?: SessionType
+  limit?: number
+  offset?: number
+}
+
+const toLatency = (startedAt: number) => Math.max(0, Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - startedAt))
+
+const sanitizeDuration = (value: number) => {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0
+  }
+  return Math.max(0, Math.floor(value))
+}
+
+const sanitizeMoodDelta = (value: number | null | undefined) => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return null
+  }
+  return Math.max(-10, Math.min(10, Math.round(value)))
+}
+
+export async function createSession(input: CreateSessionInput): Promise<SessionRecord> {
+  const startedAt = typeof performance !== 'undefined' ? performance.now() : Date.now()
+  Sentry.addBreadcrumb({
+    category: 'session',
+    message: 'session:create',
+    level: 'info',
+    data: { type: input.type }
+  })
+
+  const payload = {
+    type: input.type,
+    duration_sec: sanitizeDuration(input.duration_sec),
+    mood_delta: sanitizeMoodDelta(input.mood_delta ?? null),
+    meta: input.meta ?? {}
+  }
+
+  const { data, error } = await supabase
+    .from('sessions')
+    .insert(payload)
+    .select('id, type, duration_sec, mood_delta, meta, created_at')
+    .single()
+
+  if (error || !data) {
+    throw error ?? new Error('session insert failed')
+  }
+
+  const latency = toLatency(startedAt)
+  Sentry.addBreadcrumb({
+    category: 'session',
+    message: 'session:create:complete',
+    level: 'info',
+    data: { type: input.type, latency_ms: latency }
+  })
+
+  const moodDeltaFromDb = (() => {
+    if (Object.prototype.hasOwnProperty.call(data, 'mood_delta')) {
+      return data.mood_delta as number | null | undefined
+    }
+    return undefined
+  })()
+
+  return {
+    id: data.id,
+    type: data.type as SessionType,
+    duration_sec: data.duration_sec ?? payload.duration_sec,
+    mood_delta:
+      typeof moodDeltaFromDb === 'number'
+        ? moodDeltaFromDb
+        : moodDeltaFromDb === null
+          ? null
+          : payload.mood_delta ?? null,
+    meta: (data.meta as Record<string, unknown> | null) ?? payload.meta,
+    created_at: data.created_at ?? new Date().toISOString()
+  }
+}
+
+export async function listMySessions(params: ListMySessionsParams = {}): Promise<SessionRecord[]> {
+  const { type, limit = 20, offset = 0 } = params
+  let query = supabase
+    .from('sessions')
+    .select('id, type, duration_sec, mood_delta, meta, created_at')
+    .order('created_at', { ascending: false })
+
+  if (type) {
+    query = query.eq('type', type)
+  }
+
+  if (Number.isFinite(limit) && Number.isFinite(offset)) {
+    const safeLimit = Math.max(1, Math.min(200, Math.floor(limit)))
+    const safeOffset = Math.max(0, Math.floor(offset))
+    query = query.range(safeOffset, safeOffset + safeLimit - 1)
+  }
+
+  const { data, error } = await query
+
+  if (error) {
+    throw error
+  }
+
+  return (data ?? []).map(row => ({
+    id: row.id as string,
+    type: row.type as SessionType,
+    duration_sec: row.duration_sec ?? 0,
+    mood_delta: row.mood_delta ?? null,
+    meta: (row.meta as Record<string, unknown> | null) ?? {},
+    created_at: row.created_at ?? new Date().toISOString()
+  }))
+}
+
+export type LogAndJournalInput = {
+  type: SessionType
+  duration_sec: number
+  mood_delta?: number | null
+  journalText?: string
+  meta?: Record<string, unknown>
+}
+
+const mkDefaultText = (input: { type: SessionType; mood_delta?: number | null }) => {
+  const label =
+    input.type === 'flash_glow'
+      ? 'Séance FlashGlow terminée.'
+      : input.type === 'breath'
+        ? 'Respiration guidée terminée.'
+        : input.type === 'music'
+          ? 'Voyage sonore clôturé.'
+          : input.type === 'scan'
+            ? 'Exploration sensorielle finalisée.'
+            : 'Séance terminée.'
+  const change = input.mood_delta != null ? "Je me sens un peu différent·e qu'avant." : 'Je prends note de mon ressenti présent.'
+  return `${label} ${change}`
+}
+
+export async function logAndJournal(params: LogAndJournalInput): Promise<SessionRecord> {
+  const session = await createSession({
+    type: params.type,
+    duration_sec: params.duration_sec,
+    mood_delta: params.mood_delta ?? null,
+    meta: params.meta
+  })
+
+  const text = params.journalText?.trim().length ? params.journalText.trim() : mkDefaultText(params)
+
+  try {
+    const startedAt = typeof performance !== 'undefined' ? performance.now() : Date.now()
+    const { data: auth } = await supabase.auth.getUser()
+
+    if (auth?.user?.id) {
+      const { error } = await supabase
+        .from('journal_entries')
+        .insert({
+          user_id: auth.user.id,
+          content: text,
+          date: new Date().toISOString(),
+          ai_feedback: null
+        })
+
+      if (error) {
+        throw error
+      }
+
+      const latency = toLatency(startedAt)
+      Sentry.addBreadcrumb({
+        category: 'journal',
+        message: 'journal:auto:insert',
+        level: 'info',
+        data: { type: params.type, latency_ms: latency }
+      })
+    }
+  } catch (error) {
+    Sentry.captureException(error)
+  }
+
+  return session
+}
+


### PR DESCRIPTION
## Summary
- wire Flash Glow Ultra to the shared `useSessionClock`, Sentry breadcrumbs, automatic journaling, and aria-live status feedback
- expose reusable session services (`createSession`, `logAndJournal`) and mood delta helper plus focused unit tests
- update Breath Constellation status tests with forwardRef-safe mocks and adjust session persistence to respect nullable `mood_delta`
- document the new session engine coverage across Flash Glow and Breath modules

## Testing
- `npx vitest run src/modules/flash-glow/__tests__/flashGlowUltraSession.test.tsx src/modules/breath-constellation/__tests__/BreathConstellationStatus.test.tsx src/modules/sessions/hooks/__tests__/useSessionClock.test.tsx src/services/sessions/__tests__/sessionsApi.test.ts src/services/sessions/__tests__/moodDelta.test.ts`
- `npm run e2e` *(fails: Playwright not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd64f525c0832db9f06af8c902a63a