### PR TITLE
feat: add SAM instant mood selector and vibe events

### DIFF
--- a/src/components/dashboard/b2c/widgets/WeatherMoodWidget.tsx
+++ b/src/components/dashboard/b2c/widgets/WeatherMoodWidget.tsx
@@ -1,17 +1,29 @@
 
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Sun, Cloud, CloudRain, Heart } from 'lucide-react';
+import { Sun, Cloud, CloudRain, CloudSun, Heart } from 'lucide-react';
+import { useMood } from '@/contexts/MoodContext';
+import { getVibeEmoji, getVibeLabel, type MoodVibe } from '@/utils/moodVibes';
 
 export const WeatherMoodWidget: React.FC = () => {
-  const weatherIcons = {
-    sunny: Sun,
-    cloudy: Cloud,
-    rainy: CloudRain
+  const { currentMood } = useMood();
+
+  const vibeVisuals: Record<MoodVibe, {
+    icon: React.ComponentType<{ className?: string }>;
+    weather: string;
+    description: string;
+    accent: string;
+  }> = {
+    calm: { icon: CloudSun, weather: 'Ciel pastel', description: 'Respiration fluide et douceur.', accent: 'text-blue-500' },
+    bright: { icon: Sun, weather: 'Grand soleil', description: 'Éclat lumineux et énergie positive.', accent: 'text-amber-500' },
+    focus: { icon: Cloud, weather: 'Ciel clair', description: 'Clarté d\'esprit et cap maintenu.', accent: 'text-purple-500' },
+    reset: { icon: CloudRain, weather: 'Bruine légère', description: 'Temps de pause pour se régénérer.', accent: 'text-indigo-500' },
   };
 
-  const currentWeather = 'sunny';
-  const WeatherIcon = weatherIcons[currentWeather];
+  const visuals = vibeVisuals[currentMood.vibe] ?? vibeVisuals.calm;
+  const WeatherIcon = visuals.icon;
+  const vibeLabel = getVibeLabel(currentMood.vibe);
+  const vibeEmoji = getVibeEmoji(currentMood.vibe);
 
   return (
     <Card>
@@ -24,21 +36,30 @@ export const WeatherMoodWidget: React.FC = () => {
       <CardContent className="space-y-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <WeatherIcon className="h-8 w-8 text-yellow-500" />
+            <WeatherIcon className={`h-8 w-8 ${visuals.accent}`} />
             <div>
-              <p className="font-medium">Ensoleillé</p>
-              <p className="text-sm text-muted-foreground">22°C</p>
+              <p className="font-medium">{visuals.weather}</p>
+              <p className="text-sm text-muted-foreground">{visuals.description}</p>
             </div>
           </div>
           <div className="text-right">
             <p className="font-medium">Humeur actuelle</p>
-            <p className="text-2xl">😊</p>
+            <p className="text-2xl" aria-label={vibeLabel} title={vibeLabel}>
+              {vibeEmoji}
+            </p>
+            <p className="text-sm text-muted-foreground capitalize">{vibeLabel}</p>
           </div>
         </div>
-        
+
         <div className="p-3 bg-blue-50 rounded-lg">
           <p className="text-sm text-blue-700">
-            🌟 Parfait temps pour une marche méditative !
+            🌟 {currentMood.vibe === 'bright'
+              ? 'Moment parfait pour partager ton énergie.'
+              : currentMood.vibe === 'focus'
+                ? 'Garde le cap sur ce qui compte pour toi.'
+                : currentMood.vibe === 'reset'
+                  ? 'Offre-toi un instant de récupération.'
+                  : 'Savoure cette douceur intérieure.'}
           </p>
         </div>
       </CardContent>

--- a/src/components/scan/SamInstantMood.tsx
+++ b/src/components/scan/SamInstantMood.tsx
@@ -1,0 +1,215 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Slider } from '@/components/ui/slider';
+import { Badge } from '@/components/ui/badge';
+import { useMood } from '@/contexts/MoodContext';
+import { getVibeEmoji, getVibeLabel, mapMoodToVibe } from '@/utils/moodVibes';
+
+interface SamStep {
+  value: number;
+  label: string;
+  helper: string;
+  emoji: string;
+}
+
+const SAM_VALENCE_STEPS: SamStep[] = [
+  { value: -80, label: 'Très difficile', helper: 'Besoin de soutien immédiat', emoji: '😣' },
+  { value: -40, label: 'Plutôt difficile', helper: 'Un peu de douceur aiderait', emoji: '🙁' },
+  { value: 0, label: 'Neutre', helper: 'État stable et posé', emoji: '😐' },
+  { value: 40, label: 'Plutôt agréable', helper: 'Sensation agréable et légère', emoji: '🙂' },
+  { value: 80, label: 'Rayonnant', helper: 'Énergie positive communicative', emoji: '😄' },
+];
+
+const SAM_AROUSAL_STEPS: SamStep[] = [
+  { value: 10, label: 'Somnolent', helper: 'Repos complet nécessaire', emoji: '😴' },
+  { value: 30, label: 'Apaisé', helper: 'Respiration calme et profonde', emoji: '😌' },
+  { value: 50, label: 'Équilibré', helper: 'Présence tranquille', emoji: '🙂' },
+  { value: 70, label: 'Tonus', helper: 'Énergie constructive', emoji: '😃' },
+  { value: 90, label: 'Vibrant', helper: 'Ébullition créative', emoji: '🤩' },
+];
+
+const getClosestIndex = (value: number, steps: SamStep[]) => {
+  return steps.reduce((closestIndex, step, index) => {
+    const currentDiff = Math.abs(step.value - value);
+    const bestDiff = Math.abs(steps[closestIndex].value - value);
+    return currentDiff < bestDiff ? index : closestIndex;
+  }, 0);
+};
+
+const SamInstantMood: React.FC = () => {
+  const { updateMood, currentMood } = useMood();
+
+  const initialValenceIndex = React.useMemo(
+    () => getClosestIndex(currentMood.valence, SAM_VALENCE_STEPS),
+    [currentMood.valence],
+  );
+  const initialArousalIndex = React.useMemo(
+    () => getClosestIndex(currentMood.arousal, SAM_AROUSAL_STEPS),
+    [currentMood.arousal],
+  );
+
+  const [valenceIndex, setValenceIndex] = React.useState(initialValenceIndex);
+  const [arousalIndex, setArousalIndex] = React.useState(initialArousalIndex);
+
+  React.useEffect(() => {
+    setValenceIndex(initialValenceIndex);
+  }, [initialValenceIndex]);
+
+  React.useEffect(() => {
+    setArousalIndex(initialArousalIndex);
+  }, [initialArousalIndex]);
+
+  const applyMood = React.useCallback(
+    (nextValenceIndex: number, nextArousalIndex: number) => {
+      const safeValenceIndex = Math.min(Math.max(nextValenceIndex, 0), SAM_VALENCE_STEPS.length - 1);
+      const safeArousalIndex = Math.min(Math.max(nextArousalIndex, 0), SAM_AROUSAL_STEPS.length - 1);
+      const valenceValue = SAM_VALENCE_STEPS[safeValenceIndex].value;
+      const arousalValue = SAM_AROUSAL_STEPS[safeArousalIndex].value;
+      updateMood(valenceValue, arousalValue);
+    },
+    [updateMood],
+  );
+
+  const handleValenceChange = React.useCallback(
+    (values: number[]) => {
+      const index = Math.round(values[0] ?? 0);
+      if (!Number.isFinite(index) || index === valenceIndex) {
+        return;
+      }
+      setValenceIndex(index);
+      applyMood(index, arousalIndex);
+    },
+    [applyMood, arousalIndex, valenceIndex],
+  );
+
+  const handleArousalChange = React.useCallback(
+    (values: number[]) => {
+      const index = Math.round(values[0] ?? 0);
+      if (!Number.isFinite(index) || index === arousalIndex) {
+        return;
+      }
+      setArousalIndex(index);
+      applyMood(valenceIndex, index);
+    },
+    [applyMood, arousalIndex, valenceIndex],
+  );
+
+  const selectValence = React.useCallback(
+    (index: number) => {
+      if (index === valenceIndex) {
+        return;
+      }
+      setValenceIndex(index);
+      applyMood(index, arousalIndex);
+    },
+    [applyMood, arousalIndex, valenceIndex],
+  );
+
+  const selectArousal = React.useCallback(
+    (index: number) => {
+      if (index === arousalIndex) {
+        return;
+      }
+      setArousalIndex(index);
+      applyMood(valenceIndex, index);
+    },
+    [applyMood, arousalIndex, valenceIndex],
+  );
+
+  const currentValence = SAM_VALENCE_STEPS[valenceIndex];
+  const currentArousal = SAM_AROUSAL_STEPS[arousalIndex];
+  const vibe = React.useMemo(
+    () => mapMoodToVibe(currentValence.value, currentArousal.value),
+    [currentArousal.value, currentValence.value],
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Check-in instantané (SAM)</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-sm text-muted-foreground">Vibe actuelle</p>
+            <p className="text-lg font-semibold flex items-center gap-2">
+              <span aria-hidden="true">{getVibeEmoji(vibe)}</span>
+              {getVibeLabel(vibe)}
+            </p>
+          </div>
+          <Badge variant="secondary" className="text-sm py-1 px-3">
+            SAM synchronisé
+          </Badge>
+        </div>
+
+        <section className="space-y-3">
+          <header>
+            <p className="text-sm uppercase tracking-wide text-muted-foreground">Ressenti</p>
+            <p className="font-medium text-foreground flex items-center gap-2">
+              <span aria-hidden="true" className="text-xl">{currentValence.emoji}</span>
+              {currentValence.label}
+            </p>
+            <p className="text-sm text-muted-foreground">{currentValence.helper}</p>
+          </header>
+          <div className="space-y-2">
+            <Slider
+              value={[valenceIndex]}
+              max={SAM_VALENCE_STEPS.length - 1}
+              min={0}
+              step={1}
+              onValueChange={handleValenceChange}
+              aria-label="Ressenti"
+            />
+            <div className="flex justify-between text-2xl" aria-hidden="true">
+              {SAM_VALENCE_STEPS.map((step, index) => (
+                <button
+                  key={step.label}
+                  type="button"
+                  className={`transition-transform ${index === valenceIndex ? 'scale-110' : 'opacity-70 hover:opacity-100'}`}
+                  onClick={() => selectValence(index)}
+                >
+                  <span role="img" aria-label={step.label}>{step.emoji}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <header>
+            <p className="text-sm uppercase tracking-wide text-muted-foreground">Énergie</p>
+            <p className="font-medium text-foreground flex items-center gap-2">
+              <span aria-hidden="true" className="text-xl">{currentArousal.emoji}</span>
+              {currentArousal.label}
+            </p>
+            <p className="text-sm text-muted-foreground">{currentArousal.helper}</p>
+          </header>
+          <div className="space-y-2">
+            <Slider
+              value={[arousalIndex]}
+              max={SAM_AROUSAL_STEPS.length - 1}
+              min={0}
+              step={1}
+              onValueChange={handleArousalChange}
+              aria-label="Énergie"
+            />
+            <div className="flex justify-between text-2xl" aria-hidden="true">
+              {SAM_AROUSAL_STEPS.map((step, index) => (
+                <button
+                  key={step.label}
+                  type="button"
+                  className={`transition-transform ${index === arousalIndex ? 'scale-110' : 'opacity-70 hover:opacity-100'}`}
+                  onClick={() => selectArousal(index)}
+                >
+                  <span role="img" aria-label={step.label}>{step.emoji}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        </section>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default SamInstantMood;

--- a/src/contexts/MoodContext.tsx
+++ b/src/contexts/MoodContext.tsx
@@ -1,11 +1,13 @@
 import React, { createContext, useContext, ReactNode } from 'react';
 import { useMoodStore } from '@/hooks/useMood';
+import type { MoodVibe } from '@/utils/moodVibes';
 
 interface MoodContextType {
   currentMood: {
     valence: number;
     arousal: number;
     timestamp: string;
+    vibe: MoodVibe;
     isLoading: boolean;
     error: string | null;
   };
@@ -30,6 +32,7 @@ export const MoodProvider: React.FC<MoodProviderProps> = ({ children }) => {
       valence: moodStore.valence,
       arousal: moodStore.arousal,
       timestamp: moodStore.timestamp,
+      vibe: moodStore.vibe,
       isLoading: moodStore.isLoading,
       error: moodStore.error,
     },

--- a/src/modules/adaptive-music/AdaptiveMusicPage.tsx
+++ b/src/modules/adaptive-music/AdaptiveMusicPage.tsx
@@ -38,6 +38,7 @@ import {
   AudioPlayerFavoriteEntry,
 } from "@/ui/AudioPlayer";
 import { useMood } from "@/contexts/MoodContext";
+import type { MoodVibe } from "@/utils/moodVibes";
 import { recordEvent } from "@/lib/scores/events";
 import {
   Clock,
@@ -129,6 +130,13 @@ const deriveIntensity = (arousal?: number): number => {
     return 0.5;
   }
   return Number(Math.min(1, Math.max(0, arousal / 100)).toFixed(2));
+};
+
+const VIBE_TO_MUSIC_MOOD: Record<MoodVibe, string> = {
+  calm: "relaxed",
+  bright: "joyful",
+  focus: "focus",
+  reset: "sleep",
 };
 
 const MOOD_OPTIONS: Array<{
@@ -354,10 +362,13 @@ const AdaptiveMusicPage: React.FC = () => {
   const [sessionDuration, setSessionDuration] = React.useState(20);
   const [instrumentalOnly, setInstrumentalOnly] = React.useState(true);
 
-  const suggestedMood = React.useMemo(
-    () => deriveMoodFromProfile(currentMood.valence, currentMood.arousal),
-    [currentMood.valence, currentMood.arousal]
-  );
+  const suggestedMood = React.useMemo(() => {
+    const vibe = currentMood.vibe;
+    if (vibe && VIBE_TO_MUSIC_MOOD[vibe]) {
+      return VIBE_TO_MUSIC_MOOD[vibe];
+    }
+    return deriveMoodFromProfile(currentMood.valence, currentMood.arousal);
+  }, [currentMood.arousal, currentMood.valence, currentMood.vibe]);
 
   const [selectedMood, setSelectedMood] = React.useState(suggestedMood);
 

--- a/src/pages/B2CScanPage.tsx
+++ b/src/pages/B2CScanPage.tsx
@@ -11,6 +11,7 @@ import { useToast } from '@/hooks/use-toast';
 import PageRoot from '@/components/common/PageRoot';
 import EmotionScannerPremium from '@/components/emotion/EmotionScannerPremium';
 import EmotionsCareMusicPlayer from '@/components/music/emotionscare/EmotionsCareMusicPlayer';
+import SamInstantMood from '@/components/scan/SamInstantMood';
 import { useMusic } from '@/contexts/MusicContext';
 import type { EmotionResult } from '@/types/emotion';
 
@@ -76,6 +77,10 @@ const B2CScanPage: React.FC = () => {
                 </Button>
               </div>
             </div>
+          </div>
+
+          <div className="max-w-3xl mx-auto w-full">
+            <SamInstantMood />
           </div>
 
           {/* Enhanced Stats */}

--- a/src/utils/moodVibes.ts
+++ b/src/utils/moodVibes.ts
@@ -1,0 +1,71 @@
+export type MoodVibe = 'calm' | 'focus' | 'bright' | 'reset';
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function resolveZone(value: number, thresholds: { low: number; high: number }): 'low' | 'medium' | 'high' {
+  if (value <= thresholds.low) {
+    return 'low';
+  }
+  if (value >= thresholds.high) {
+    return 'high';
+  }
+  return 'medium';
+}
+
+/**
+ * Convertit un couple valence/arousal en vibe simplifiée.
+ * Les bornes sont volontairement larges pour garder une lecture qualitative.
+ */
+export function mapMoodToVibe(valence: number, arousal: number): MoodVibe {
+  const clampedValence = clamp(valence, -100, 100);
+  const clampedArousal = clamp(arousal, 0, 100);
+
+  const valenceZone = resolveZone(clampedValence, { low: -25, high: 25 });
+  const arousalZone = resolveZone(clampedArousal, { low: 40, high: 60 });
+
+  if (valenceZone === 'high' && arousalZone === 'high') {
+    return 'bright';
+  }
+
+  if (valenceZone === 'high') {
+    return 'calm';
+  }
+
+  if (valenceZone === 'low' && arousalZone === 'low') {
+    return 'reset';
+  }
+
+  if (arousalZone === 'high') {
+    return 'focus';
+  }
+
+  if (valenceZone === 'low') {
+    return 'reset';
+  }
+
+  return arousalZone === 'low' ? 'calm' : 'focus';
+}
+
+const VIBE_LABELS: Record<MoodVibe, string> = {
+  calm: 'Calme',
+  focus: 'Focus',
+  bright: 'Bright',
+  reset: 'Reset',
+};
+
+const VIBE_EMOJIS: Record<MoodVibe, string> = {
+  calm: '😌',
+  focus: '🎯',
+  bright: '🌟',
+  reset: '🌙',
+};
+
+export function getVibeLabel(vibe: MoodVibe): string {
+  return VIBE_LABELS[vibe];
+}
+
+export function getVibeEmoji(vibe: MoodVibe): string {
+  return VIBE_EMOJIS[vibe];
+}


### PR DESCRIPTION
## Summary
- add a Self-Assessment Manikin slider card to the B2C scan page for instant mood updates
- compute mood vibes from valence/arousal in the mood store and expose them through the context and global event
- reflect the active vibe in the dashboard weather widget and adaptive music playlist suggestions

## Testing
- npm run typecheck *(fails: `tsc --noEmit` prints usage/help because the repository has no active tsconfig)*

------
https://chatgpt.com/codex/tasks/task_e_68ce6603872c832db08def5ad00fbed2