### PR TITLE
Add clinical consent prompts per module

### DIFF
--- a/src/components/consent/ClinicalOptIn.tsx
+++ b/src/components/consent/ClinicalOptIn.tsx
@@ -1,0 +1,79 @@
+import { useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+interface ClinicalOptInProps {
+  title: string;
+  description: string;
+  acceptLabel?: string;
+  declineLabel?: string;
+  privacyLabel?: string;
+  privacyHref?: string;
+  onAccept: () => Promise<void> | void;
+  onDecline: () => Promise<void> | void;
+  isProcessing?: boolean;
+  error?: string | null;
+  className?: string;
+}
+
+export const ClinicalOptIn: React.FC<ClinicalOptInProps> = ({
+  title,
+  description,
+  acceptLabel = 'Oui, activer',
+  declineLabel = 'Plus tard',
+  privacyLabel = 'Politique de confidentialité',
+  privacyHref = '/legal/privacy',
+  onAccept,
+  onDecline,
+  isProcessing = false,
+  error,
+  className
+}) => {
+  const handleAccept = useCallback(async () => {
+    await onAccept();
+  }, [onAccept]);
+
+  const handleDecline = useCallback(async () => {
+    await onDecline();
+  }, [onDecline]);
+
+  return (
+    <Card className={cn('border-dashed border-primary/30 bg-primary/5', className)}>
+      <CardContent className="flex flex-col gap-4 p-6">
+        <div>
+          <h3 className="text-lg font-semibold text-foreground">
+            {title}
+          </h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {description}
+          </p>
+        </div>
+
+        {error && (
+          <p className="text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        )}
+
+        <div className="flex flex-wrap items-center gap-3">
+          <Button onClick={handleAccept} disabled={isProcessing}>
+            {acceptLabel}
+          </Button>
+          <Button onClick={handleDecline} variant="ghost" disabled={isProcessing}>
+            {declineLabel}
+          </Button>
+          <Link
+            to={privacyHref}
+            className="text-sm underline text-muted-foreground hover:text-foreground"
+          >
+            {privacyLabel}
+          </Link>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ClinicalOptIn;

--- a/src/hooks/useClinicalConsent.ts
+++ b/src/hooks/useClinicalConsent.ts
@@ -1,0 +1,221 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+
+type ClinicalConsentDecision = 'granted' | 'declined';
+
+export type ClinicalInstrumentCode =
+  | 'WHO5'
+  | 'STAI6'
+  | 'PANAS'
+  | 'SUDS'
+  | 'SAM';
+
+interface ClinicalConsentState {
+  decision: ClinicalConsentDecision | null;
+  loading: boolean;
+  isSaving: boolean;
+  shouldPrompt: boolean;
+  hasConsented: boolean;
+  error: string | null;
+  isDNTEnabled: boolean;
+  grantConsent: () => Promise<void>;
+  declineConsent: () => Promise<void>;
+}
+
+const detectDoNotTrack = (): boolean => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  const navigatorDnt =
+    (window.navigator as Navigator & { doNotTrack?: string; msDoNotTrack?: string }).doNotTrack ??
+    (window as Window & { doNotTrack?: string }).doNotTrack ??
+    (window.navigator as Navigator & { msDoNotTrack?: string }).msDoNotTrack;
+
+  return navigatorDnt === '1' || navigatorDnt === 'yes';
+};
+
+export const useClinicalConsent = (instrument: ClinicalInstrumentCode): ClinicalConsentState => {
+  const [decision, setDecision] = useState<ClinicalConsentDecision | null>(null);
+  const [consentId, setConsentId] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [isSaving, setIsSaving] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isDNTEnabled = useMemo(() => detectDoNotTrack(), []);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchConsent = async () => {
+      if (!instrument) {
+        setLoading(false);
+        return;
+      }
+
+      if (isDNTEnabled) {
+        if (isMounted) {
+          setDecision('declined');
+          setLoading(false);
+        }
+        return;
+      }
+
+      try {
+        const {
+          data: { user }
+        } = await supabase.auth.getUser();
+
+        if (!user) {
+          if (isMounted) {
+            setDecision(null);
+            setConsentId(null);
+            setLoading(false);
+          }
+          return;
+        }
+
+        const { data, error: fetchError } = await supabase
+          .from('clinical_consents')
+          .select('id, is_active, revoked_at')
+          .eq('user_id', user.id)
+          .eq('instrument_code', instrument)
+          .order('granted_at', { ascending: false })
+          .limit(1)
+          .maybeSingle();
+
+        if (!isMounted) {
+          return;
+        }
+
+        if (fetchError && fetchError.code !== 'PGRST116') {
+          console.error('useClinicalConsent fetch error:', fetchError);
+          setError("Une erreur est survenue lors de la vérification du consentement.");
+        } else {
+          setError(null);
+        }
+
+        if (data) {
+          setConsentId(data.id);
+
+          if (data.is_active === true) {
+            setDecision('granted');
+          } else if (data.is_active === false || data.revoked_at) {
+            setDecision('declined');
+          } else {
+            setDecision(null);
+          }
+        } else {
+          setConsentId(null);
+          setDecision(null);
+        }
+      } catch (err) {
+        console.error('useClinicalConsent error:', err);
+        if (isMounted) {
+          setError("Impossible de récupérer votre consentement pour le moment.");
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchConsent();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [instrument, isDNTEnabled]);
+
+  const updateConsent = useCallback(
+    async (granted: boolean) => {
+      if (!instrument || isDNTEnabled) {
+        return;
+      }
+
+      setIsSaving(true);
+      setError(null);
+
+      try {
+        const {
+          data: { user }
+        } = await supabase.auth.getUser();
+
+        if (!user) {
+          setError('Vous devez être connecté pour enregistrer votre choix.');
+          setIsSaving(false);
+          return;
+        }
+
+        const timestamp = new Date().toISOString();
+
+        if (consentId) {
+          const { error: updateError } = await supabase
+            .from('clinical_consents')
+            .update({
+              is_active: granted,
+              granted_at: granted ? timestamp : null,
+              revoked_at: granted ? null : timestamp
+            })
+            .eq('id', consentId);
+
+          if (updateError) {
+            throw updateError;
+          }
+        } else {
+          const insertPayload = {
+            user_id: user.id,
+            instrument_code: instrument,
+            is_active: granted,
+            granted_at: granted ? timestamp : null,
+            revoked_at: granted ? null : timestamp
+          };
+
+          const { data, error: insertError } = await supabase
+            .from('clinical_consents')
+            .insert(insertPayload)
+            .select('id')
+            .single();
+
+          if (insertError) {
+            throw insertError;
+          }
+
+          setConsentId(data?.id ?? null);
+        }
+
+        setDecision(granted ? 'granted' : 'declined');
+        setLoading(false);
+      } catch (err) {
+        console.error('useClinicalConsent update error:', err);
+        setError("Impossible d'enregistrer votre décision pour le moment.");
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [consentId, instrument, isDNTEnabled]
+  );
+
+  const grantConsent = useCallback(async () => {
+    await updateConsent(true);
+  }, [updateConsent]);
+
+  const declineConsent = useCallback(async () => {
+    await updateConsent(false);
+  }, [updateConsent]);
+
+  return {
+    decision,
+    loading,
+    isSaving,
+    shouldPrompt: !loading && decision === null && !isDNTEnabled,
+    hasConsented: decision === 'granted',
+    error,
+    isDNTEnabled,
+    grantConsent,
+    declineConsent
+  };
+};
+
+export default useClinicalConsent;

--- a/src/pages/B2CDashboardPage.tsx
+++ b/src/pages/B2CDashboardPage.tsx
@@ -6,11 +6,12 @@ import { Progress } from '@/components/ui/progress';
 import { Badge } from '@/components/ui/badge';
 import RecentEmotionScansWidget from '@/components/dashboard/widgets/RecentEmotionScansWidget';
 import JournalSummaryCard from '@/components/dashboard/widgets/JournalSummaryCard';
-import { 
-  Brain, 
-  Music, 
-  BookOpen, 
-  Headphones, 
+import { ClinicalOptIn } from '@/components/consent/ClinicalOptIn';
+import {
+  Brain,
+  Music,
+  BookOpen,
+  Headphones,
   Target, 
   TrendingUp, 
   Calendar,
@@ -20,9 +21,11 @@ import {
 } from 'lucide-react';
 import { useAccessibilityAudit } from '@/lib/accessibility-checker';
 import { useEffect } from 'react';
+import { useClinicalConsent } from '@/hooks/useClinicalConsent';
 
 export default function B2CDashboardPage() {
   const { runAudit } = useAccessibilityAudit();
+  const who5Consent = useClinicalConsent('WHO5');
 
   useEffect(() => {
     // Audit d'accessibilité en développement
@@ -98,6 +101,19 @@ export default function B2CDashboardPage() {
             Découvrez vos outils d'intelligence émotionnelle personnalisés
           </p>
         </header>
+
+        {who5Consent.shouldPrompt && (
+          <div className="mb-8">
+            <ClinicalOptIn
+              title="Activer le suivi bien-être WHO-5"
+              description="Ce mini questionnaire nous aide à ajuster votre tableau de bord. Votre choix est mémorisé et peut être modifié dans les réglages."
+              onAccept={who5Consent.grantConsent}
+              onDecline={who5Consent.declineConsent}
+              isProcessing={who5Consent.isSaving}
+              error={who5Consent.error}
+            />
+          </div>
+        )}
 
         {/* Statistiques rapides */}
         <section aria-labelledby="stats-title" className="mb-8">

--- a/src/pages/B2CNyveeCoconPage.tsx
+++ b/src/pages/B2CNyveeCoconPage.tsx
@@ -9,12 +9,15 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Star, Heart, Wind, Eye } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
+import { ClinicalOptIn } from '@/components/consent/ClinicalOptIn';
+import { useClinicalConsent } from '@/hooks/useClinicalConsent';
 
 const NyveeCocon: React.FC = () => {
   const navigate = useNavigate();
   const [sessionState, setSessionState] = useState<'intro' | 'breathing' | 'silence' | 'anchor' | 'complete'>('intro');
   const [timeRemaining, setTimeRemaining] = useState(360); // 6 minutes
   const [breathingPhase, setBreathingPhase] = useState<'inhale' | 'hold' | 'exhale'>('inhale');
+  const stai6Consent = useClinicalConsent('STAI6');
 
   // Protocole d'ancrage 5-4-3-2-1 pour l'agitation
   const anchorSteps = [
@@ -124,7 +127,20 @@ const NyveeCocon: React.FC = () => {
         ))}
       </div>
 
-      <div className="relative z-10 max-w-2xl mx-auto">
+      <div className="relative z-10 max-w-2xl mx-auto space-y-6">
+        {stai6Consent.shouldPrompt && (
+          <ClinicalOptIn
+            title="Activer l'évaluation STAI-6"
+            description="Ces quelques questions nous aident à déclencher le cocon quand l'anxiété monte. Votre choix est mémorisé et peut être changé plus tard."
+            acceptLabel="Oui, personnaliser"
+            declineLabel="Non merci"
+            onAccept={stai6Consent.grantConsent}
+            onDecline={stai6Consent.declineConsent}
+            isProcessing={stai6Consent.isSaving}
+            error={stai6Consent.error}
+            className="bg-white/10 border-white/20 backdrop-blur-md"
+          />
+        )}
         <AnimatePresence mode="wait">
           {sessionState === 'intro' && (
             <motion.div

--- a/src/pages/B2CScanPage.tsx
+++ b/src/pages/B2CScanPage.tsx
@@ -3,8 +3,8 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
-import { 
-  Brain, History, Download, Settings, TrendingUp, 
+import {
+  Brain, History, Download, Settings, TrendingUp,
   Activity, Heart, Sparkles, Music
 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
@@ -13,12 +13,15 @@ import EmotionScannerPremium from '@/components/emotion/EmotionScannerPremium';
 import EmotionsCareMusicPlayer from '@/components/music/emotionscare/EmotionsCareMusicPlayer';
 import { useMusic } from '@/contexts/MusicContext';
 import type { EmotionResult } from '@/types/emotion';
+import { ClinicalOptIn } from '@/components/consent/ClinicalOptIn';
+import { useClinicalConsent } from '@/hooks/useClinicalConsent';
 
 const B2CScanPage: React.FC = () => {
   const [scanHistory, setScanHistory] = useState<EmotionResult[]>([]);
   const [showMusicPlayer, setShowMusicPlayer] = useState(false);
   const { state: musicState, generateEmotionPlaylist } = useMusic();
   const { toast } = useToast();
+  const samConsent = useClinicalConsent('SAM');
 
   const handleEmotionDetected = async (result: EmotionResult) => {
     setScanHistory(prev => [result, ...prev.slice(0, 9)]);
@@ -65,7 +68,7 @@ const B2CScanPage: React.FC = () => {
                   Analysez vos émotions en temps réel avec l'intelligence artificielle avancée
                 </p>
               </div>
-              
+
               <div className="flex items-center gap-2">
                 <Button variant="outline" size="sm" disabled={scanHistory.length === 0}>
                   <Download className="w-4 h-4 mr-2" />
@@ -77,6 +80,19 @@ const B2CScanPage: React.FC = () => {
               </div>
             </div>
           </div>
+
+          {samConsent.shouldPrompt && (
+            <ClinicalOptIn
+              title="Activer l'évaluation SAM"
+              description="Le suivi de votre intensité émotionnelle améliore les recommandations du scanner. Votre décision est mémorisée."
+              acceptLabel="Oui, activer"
+              declineLabel="Non merci"
+              onAccept={samConsent.grantConsent}
+              onDecline={samConsent.declineConsent}
+              isProcessing={samConsent.isSaving}
+              error={samConsent.error}
+            />
+          )}
 
           {/* Enhanced Stats */}
           {scanHistory.length > 0 && (

--- a/src/pages/modules/FlashGlowPage.tsx
+++ b/src/pages/modules/FlashGlowPage.tsx
@@ -2,9 +2,9 @@ import React, { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
-import { 
-  Play, 
-  Pause, 
+import {
+  Play,
+  Pause,
   ArrowLeft,
   Zap,
   Timer
@@ -15,6 +15,8 @@ import { UniverseEngine } from '@/components/universe/UniverseEngine';
 import { RewardSystem } from '@/components/rewards/RewardSystem';
 import { getOptimizedUniverse } from '@/data/universes/config';
 import { useOptimizedAnimation } from '@/hooks/useOptimizedAnimation';
+import { ClinicalOptIn } from '@/components/consent/ClinicalOptIn';
+import { useClinicalConsent } from '@/hooks/useClinicalConsent';
 
 interface FlashGlowSession {
   id: string;
@@ -50,20 +52,21 @@ const flashSessions: FlashGlowSession[] = [
 
 const FlashGlowPage: React.FC = () => {
   const { toast } = useToast();
-  
+
   // Get optimized universe config
   const universe = getOptimizedUniverse('flashGlow');
-  
+
   // Universe state
   const [isEntering, setIsEntering] = useState(true);
   const [universeEntered, setUniverseEntered] = useState(false);
-  
+
   // Session state
   const [selectedSession, setSelectedSession] = useState<FlashGlowSession | null>(null);
   const [isActive, setIsActive] = useState(false);
   const [timeRemaining, setTimeRemaining] = useState(0);
   const [showReward, setShowReward] = useState(false);
   const [glowIntensity, setGlowIntensity] = useState(0);
+  const sudsConsent = useClinicalConsent('SUDS');
   
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const glowIntervalRef = useRef<NodeJS.Timeout | null>(null);
@@ -223,6 +226,21 @@ const FlashGlowPage: React.FC = () => {
 
       {/* Main Content */}
       <main className="relative z-10 container mx-auto px-6 py-12">
+        {sudsConsent.shouldPrompt && (
+          <div className="mb-10">
+            <ClinicalOptIn
+              title="Activer l'évaluation SUDS"
+              description="Ce score de stress nous aide à ajuster l'intensité des sessions FlashGlow. Votre décision est mémorisée et peut être changée ultérieurement."
+              acceptLabel="Oui, personnaliser"
+              declineLabel="Pas maintenant"
+              onAccept={sudsConsent.grantConsent}
+              onDecline={sudsConsent.declineConsent}
+              isProcessing={sudsConsent.isSaving}
+              error={sudsConsent.error}
+              className="bg-white/10 border-white/25 backdrop-blur-md"
+            />
+          </div>
+        )}
         <AnimatePresence mode="wait">
           {!selectedSession ? (
             <motion.div

--- a/src/pages/modules/JournalPage.tsx
+++ b/src/pages/modules/JournalPage.tsx
@@ -3,7 +3,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Textarea } from '@/components/ui/textarea';
-import { 
+import {
   ArrowLeft,
   Flower,
   PenTool,
@@ -16,6 +16,8 @@ import { UniverseEngine } from '@/components/universe/UniverseEngine';
 import { RewardSystem } from '@/components/rewards/RewardSystem';
 import { getOptimizedUniverse } from '@/data/universes/config';
 import { useOptimizedAnimation } from '@/hooks/useOptimizedAnimation';
+import { ClinicalOptIn } from '@/components/consent/ClinicalOptIn';
+import { useClinicalConsent } from '@/hooks/useClinicalConsent';
 
 interface JournalEntry {
   id: string;
@@ -34,20 +36,21 @@ const flowerColors = [
 
 const JournalPage: React.FC = () => {
   const { toast } = useToast();
-  
+
   // Get optimized universe config
   const universe = getOptimizedUniverse('journal');
-  
+
   // Universe state
   const [isEntering, setIsEntering] = useState(true);
   const [universeEntered, setUniverseEntered] = useState(false);
-  
+
   // Journal state
   const [currentText, setCurrentText] = useState('');
   const [isWriting, setIsWriting] = useState(false);
   const [showReward, setShowReward] = useState(false);
   const [savedEntry, setSavedEntry] = useState<JournalEntry | null>(null);
   const [flowerGrowth, setFlowerGrowth] = useState(0);
+  const panasConsent = useClinicalConsent('PANAS');
 
   // Optimized animations
   const { entranceVariants, cleanupAnimation } = useOptimizedAnimation({
@@ -168,7 +171,20 @@ const JournalPage: React.FC = () => {
       </header>
 
       {/* Main Content */}
-      <main className="relative z-10 container mx-auto px-6 py-12">
+      <main className="relative z-10 container mx-auto px-6 py-12 space-y-12">
+        {panasConsent.shouldPrompt && (
+          <ClinicalOptIn
+            title="Activer l'humeur PANAS"
+            description="Quelques mots sur vos émotions nous aident à nourrir le journal. Votre choix est mémorisé et reste modifiable dans les paramètres."
+            acceptLabel="Oui, me guider"
+            declineLabel="Non merci"
+            onAccept={panasConsent.grantConsent}
+            onDecline={panasConsent.declineConsent}
+            isProcessing={panasConsent.isSaving}
+            error={panasConsent.error}
+            className="bg-white/10 border-white/20 backdrop-blur-md"
+          />
+        )}
         <AnimatePresence mode="wait">
           {!isWriting ? (
             <motion.div


### PR DESCRIPTION
## Summary
- add a reusable `useClinicalConsent` hook that stores instrument consent via Supabase and skips prompts when DNT is enabled
- create a minimal `ClinicalOptIn` component for soft consent requests with privacy link
- wire the consent prompt into Dashboard (WHO5), Nyvée (STAI6), FlashGlow (SUDS), Journal (PANAS) and Scan (SAM)

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68ce656c6124832da870a6b0602fd2f8