### PR TITLE
feat(edge): harden /assess-start response

### DIFF
--- a/supabase/functions/assess-start/index.ts
+++ b/supabase/functions/assess-start/index.ts
@@ -59,12 +59,38 @@ serve(async (req) => {
     }
 
     const { instrument, locale } = parsed.data;
-    const catalog = getCatalog(instrument, locale ?? 'fr');
+    const resolvedLocale = locale ?? 'fr';
+
+    let catalog: ReturnType<typeof getCatalog>;
+    try {
+      catalog = getCatalog(instrument, resolvedLocale);
+    } catch (_error) {
+      return appendCorsHeaders(
+        json(422, { error: 'invalid_body', details: 'catalog_unavailable' }),
+        cors,
+      );
+    }
+
+    const payload = {
+      instrument,
+      locale: resolvedLocale,
+      name: catalog.name,
+      version: catalog.version,
+      expiry_minutes: catalog.expiry_minutes,
+      items: catalog.items.map((item) => ({
+        id: item.id,
+        prompt: item.prompt,
+        type: item.type,
+        options: item.options,
+        min: item.min,
+        max: item.max,
+      })),
+    };
 
     addSentryBreadcrumb({
       category: 'assess:start',
       message: 'catalog served',
-      data: { instrument },
+      data: { instrument, locale: resolvedLocale },
     });
 
     await logAccess({
@@ -74,10 +100,13 @@ serve(async (req) => {
       action: 'assess:start',
       result: 'success',
       user_agent: 'redacted',
-      details: `instrument=${instrument}`,
+      details: `instrument=${instrument} locale=${resolvedLocale}`,
     });
 
-    const response = json(200, catalog);
+    const response = json(200, payload);
+    response.headers.set('RateLimit-Limit', String(rateDecision.limit));
+    response.headers.set('RateLimit-Remaining', String(rateDecision.remaining));
+    response.headers.set('RateLimit-Reset', String(rateDecision.resetAt));
     return appendCorsHeaders(response, cors);
   } catch (error) {
     captureSentryException(error, { route: 'assess-start' });


### PR DESCRIPTION
## Summary
- return a sanitized localized assessment catalog payload that includes instrument metadata
- add rate limit headers and richer Sentry/log breadcrumbs when serving the catalog

## Testing
- npx vitest run --environment edge-runtime supabase/tests/assess-functions.test.ts -t "returns catalog for valid request"

------
https://chatgpt.com/codex/tasks/task_e_68ce657add24832da681d326da5824b9