### PR TITLE
feat: add PANAS-driven journaling suggestions

### DIFF
--- a/src/modules/journal/usePanasSuggestions.ts
+++ b/src/modules/journal/usePanasSuggestions.ts
@@ -1,0 +1,351 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '@/integrations/supabase/client'
+import { useAuth } from '@/contexts/AuthContext'
+import { useToast } from '@/hooks/use-toast'
+import { useAssessment } from '@/hooks/useAssessment'
+
+const PROMPT_STORAGE_KEY = 'journal.panas_prompt_last_seen'
+const PROMPT_INTERVAL_MS = 72 * 60 * 60 * 1000 // 72h ≈ 2-3 rappels par semaine
+
+const POSITIVE_KEYWORDS = [
+  'positif',
+  'positive',
+  'enthousiasme',
+  'énergie',
+  'élan',
+  'ressource',
+  'soutien',
+  'lumière',
+  'ouverture',
+]
+
+const NEGATIVE_KEYWORDS = [
+  'tension',
+  'fatigue',
+  'charge',
+  'agitation',
+  'difficile',
+  'négatif',
+  'fragile',
+  'saturé',
+  'apaisement nécessaire',
+  'apaisement',
+]
+
+type RawAssessment = {
+  score_json: Record<string, unknown> | null
+  ts: string | null
+}
+
+type StoredPrompt = number | null
+
+export type AffectOrientation = 'pa' | 'na' | 'balanced'
+
+export type PanasSuggestion = {
+  id: string
+  title: string
+  description: string
+  prompt: string
+}
+
+type SuggestionSet = Record<AffectOrientation, PanasSuggestion[]>
+
+const SUGGESTIONS: SuggestionSet = {
+  na: [
+    {
+      id: 'soothing-anchor',
+      title: 'Ancrage apaisant',
+      description:
+        "Décris un lieu, un geste ou une sensation qui t'aide à retrouver un <em>sentiment de sécurité</em> immédiat.",
+      prompt: "Quel rituel ou endroit te permet de souffler et de te sentir en sécurité ?",
+    },
+    {
+      id: 'micro-kindness',
+      title: 'Micro-attention douce',
+      description:
+        "Liste trois attentions délicates que tu pourrais t'offrir aujourd'hui pour <em>adoucir la journée</em>.",
+      prompt: "Quelles petites attentions peux-tu t'accorder pour rendre cette journée plus douce ?",
+    },
+    {
+      id: 'compassion-letter',
+      title: 'Lettre de compassion',
+      description:
+        "Écris-toi quelques lignes comme si un ami te rappelait que tu as déjà traversé des moments <strong>compliqués avec courage</strong>.",
+      prompt: "Si ton meilleur ami écrivait pour t'encourager, que te dirait-il aujourd'hui ?",
+    },
+  ],
+  pa: [
+    {
+      id: 'amplify-joy',
+      title: 'Amplifier l’élan',
+      description:
+        "Note ce qui t'a donné de l'<strong>élan positif</strong> récemment et comment tu pourrais en prolonger l'effet.",
+      prompt: "Quel moment récent t'a donné de l'énergie et comment peux-tu en savourer encore les bénéfices ?",
+    },
+    {
+      id: 'share-light',
+      title: 'Partager la lumière',
+      description:
+        "Imagine une façon simple de <em>transmettre cette énergie</em> à quelqu'un aujourd'hui (un mot, un geste, une idée).",
+      prompt: "Comment pourrais-tu partager un peu de ton élan positif autour de toi aujourd'hui ?",
+    },
+    {
+      id: 'future-self',
+      title: 'Message au futur toi',
+      description:
+        "Écris un message à ton toi futur pour lui rappeler ce qui te rend <strong>si vivant(e)</strong> en ce moment.",
+      prompt: "Quel message as-tu envie d'envoyer à ton toi futur pour qu'il se rappelle ce qui te porte aujourd'hui ?",
+    },
+  ],
+  balanced: [
+    {
+      id: 'body-scan',
+      title: 'Scan météo intérieure',
+      description:
+        "Observe comment ton corps réagit aujourd'hui : où se trouve l'<em>espace le plus détendu</em>, où la tension est-elle présente ?",
+      prompt: "Si ton corps avait une météo, comment décrirais-tu les zones calmes et celles en besoin de douceur ?",
+    },
+    {
+      id: 'micro-gratitude',
+      title: 'Gratitude en nuance',
+      description:
+        "Repère une petite chose qui t'a fait du bien et une autre qui a demandé de l'énergie, sans jugement, juste pour <strong>reconnaître</strong>.",
+      prompt: "Quelle petite chose te fait du bien aujourd'hui et qu'est-ce qui pourrait recevoir un peu plus de soin ?",
+    },
+    {
+      id: 'gentle-next-step',
+      title: 'Pas doux suivant',
+      description:
+        "Écris une intention simple pour avancer d'un pas, même minuscule, vers plus d'<em>équilibre</em> cette semaine.",
+      prompt: "Quel pas tout doux pourrais-tu poser cette semaine pour prendre soin de ton équilibre ?",
+    },
+  ],
+}
+
+const getStoredPromptTimestamp = (): StoredPrompt => {
+  if (typeof window === 'undefined') return null
+  const raw = window.localStorage.getItem(PROMPT_STORAGE_KEY)
+  if (!raw) return null
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+const persistPromptTimestamp = (value: number) => {
+  if (typeof window === 'undefined') return
+  window.localStorage.setItem(PROMPT_STORAGE_KEY, String(value))
+}
+
+const collectTextClues = (scoreJson: Record<string, unknown> | null | undefined): string => {
+  if (!scoreJson) return ''
+  const fragments: string[] = []
+
+  const summary = scoreJson.summary
+  const focus = scoreJson.focus
+
+  if (typeof summary === 'string') fragments.push(summary)
+  if (typeof focus === 'string') fragments.push(focus)
+
+  const subs = scoreJson.subs
+  if (subs && typeof subs === 'object') {
+    Object.values(subs).forEach(value => {
+      if (!value) return
+      if (typeof value === 'string') {
+        fragments.push(value)
+      } else if (typeof value === 'object') {
+        const maybeLabel = (value as Record<string, unknown>).label
+        const maybeTrend = (value as Record<string, unknown>).trend
+        const maybeHint = (value as Record<string, unknown>).hint
+
+        if (typeof maybeLabel === 'string') fragments.push(maybeLabel)
+        if (typeof maybeTrend === 'string') fragments.push(maybeTrend)
+        if (typeof maybeHint === 'string') fragments.push(maybeHint)
+      }
+    })
+  }
+
+  return fragments.join(' ').toLowerCase()
+}
+
+const countMatches = (haystack: string, needles: string[]) =>
+  needles.reduce((total, needle) => (haystack.includes(needle) ? total + 1 : total), 0)
+
+const resolveOrientation = (scoreJson: Record<string, unknown> | null | undefined): AffectOrientation => {
+  const clues = collectTextClues(scoreJson)
+  if (!clues) {
+    return 'balanced'
+  }
+
+  const positive = countMatches(clues, POSITIVE_KEYWORDS)
+  const negative = countMatches(clues, NEGATIVE_KEYWORDS)
+
+  if (negative > positive) return 'na'
+  if (positive > negative) return 'pa'
+  return 'balanced'
+}
+
+const describeRecency = (isoDate?: string | null): string => {
+  if (!isoDate) return "Pas encore d'auto-évaluation PANAS."
+  const parsed = Number.isNaN(Date.parse(isoDate)) ? null : new Date(isoDate)
+  if (!parsed) return "Mise à jour PANAS disponible."
+
+  const now = Date.now()
+  const diff = now - parsed.getTime()
+  const dayMs = 24 * 60 * 60 * 1000
+
+  if (diff < 2 * dayMs) {
+    return 'Dernière photo émotionnelle toute récente.'
+  }
+  if (diff < 7 * dayMs) {
+    return 'Évaluation PANAS réalisée cette semaine.'
+  }
+  if (diff < 30 * dayMs) {
+    return 'Dernier point PANAS pris ce mois-ci.'
+  }
+  return 'La prochaine auto-évaluation rapprochera le suivi.'
+}
+
+export type UsePanasSuggestionsResult = {
+  orientation: AffectOrientation
+  suggestions: PanasSuggestion[]
+  recencyLabel: string
+  promptVisible: boolean
+  isRequestingConsent: boolean
+  requestConsent: () => Promise<void>
+  skipPrompt: () => void
+  isLoading: boolean
+  hasConsent: boolean
+}
+
+export function usePanasSuggestions(): UsePanasSuggestionsResult {
+  const { user } = useAuth()
+  const { toast } = useToast()
+  const assessment = useAssessment('PANAS')
+
+  const [lastPromptTs, setLastPromptTs] = useState<StoredPrompt>(() => getStoredPromptTimestamp())
+  const [promptVisible, setPromptVisible] = useState(false)
+  const [isRequestingConsent, setIsRequestingConsent] = useState(false)
+
+  const consentQuery = useQuery({
+    queryKey: ['panas', 'consent', user?.id],
+    enabled: Boolean(user?.id),
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('clinical_consents')
+        .select('is_active, granted_at, revoked_at')
+        .eq('instrument_code', 'PANAS')
+        .order('granted_at', { ascending: false })
+        .limit(1)
+        .maybeSingle()
+
+      if (error) throw error
+      return data
+    },
+    staleTime: 60 * 1000,
+  })
+
+  const assessmentQuery = useQuery<RawAssessment | null>({
+    queryKey: ['panas', 'latest', user?.id],
+    enabled: Boolean(user?.id),
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('assessments')
+        .select('score_json, ts')
+        .eq('instrument', 'PANAS')
+        .order('ts', { ascending: false })
+        .limit(1)
+        .maybeSingle()
+
+      if (error) throw error
+      return data as RawAssessment | null
+    },
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const hasConsent = useMemo(
+    () =>
+      assessment.state.hasConsent ||
+      Boolean(consentQuery.data?.is_active),
+    [assessment.state.hasConsent, consentQuery.data?.is_active],
+  )
+
+  const canPrompt = useMemo(() => {
+    if (!user?.id) return false
+    if (consentQuery.isLoading) return false
+    if (hasConsent) return false
+    if (!lastPromptTs) return true
+    return Date.now() - lastPromptTs >= PROMPT_INTERVAL_MS
+  }, [user?.id, consentQuery.isLoading, hasConsent, lastPromptTs])
+
+  useEffect(() => {
+    if (canPrompt && !promptVisible) {
+      const now = Date.now()
+      setPromptVisible(true)
+      setLastPromptTs(now)
+      persistPromptTimestamp(now)
+    }
+    if (!canPrompt && promptVisible) {
+      setPromptVisible(false)
+    }
+  }, [canPrompt, promptVisible])
+
+  const orientation = useMemo<AffectOrientation>(() => {
+    if (!assessmentQuery.data?.score_json) {
+      return 'balanced'
+    }
+    return resolveOrientation(
+      assessmentQuery.data.score_json as Record<string, unknown>,
+    )
+  }, [assessmentQuery.data?.score_json])
+
+  const recencyLabel = useMemo(
+    () => describeRecency(assessmentQuery.data?.ts ?? null),
+    [assessmentQuery.data?.ts],
+  )
+
+  const requestConsent = useCallback(async () => {
+    try {
+      setIsRequestingConsent(true)
+      await assessment.grantConsent('PANAS')
+      await assessment.triggerAssessment('PANAS')
+      setPromptVisible(false)
+      const now = Date.now()
+      setLastPromptTs(now)
+      persistPromptTimestamp(now)
+      toast({
+        title: 'Auto-évaluation activée',
+        description: 'Nous t’inviterons régulièrement chaque semaine pour un court PANAS.',
+      })
+    } catch (error) {
+      console.error('PANAS consent error', error)
+      toast({
+        title: 'Activation indisponible',
+        description: "La demande n'a pas pu aboutir. Réessaie dans un instant.",
+        variant: 'destructive',
+      })
+    } finally {
+      setIsRequestingConsent(false)
+    }
+  }, [assessment, toast])
+
+  const skipPrompt = useCallback(() => {
+    setPromptVisible(false)
+    const now = Date.now()
+    setLastPromptTs(now)
+    persistPromptTimestamp(now)
+  }, [])
+
+  const suggestions = useMemo(() => SUGGESTIONS[orientation], [orientation])
+
+  return {
+    orientation,
+    suggestions,
+    recencyLabel,
+    promptVisible,
+    isRequestingConsent,
+    requestConsent,
+    skipPrompt,
+    isLoading: consentQuery.isLoading || assessmentQuery.isLoading,
+    hasConsent,
+  }
+}

--- a/src/modules/sessions/hooks/useSessionClock.ts
+++ b/src/modules/sessions/hooks/useSessionClock.ts
@@ -253,11 +253,11 @@ export function useSessionClock(options: Options = {}): Return {
   }, [])
 
   useEffect(() => {
-    if (autoStart) {
-      start()
+    if (!autoStart) {
+      return
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+    start()
+  }, [autoStart, start])
 
   const progress = useMemo(() => {
     if (!durationRef.current || durationRef.current <= 0) {

--- a/src/pages/journal/JournalView.tsx
+++ b/src/pages/journal/JournalView.tsx
@@ -7,6 +7,7 @@ import { useJournalComposer } from '@/modules/journal/useJournalComposer'
 import { listFeed } from '@/services/journal/journalApi'
 import type { SanitizedNote } from '@/modules/journal/types'
 import { JournalFeed } from './JournalFeed'
+import { PanasSuggestionsCard } from './PanasSuggestionsCard'
 
 const PAGE_SIZE = 10
 
@@ -80,6 +81,8 @@ export default function JournalView() {
           <JournalComposer composer={composer} />
         </CardContent>
       </Card>
+
+      <PanasSuggestionsCard composer={composer} />
 
       <JournalFeed
         search={search}

--- a/src/pages/journal/PanasSuggestionsCard.tsx
+++ b/src/pages/journal/PanasSuggestionsCard.tsx
@@ -1,0 +1,137 @@
+import DOMPurify from 'dompurify'
+import { useMemo } from 'react'
+import { AlertCircle, Brain, Sparkles } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { useToast } from '@/hooks/use-toast'
+import { usePanasSuggestions } from '@/modules/journal/usePanasSuggestions'
+import type { useJournalComposer } from '@/modules/journal/useJournalComposer'
+import type { PanasSuggestion } from '@/modules/journal/usePanasSuggestions'
+import { cn } from '@/lib/utils'
+
+type JournalComposerRef = ReturnType<typeof useJournalComposer>
+
+type PanasSuggestionsCardProps = {
+  composer: JournalComposerRef
+}
+
+const orientationBadges: Record<string, { label: string; variant: 'default' | 'secondary' | 'outline' }> = {
+  pa: { label: 'PA en soutien', variant: 'default' },
+  na: { label: 'NA à apaiser', variant: 'secondary' },
+  balanced: { label: 'État stable', variant: 'outline' },
+}
+
+const sanitizeDescription = (value: string) =>
+  DOMPurify.sanitize(value, {
+    ALLOWED_TAGS: ['strong', 'em'],
+    ALLOWED_ATTR: {},
+  })
+
+const suggestionToPlainText = (suggestion: PanasSuggestion) => suggestion.prompt
+
+export function PanasSuggestionsCard({ composer }: PanasSuggestionsCardProps) {
+  const { toast } = useToast()
+  const {
+    orientation,
+    suggestions,
+    recencyLabel,
+    promptVisible,
+    requestConsent,
+    skipPrompt,
+    isRequestingConsent,
+    isLoading,
+    hasConsent,
+  } = usePanasSuggestions()
+
+  const sanitizedSuggestions = useMemo(
+    () =>
+      suggestions.map(item => ({
+        ...item,
+        sanitized: sanitizeDescription(item.description),
+      })),
+    [suggestions],
+  )
+
+  const handleUseSuggestion = (suggestion: PanasSuggestion) => {
+    const plain = suggestionToPlainText(suggestion)
+    composer.setText(prev => {
+      if (!prev.trim()) return plain
+      return `${prev.trim()}\n\n${plain}`
+    })
+    toast({
+      title: 'Inspiration ajoutée',
+      description: 'Le thème choisi a été ajouté à ta note.',
+    })
+  }
+
+  const orientationMeta = orientationBadges[orientation] ?? orientationBadges.balanced
+
+  return (
+    <Card aria-live="polite" className="border-primary/20 bg-muted/30">
+      <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-start gap-3">
+          <Brain className="mt-0.5 h-5 w-5 text-primary" aria-hidden="true" />
+          <div>
+            <CardTitle className="text-base sm:text-lg">Suggestions guidées par ton PANAS</CardTitle>
+            <p className="text-sm text-muted-foreground">{recencyLabel}</p>
+          </div>
+        </div>
+        <Badge variant={orientationMeta.variant}>{orientationMeta.label}</Badge>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {promptVisible && !hasConsent && (
+          <div className="rounded-lg border border-dashed border-primary/40 bg-primary/5 p-4">
+            <div className="flex items-start gap-2">
+              <AlertCircle className="mt-0.5 h-4 w-4 text-primary" aria-hidden="true" />
+              <div className="space-y-2 text-sm">
+                <p className="font-medium text-primary">Activer le suivi affectif&nbsp;?</p>
+                <p>
+                  Nous pouvons te proposer quelques invitations PANAS chaque semaine pour affiner les thèmes du journal. Tu peux
+                  arrêter à tout moment.
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  <Button size="sm" onClick={() => void requestConsent()} disabled={isRequestingConsent}>
+                    {isRequestingConsent ? 'Activation…' : 'Oui, activer'}
+                  </Button>
+                  <Button size="sm" variant="ghost" onClick={skipPrompt}>
+                    Plus tard
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className={cn('space-y-4', isLoading && 'opacity-60')}>
+          {sanitizedSuggestions.map(suggestion => (
+            <article
+              key={suggestion.id}
+              className="rounded-lg border border-border/60 bg-background/60 p-4 shadow-sm"
+            >
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="space-y-2">
+                  <h3 className="text-sm font-semibold leading-snug sm:text-base">{suggestion.title}</h3>
+                  <p
+                    className="text-sm text-muted-foreground"
+                    dangerouslySetInnerHTML={{ __html: suggestion.sanitized }}
+                  />
+                </div>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="flex-shrink-0"
+                  onClick={() => handleUseSuggestion(suggestion)}
+                >
+                  <Sparkles className="mr-2 h-4 w-4" aria-hidden="true" />
+                  Explorer ce thème
+                </Button>
+              </div>
+            </article>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
## Summary
- derive PANAS orientation and spaced opt-in tracking with a dedicated journal hook
- render sanitized PANAS guidance in the journal view with quick insertion actions
- align the session clock auto-start effect with hook lint rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce660fbaa8832dbb7b8a07855587a5