### PR TITLE
feat(edge): secure assess submit storage

### DIFF
--- a/supabase/functions/_shared/assess.ts
+++ b/supabase/functions/_shared/assess.ts
@@ -392,32 +392,32 @@ function determineLevel(instrument: InstrumentCode, total: number, itemCount: nu
 function generateSummary(instrument: InstrumentCode, level: number): string {
   const summaries: Record<InstrumentCode, Record<number, string>> = {
     'WHO5': {
-      0: 'besoin de douceur',
-      1: 'moment plus délicat',
-      2: 'équilibre stable',
-      3: 'bonne forme',
-      4: 'très belle énergie'
+      0: 'bien-être fragile',
+      1: 'affect délicat',
+      2: 'affect équilibré',
+      3: 'bien-être solide',
+      4: 'affect lumineux'
     },
     'STAI6': {
-      0: 'grande sérénité',
-      1: 'calme ressenti',
-      2: 'état équilibré',
-      3: 'tension présente',
-      4: 'besoin d\'apaisement'
+      0: 'tension apaisée',
+      1: 'tension douce',
+      2: 'tension modérée',
+      3: 'tension élevée',
+      4: 'tension intense'
     },
     'SUDS': {
-      0: 'grande tranquillité',
-      1: 'sérénité',
-      2: 'état neutre',
-      3: 'tension élevée',
-      4: 'détresse importante'
+      0: 'tension très basse',
+      1: 'tension apaisée',
+      2: 'tension équilibrée',
+      3: 'tension forte',
+      4: 'tension critique'
     },
     'SAM': {
-      0: 'humeur difficile',
-      1: 'tonalité plus basse',
-      2: 'état mixte',
-      3: 'bonne humeur',
-      4: 'excellente forme'
+      0: 'affect à soutenir',
+      1: 'affect en hausse',
+      2: 'affect neutre',
+      3: 'affect positif',
+      4: 'affect rayonnant'
     }
   };
 
@@ -426,9 +426,24 @@ function generateSummary(instrument: InstrumentCode, level: number): string {
 
 export function sanitizeAggregateText(text: string): string {
   // Remove any numerical data that might leak individual scores
-  return text
+  const cleaned = text
     .replace(/\d+(\.\d+)?%?/g, '') // Remove all numbers
     .replace(/score|niveau|points?/gi, '') // Remove scoring terms
     .replace(/\s+/g, ' ') // Normalize whitespace
     .trim();
+
+  if (!cleaned) {
+    return '';
+  }
+
+  return cleaned.startsWith('•') ? cleaned : `• ${cleaned}`;
+}
+
+export function sanitizeSummaryText(text: string): string {
+  const cleaned = text
+    .replace(/\d+(?:[.,]\d+)?%?/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  return cleaned.length > 0 ? cleaned : 'résumé disponible';
 }

--- a/supabase/functions/assess-start/index.ts
+++ b/supabase/functions/assess-start/index.ts
@@ -77,7 +77,7 @@ serve(async (req) => {
       details: `instrument=${instrument}`,
     });
 
-    const response = json(200, catalog);
+    const response = json(200, { ...catalog, instrument: catalog.code });
     return appendCorsHeaders(response, cors);
   } catch (error) {
     captureSentryException(error, { route: 'assess-start' });

--- a/supabase/tests/assess-functions.test.ts
+++ b/supabase/tests/assess-functions.test.ts
@@ -252,6 +252,7 @@ describe('assess-submit function', () => {
     expect(response.status).toBe(200);
     expect(insertMock).toHaveBeenCalledTimes(1);
     const payload = insertMock.mock.calls[0][0];
+    expect(payload.user_id).toBe('user-123');
     expect(payload.instrument).toBe('WHO5');
     expect(payload.score_json.summary).toMatch(/bien-être|affect|tension/);
     expect(payload.score_json.summary).not.toMatch(/\d/);
@@ -260,6 +261,12 @@ describe('assess-submit function', () => {
       route: 'assess-submit',
       action: 'assess:submit',
       result: 'success',
+    }));
+    expect(addSentryBreadcrumbMock).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'storing sanitized summary',
+    }));
+    expect(addSentryBreadcrumbMock).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'assessment stored',
     }));
   });
 


### PR DESCRIPTION
## Summary
- ensure assessment submissions include the authenticated owner id and sanitized text-only summaries
- add additional Sentry breadcrumbs and reusable summary sanitisation helpers for assessment flows
- align assessment catalog response shape and bullet formatting with updated contract tests

## Testing
- npx vitest --environment edge-runtime supabase/tests/assess-functions.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ce65a2e978832d8322bdd76b50b104