### PR TITLE
Add clinical assessment QA coverage

### DIFF
--- a/supabase/tests/assess-utils.test.ts
+++ b/supabase/tests/assess-utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeAssessment, sanitizeAggregateText } from '../functions/_shared/assess.ts';
+
+describe('summarizeAssessment determineLevel', () => {
+  it.each([
+    [{ '1': 2, '2': 2, '3': 2, '4': 2, '5': 2 }, 0],
+    [{ '1': 3, '2': 3, '3': 2, '4': 3, '5': 3 }, 1],
+    [{ '1': 4, '2': 4, '3': 3, '4': 4, '5': 3 }, 2],
+    [{ '1': 5, '2': 5, '3': 4, '4': 4, '5': 4 }, 3],
+    [{ '1': 5, '2': 5, '3': 5, '4': 5, '5': 4 }, 4],
+  ])('maps WHO5 responses %j to level %s', (answers, expectedLevel) => {
+    const result = summarizeAssessment('WHO5', answers);
+    expect(result.level).toBe(expectedLevel);
+  });
+});
+
+describe('summarizeAssessment reversed items', () => {
+  it('correctly inverts STAI-6 reversed items before scoring', () => {
+    const answers = { '1': 4, '2': 3, '3': 3, '4': 4, '5': 2, '6': 2 };
+    const result = summarizeAssessment('STAI6', answers);
+
+    expect(result.scores.total).toBe(12);
+    expect(result.level).toBe(1);
+  });
+});
+
+describe('sanitizeAggregateText', () => {
+  it('removes digits and scoring terminology from aggregate text', () => {
+    const raw = 'Score moyen 18/25 (72%) avec niveau 3 points à surveiller.';
+    const sanitized = sanitizeAggregateText(raw);
+
+    expect(sanitized).not.toMatch(/\d/);
+    expect(sanitized).not.toMatch(/score|niveau|point/i);
+    expect(sanitized).toBe('moyen / () avec à surveiller.');
+  });
+});

--- a/tests/e2e/clinical-adaptation.spec.ts
+++ b/tests/e2e/clinical-adaptation.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+const loadAssessModule = async () => {
+  return await import('../../supabase/functions/_shared/assess.ts');
+};
+
+test.describe('Clinical adaptation signals', () => {
+  test('WHO5 low total suggests gentle dashboard tone', async () => {
+    const { summarizeAssessment } = await loadAssessModule();
+    const answers = { '1': 1, '2': 1, '3': 2, '4': 2, '5': 1 };
+    const result = summarizeAssessment('WHO5', answers);
+
+    expect(result.level).toBe(0);
+    expect(result.summary).toContain('douceur');
+  });
+
+  test('STAI-6 elevated responses map to high anxiety band', async () => {
+    const { summarizeAssessment } = await loadAssessModule();
+    const answers = { '1': 1, '2': 4, '3': 4, '4': 1, '5': 4, '6': 4 };
+    const result = summarizeAssessment('STAI6', answers);
+
+    expect(result.level).toBeGreaterThanOrEqual(3);
+    expect(result.summary).toContain('apaisement');
+  });
+
+  test('SUDS peak distress lands in escalation window', async () => {
+    const { summarizeAssessment } = await loadAssessModule();
+    const answers = { '1': 10 };
+    const result = summarizeAssessment('SUDS', answers);
+
+    expect(result.level).toBe(4);
+    expect(result.summary).toContain('détresse');
+  });
+
+  test('Aggregate summaries presented without numeric leakage', async () => {
+    const { sanitizeAggregateText } = await loadAssessModule();
+    const sanitized = sanitizeAggregateText('Score moyen 68% (niveau 3) - 12 points.');
+
+    expect(sanitized).not.toMatch(/\d/);
+    expect(sanitized).not.toMatch(/score|niveau|points?/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add vitest coverage to verify WHO-5 level thresholds, STAI-6 reversed scoring, and aggregate text sanitisation
- add playwright regression that exercises clinical summaries for WHO5, STAI-6, SUDS and aggregate outputs

## Testing
- npx vitest run supabase/tests/assess-utils.test.ts
- npx playwright test tests/e2e/clinical-adaptation.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68ce665738a4832d8da75f3af3326951