### PR TITLE
feat: emit orchestration signals from assessment submit

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1431,7 +1431,6 @@ export type Database = {
           module_context: string
           source_instrument: string
           user_id: string
-          window_type: string
         }
         Insert: {
           created_at?: string | null
@@ -1443,7 +1442,6 @@ export type Database = {
           module_context: string
           source_instrument: string
           user_id: string
-          window_type: string
         }
         Update: {
           created_at?: string | null
@@ -1455,7 +1453,6 @@ export type Database = {
           module_context?: string
           source_instrument?: string
           user_id?: string
-          window_type?: string
         }
         Relationships: [
           {

--- a/src/services/clinicalOrchestration.ts
+++ b/src/services/clinicalOrchestration.ts
@@ -23,7 +23,6 @@ export interface ClinicalSignal {
   source_instrument: string;
   domain: string;
   level: number; // 0-4 severity
-  window_type: string;
   module_context: string;
   metadata: any;
   expires_at: string;

--- a/supabase/functions/assess-submit/index.ts
+++ b/supabase/functions/assess-submit/index.ts
@@ -3,7 +3,7 @@ import { z } from '../_shared/zod.ts';
 import { createClient } from '../_shared/supabase.ts';
 
 import { authenticateRequest, logUnauthorizedAccess } from '../_shared/auth-middleware.ts';
-import { getCatalog, instrumentSchema, summarizeAssessment } from '../_shared/assess.ts';
+import { getCatalog, instrumentSchema, InstrumentCode, summarizeAssessment } from '../_shared/assess.ts';
 import { appendCorsHeaders, preflightResponse, rejectCors, resolveCors } from '../_shared/cors.ts';
 import { json } from '../_shared/http.ts';
 import { hash } from '../_shared/hash_user.ts';
@@ -24,6 +24,93 @@ const submitSchema = z.object({
 
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL') ?? '';
 const SUPABASE_ANON_KEY = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
+const SIGNAL_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+const SIGNAL_MODULE_CONTEXT = 'assessment_submit';
+
+type OrchestrationHint = {
+  action: string;
+  intensity: 'low' | 'medium' | 'high';
+  context: string;
+  duration_ms?: number;
+};
+
+const instrumentDomains: Record<InstrumentCode, string> = {
+  WHO5: 'wellbeing',
+  STAI6: 'anxiety',
+  PANAS: 'affect',
+  PSS10: 'stress',
+  UCLA3: 'social',
+  MSPSS: 'social',
+  AAQ2: 'flexibility',
+  POMS: 'mood',
+  SSQ: 'vr_safety',
+  ISI: 'sleep',
+  GAS: 'goals',
+  GRITS: 'persistence',
+  BRS: 'resilience',
+  WEMWBS: 'wellbeing',
+  UWES: 'engagement',
+  CBI: 'burnout',
+  CVSQ: 'vision',
+  SAM: 'valence_arousal',
+  SUDS: 'distress',
+};
+
+function getInstrumentDomain(instrument: InstrumentCode): string {
+  return instrumentDomains[instrument] ?? 'general';
+}
+
+function buildOrchestrationHints(
+  instrument: InstrumentCode,
+  level: number,
+  scores: Record<string, number>,
+): OrchestrationHint[] {
+  const hints: OrchestrationHint[] = [];
+
+  switch (instrument) {
+    case 'WHO5':
+      if (level <= 1) {
+        hints.push(
+          { action: 'gentle_tone', intensity: 'high', context: 'dashboard_cards' },
+          { action: 'increase_support', intensity: 'medium', context: 'ui_adaptation' },
+        );
+      } else if (level >= 3) {
+        hints.push({ action: 'encourage_movement', intensity: 'low', context: 'activity_suggestions' });
+      }
+      break;
+
+    case 'STAI6':
+      if (level >= 3) {
+        hints.push(
+          { action: 'suggest_breathing', intensity: 'high', context: 'nyvee_module' },
+          { action: 'reduce_intensity', intensity: 'medium', context: 'visual_effects' },
+        );
+      }
+      break;
+
+    case 'PANAS': {
+      const positiveAffect = scores['PA'];
+      const negativeAffect = scores['NA'];
+      if (typeof positiveAffect === 'number' && positiveAffect < 40) {
+        hints.push({ action: 'offer_social', intensity: 'medium', context: 'community_nudge' });
+      }
+      if (typeof negativeAffect === 'number' && negativeAffect > 60) {
+        hints.push({ action: 'gentle_tone', intensity: 'high', context: 'journal_suggestions' });
+      }
+      break;
+    }
+
+    case 'SUDS':
+      if (level >= 3) {
+        hints.push({ action: 'extend_session', intensity: 'medium', context: 'flash_glow', duration_ms: 60_000 });
+      } else if (level <= 1) {
+        hints.push({ action: 'soft_exit', intensity: 'low', context: 'session_completion' });
+      }
+      break;
+  }
+
+  return hints;
+}
 
 serve(async (req) => {
   const cors = resolveCors(req);
@@ -76,6 +163,7 @@ serve(async (req) => {
     const { instrument, answers, ts } = parsed.data;
     const summary = summarizeAssessment(instrument, answers);
     const catalog = getCatalog(instrument, 'fr');
+    const hints = buildOrchestrationHints(instrument, summary.level, summary.scores);
 
     addSentryBreadcrumb({
       category: 'assess:submit',
@@ -89,12 +177,14 @@ serve(async (req) => {
     });
 
     const payload = {
+      user_id: auth.user.id,
       instrument,
       score_json: {
         summary: summary.summary,
-        focus: summary.focus,
+        focus: summary.focus ?? null,
         instrument_version: catalog.version,
         generated_at: new Date().toISOString(),
+        level: summary.level,
       },
       ts: ts ?? new Date().toISOString(),
     };
@@ -106,6 +196,27 @@ serve(async (req) => {
       return appendCorsHeaders(json(500, { error: 'storage_failed' }), cors);
     }
 
+    const signalPayload = {
+      user_id: auth.user.id,
+      source_instrument: instrument,
+      domain: getInstrumentDomain(instrument),
+      level: summary.level,
+      module_context: SIGNAL_MODULE_CONTEXT,
+      metadata: {
+        summary: summary.summary,
+        focus: summary.focus ?? null,
+        hints,
+      },
+      expires_at: new Date(Date.now() + SIGNAL_TTL_MS).toISOString(),
+    };
+
+    const { error: signalError } = await supabase.from('clinical_signals').insert(signalPayload);
+    if (signalError) {
+      captureSentryException(signalError, { route: 'assess-submit', stage: 'signal_insert' });
+      console.error('[assess-submit] failed to store orchestration signal', { message: signalError.message });
+      return appendCorsHeaders(json(500, { error: 'signal_storage_failed' }), cors);
+    }
+
     await logAccess({
       user_id: hash(auth.user.id),
       role: auth.user.user_metadata?.role ?? null,
@@ -113,10 +224,10 @@ serve(async (req) => {
       action: 'assess:submit',
       result: 'success',
       user_agent: 'redacted',
-      details: `instrument=${instrument}`,
+      details: `instrument=${instrument};hints=${hints.length}`,
     });
 
-    const response = json(200, { status: 'ok', stored: true });
+    const response = json(200, { status: 'ok', stored: true, signal: true });
     return appendCorsHeaders(response, cors);
   } catch (error) {
     captureSentryException(error, { route: 'assess-submit' });

--- a/supabase/migrations/20251201093000_signals_01.sql
+++ b/supabase/migrations/20251201093000_signals_01.sql
@@ -1,0 +1,62 @@
+-- Migration: SIGNALS-01 - Clinical orchestration signals table
+-- Ensures the clinical_signals table exists with the expected structure
+-- and owner-based row level security policies.
+
+-- Create table if it does not yet exist
+CREATE TABLE IF NOT EXISTS public.clinical_signals (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  source_instrument TEXT NOT NULL,
+  domain TEXT NOT NULL,
+  level INTEGER NOT NULL,
+  module_context TEXT NOT NULL,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Backfill defaults and adjust existing schema if the table was created previously
+ALTER TABLE public.clinical_signals
+  ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  ALTER COLUMN metadata SET DEFAULT '{}'::jsonb,
+  ALTER COLUMN metadata SET NOT NULL,
+  ALTER COLUMN module_context SET NOT NULL,
+  ALTER COLUMN level SET NOT NULL,
+  ALTER COLUMN domain SET NOT NULL,
+  ALTER COLUMN source_instrument SET NOT NULL,
+  ALTER COLUMN user_id SET NOT NULL,
+  ALTER COLUMN expires_at SET NOT NULL,
+  ALTER COLUMN created_at SET DEFAULT now(),
+  ALTER COLUMN created_at SET NOT NULL;
+
+-- Remove legacy columns no longer used
+ALTER TABLE public.clinical_signals
+  DROP COLUMN IF EXISTS window_type;
+
+-- Ensure row level security is enabled
+ALTER TABLE public.clinical_signals ENABLE ROW LEVEL SECURITY;
+
+-- Recreate policies to guarantee owner-level access control
+DROP POLICY IF EXISTS "signals_select_own" ON public.clinical_signals;
+DROP POLICY IF EXISTS "signals_manage_own" ON public.clinical_signals;
+DROP POLICY IF EXISTS "signals_service_access" ON public.clinical_signals;
+
+CREATE POLICY "signals_select_own" ON public.clinical_signals
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "signals_manage_own" ON public.clinical_signals
+  FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "signals_service_access" ON public.clinical_signals
+  FOR ALL
+  USING (auth.jwt() ->> 'role' = 'service_role');
+
+-- Helpful indexes for retrieving active signals
+CREATE INDEX IF NOT EXISTS idx_clinical_signals_user_expires
+  ON public.clinical_signals(user_id, expires_at);
+
+CREATE INDEX IF NOT EXISTS idx_clinical_signals_context
+  ON public.clinical_signals(module_context);


### PR DESCRIPTION
## Summary
- ensure the `clinical_signals` table schema enforces metadata defaults, RLS policies, and helpful indexes
- emit orchestration hints from the assess-submit edge function and persist them with a 24h TTL signal
- align client services and Supabase types with the updated schema, supplying `user_id` on inserts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce65beddec832d84bb5f66efab3d2d