### PR TITLE
feat(edge): enforce aggregate anonymity threshold

### DIFF
--- a/supabase/functions/_shared/assess.ts
+++ b/supabase/functions/_shared/assess.ts
@@ -427,7 +427,8 @@ function generateSummary(instrument: InstrumentCode, level: number): string {
 export function sanitizeAggregateText(text: string): string {
   // Remove any numerical data that might leak individual scores
   const cleaned = text
-    .replace(/\d+(\.\d+)?%?/g, '') // Remove all numbers
+    .replace(/\d+(?:[.,]\d+)?\s*%?/g, '') // Remove all numbers (dot/comma decimals + optional %)
+    .replace(/%/g, '') // Remove any stray percentage symbols
     .replace(/score|niveau|points?/gi, '') // Remove scoring terms
     .replace(/\s+/g, ' ') // Normalize whitespace
     .trim();

--- a/supabase/functions/assess-aggregate/index.ts
+++ b/supabase/functions/assess-aggregate/index.ts
@@ -75,7 +75,8 @@ serve(async (req) => {
       .from('org_assess_rollups')
       .select('instrument, period, n, text_summary')
       .eq('org_id', orgId)
-      .eq('period', period);
+      .eq('period', period)
+      .gte('n', 5);
 
     if (instruments && instruments.length > 0) {
       query = query.in('instrument', instruments);

--- a/supabase/tests/assess-functions.test.ts
+++ b/supabase/tests/assess-functions.test.ts
@@ -335,20 +335,23 @@ describe('assess-aggregate function', () => {
     const selectMock = vi.fn();
     const eqMock = vi.fn();
     const inMock = vi.fn();
+    const gteMock = vi.fn();
     const result = { data: [
-      { instrument: 'WHO5', period: '2024-Q1', n: 7, text_summary: 'Équipe sereine et 12 initiatives positives.' },
+      { instrument: 'WHO5', period: '2024-Q1', n: 7, text_summary: 'Équipe sereine et 12,5 % initiatives positives.' },
       { instrument: 'STAI6', period: '2024-Q1', n: 3, text_summary: 'Sensibilité ponctuelle.' },
     ], error: null };
     const builder: any = {
       select: selectMock,
       eq: eqMock,
       in: inMock,
+      gte: gteMock,
       then: (onFulfilled: (value: unknown) => unknown, onRejected?: (reason: unknown) => unknown) =>
         Promise.resolve(result).then(onFulfilled, onRejected),
     };
     selectMock.mockReturnValue(builder);
     eqMock.mockReturnValue(builder);
     inMock.mockReturnValue(builder);
+    gteMock.mockReturnValue(builder);
     const fromMock = vi.fn(() => builder);
     supabaseClientMock.mockReturnValue({ from: fromMock });
 
@@ -368,8 +371,10 @@ describe('assess-aggregate function', () => {
     expect(payload.summaries).toHaveLength(1);
     expect(payload.summaries[0].instrument).toBe('WHO5');
     expect(payload.summaries[0].text).not.toMatch(/\d/);
+    expect(payload.summaries[0].text).not.toContain('%');
     expect(payload.summaries[0].text).toContain('•');
     expect(inMock).not.toHaveBeenCalled();
+    expect(gteMock).toHaveBeenCalledWith('n', 5);
     expect(addSentryBreadcrumbMock).toHaveBeenCalledWith(expect.objectContaining({
       category: 'assess:aggregate',
     }));
@@ -388,12 +393,14 @@ describe('assess-aggregate function', () => {
       select: vi.fn(),
       eq: vi.fn(),
       in: vi.fn(),
+      gte: vi.fn(),
       then: (onFulfilled: (value: unknown) => unknown, onRejected?: (reason: unknown) => unknown) =>
         Promise.resolve({ data: null, error }).then(onFulfilled, onRejected),
     };
     builder.select.mockReturnValue(builder);
     builder.eq.mockReturnValue(builder);
     builder.in.mockReturnValue(builder);
+    builder.gte.mockReturnValue(builder);
     const fromMock = vi.fn(() => builder);
     supabaseClientMock.mockReturnValue({ from: fromMock });
 


### PR DESCRIPTION
## Summary
- filter `org_assess_rollups` directly at the edge layer with a `n >= 5` guard before returning data
- harden aggregate text scrubbing to drop commas, decimals and stray percent symbols from summaries
- expand assess aggregate contract tests to assert new sanitisation and Supabase query expectations

## Testing
- npx vitest run supabase/tests/assess-functions.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ce65b36108832dadd5c104b433749f