### PR TITLE
Add clinical privacy lint and audit

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -39,6 +39,15 @@ export default [
     }
   },
   {
+    files: ["src/app/**/*.{ts,tsx,js,jsx}"],
+    plugins: {
+      ec,
+    },
+    rules: {
+      "ec/no-clinical-score-terms": "error",
+    }
+  },
+  {
     files: ["services/**/*.{ts,tsx,js,jsx,mjs,cjs}", "supabase/functions/**/*.{ts,tsx,js,jsx,mjs,cjs}"],
     rules: {
       "no-restricted-imports": "off",

--- a/tests/e2e/privacy-clinical-audit.spec.ts
+++ b/tests/e2e/privacy-clinical-audit.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '@playwright/test';
+import manifest from '../../scripts/routes/ROUTES_MANIFEST.json';
+
+type ForbiddenPattern = { pattern: RegExp; label: string };
+
+type ForbiddenDigit = { value: string; context: string };
+
+const FORBIDDEN_TEXT_PATTERNS: ForbiddenPattern[] = [
+  { pattern: /\bscores?\b/i, label: 'term "score"' },
+  { pattern: /\bpoints?\b/i, label: 'term "points"' },
+  { pattern: /%/, label: 'percent symbol "%"' },
+];
+
+const DIGIT_CONTEXT_ALLOWLIST: RegExp[] = [
+  /30 derniers jours/i,
+  /lissées sur 3 jours/i,
+  /sur 8 semaines/i,
+];
+
+const auditedRoutes = manifest.routes
+  .map((route) => route.path)
+  .filter((path): path is string => typeof path === 'string')
+  .filter((path) => path.startsWith('/app/') || path.startsWith('/b2b/'));
+
+const uniqueRoutes = Array.from(new Set(auditedRoutes));
+
+function findForbiddenDigits(text: string): ForbiddenDigit[] {
+  const matches = text.matchAll(/\d+/g);
+  const forbidden: ForbiddenDigit[] = [];
+
+  for (const match of matches) {
+    if (!match[0] || match.index == null) {
+      continue;
+    }
+
+    const value = match[0];
+    const start = Math.max(0, match.index - 40);
+    const end = Math.min(text.length, match.index + value.length + 40);
+    const context = text.slice(start, end);
+
+    const isAllowed = DIGIT_CONTEXT_ALLOWLIST.some((pattern) => pattern.test(context));
+    if (isAllowed) {
+      continue;
+    }
+
+    forbidden.push({ value, context: context.trim() });
+  }
+
+  return forbidden;
+}
+
+test.describe('Clinical privacy text audit', () => {
+  for (const path of uniqueRoutes) {
+    test(`${path} should not expose clinical metrics`, async ({ page }) => {
+      await page.goto(path);
+
+      const rootLocator = page.locator('[data-testid="page-root"]');
+      await expect(rootLocator).toBeVisible({ timeout: 5000 });
+
+      const bodyText = await page.locator('body').innerText();
+      const normalized = bodyText.replace(/\s+/g, ' ').trim();
+
+      for (const { pattern, label } of FORBIDDEN_TEXT_PATTERNS) {
+        const match = normalized.match(pattern);
+        expect(match, `Forbidden ${label} detected on ${path}: "${match?.[0] ?? ''}"`).toBeNull();
+      }
+
+      const forbiddenDigits = findForbiddenDigits(normalized);
+      expect(
+        forbiddenDigits,
+        forbiddenDigits
+          .map((entry) => `value "${entry.value}" (context: "${entry.context}")`)
+          .join(', ') ||
+          undefined
+      ).toEqual([]);
+    });
+  }
+});

--- a/tools/eslint-plugin-ec/index.js
+++ b/tools/eslint-plugin-ec/index.js
@@ -6,5 +6,6 @@ module.exports = {
     "no-legacy-routes-helpers": require("./rules/no-legacy-routes-helpers"),
     // optionnel, voir plus bas
     "no-alias-routes": require("./rules/no-alias-routes"),
+    "no-clinical-score-terms": require("./rules/no-clinical-score-terms"),
   }
 };

--- a/tools/eslint-plugin-ec/rules/no-clinical-score-terms.js
+++ b/tools/eslint-plugin-ec/rules/no-clinical-score-terms.js
@@ -1,0 +1,225 @@
+"use strict";
+
+const CLINICAL_UI_PATH_REGEX = new RegExp(String.raw`[\\/]src[\\/]app[\\/]`);
+
+const FORBIDDEN_PATTERNS = [
+  { regex: /\bscores?\b/i, label: "score" },
+  { regex: /\bpoints?\b/i, label: "points" },
+  { regex: /%/, label: "%" },
+];
+
+const NON_TEXTUAL_ATTRIBUTES = new Set([
+  "class",
+  "className",
+  "style",
+  "id",
+  "variant",
+  "size",
+  "color",
+  "to",
+  "href",
+  "src",
+  "width",
+  "height",
+  "minWidth",
+  "maxWidth",
+  "data-testid",
+  "data-test",
+  "data-id",
+  "data-track",
+  "testid",
+  "role",
+  "tabIndex",
+  "type",
+  "as",
+  "rel",
+  "target",
+]);
+
+function getAttributeName(attribute) {
+  if (!attribute || attribute.type !== "JSXAttribute") {
+    return null;
+  }
+
+  const { name } = attribute;
+  if (!name) {
+    return null;
+  }
+
+  if (name.type === "JSXIdentifier") {
+    return name.name;
+  }
+
+  if (name.type === "JSXNamespacedName") {
+    const namespace = name.namespace?.name ?? "";
+    const local = name.name?.name ?? "";
+    return namespace && local ? `${namespace}:${local}` : namespace || local || null;
+  }
+
+  return null;
+}
+
+function findNearestJSXAttribute(node) {
+  let current = node.parent;
+  while (current) {
+    if (current.type === "JSXAttribute") {
+      return current;
+    }
+    if (current.type === "Program") {
+      return null;
+    }
+    current = current.parent;
+  }
+  return null;
+}
+
+function isWithinJSX(node) {
+  let current = node.parent;
+  while (current) {
+    if (
+      current.type === "JSXElement" ||
+      current.type === "JSXFragment" ||
+      current.type === "JSXExpressionContainer"
+    ) {
+      return true;
+    }
+    if (current.type === "Program") {
+      return false;
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
+function isLikelyTextualAttribute(attribute) {
+  const name = getAttributeName(attribute);
+  if (!name) {
+    return false;
+  }
+
+  if (NON_TEXTUAL_ATTRIBUTES.has(name)) {
+    return false;
+  }
+
+  if (name.startsWith("data-")) {
+    return false;
+  }
+
+  if (name.startsWith("aria-")) {
+    return true;
+  }
+
+  const lower = name.toLowerCase();
+  const textualHints = [
+    "label",
+    "title",
+    "text",
+    "message",
+    "description",
+    "content",
+    "caption",
+    "placeholder",
+    "helper",
+    "tooltip",
+    "children",
+    "heading",
+    "summary",
+    "subtitle",
+  ];
+
+  return textualHints.some((hint) => lower.includes(hint));
+}
+
+function reportIfForbidden(context, node, rawText) {
+  if (!rawText || typeof rawText !== "string") {
+    return;
+  }
+
+  const text = rawText.trim();
+  if (!text) {
+    return;
+  }
+
+  for (const { regex, label } of FORBIDDEN_PATTERNS) {
+    if (regex.test(text)) {
+      context.report({
+        node,
+        messageId: "forbiddenTerm",
+        data: {
+          term: label,
+        },
+      });
+      break;
+    }
+  }
+}
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Empêche l'affichage de termes ou symboles de score dans l'interface clinique (src/app).",
+      recommended: false,
+    },
+    schema: [],
+    messages: {
+      forbiddenTerm:
+        "Terme clinique sensible \"{{term}}\" détecté dans l'interface. Supprime ou anonymise ce contenu.",
+    },
+  },
+  create(context) {
+    const filename = context.getFilename();
+    if (!CLINICAL_UI_PATH_REGEX.test(filename)) {
+      return {};
+    }
+
+    return {
+      JSXText(node) {
+        reportIfForbidden(context, node, node.value);
+      },
+      Literal(node) {
+        if (typeof node.value !== "string") {
+          return;
+        }
+
+        const attribute = findNearestJSXAttribute(node);
+        if (attribute) {
+          if (!isLikelyTextualAttribute(attribute)) {
+            return;
+          }
+          reportIfForbidden(context, node, node.value);
+          return;
+        }
+
+        if (!isWithinJSX(node)) {
+          return;
+        }
+
+        reportIfForbidden(context, node, node.value);
+      },
+      TemplateLiteral(node) {
+        const attribute = findNearestJSXAttribute(node);
+        if (attribute && !isLikelyTextualAttribute(attribute)) {
+          return;
+        }
+
+        if (!attribute && !isWithinJSX(node)) {
+          return;
+        }
+
+        const text = node.quasis
+          .map((quasi) =>
+            typeof quasi.value.cooked === "string"
+              ? quasi.value.cooked
+              : typeof quasi.value.raw === "string"
+              ? quasi.value.raw
+              : ""
+          )
+          .join("");
+
+        reportIfForbidden(context, node, text);
+      },
+    };
+  },
+};


### PR DESCRIPTION
## Summary
- add custom ESLint rule to ban clinical score terminology in src/app UI code
- wire the rule into the lint config for the clinical app directory
- add Playwright audit that scans /app and /b2b routes for forbidden terms or numbers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce663558d0832d8acab8718f3195b4