### PR TITLE
feat(observability): tighten clinical edge tracing and metrics

### DIFF
--- a/supabase/functions/_shared/assess.ts
+++ b/supabase/functions/_shared/assess.ts
@@ -392,11 +392,11 @@ function determineLevel(instrument: InstrumentCode, total: number, itemCount: nu
 function generateSummary(instrument: InstrumentCode, level: number): string {
   const summaries: Record<InstrumentCode, Record<number, string>> = {
     'WHO5': {
-      0: 'besoin de douceur',
-      1: 'moment plus délicat',
-      2: 'équilibre stable',
-      3: 'bonne forme',
-      4: 'très belle énergie'
+      0: 'bien-être fragile, besoin de douceur',
+      1: 'bien-être à renforcer',
+      2: 'bien-être stable',
+      3: 'bien-être élevé',
+      4: 'bien-être rayonnant'
     },
     'STAI6': {
       0: 'grande sérénité',
@@ -427,8 +427,10 @@ function generateSummary(instrument: InstrumentCode, level: number): string {
 export function sanitizeAggregateText(text: string): string {
   // Remove any numerical data that might leak individual scores
   return text
-    .replace(/\d+(\.\d+)?%?/g, '') // Remove all numbers
+    .replace(/\d+(?:\.\d+)?%?/g, '•') // Replace all numbers by bullet markers
     .replace(/score|niveau|points?/gi, '') // Remove scoring terms
+    .replace(/\s*•\s*/g, ' • ') // Normalize spacing around bullets
     .replace(/\s+/g, ' ') // Normalize whitespace
+    .replace(/• (?=[\.,])/g, '•') // Avoid spaces before punctuation
     .trim();
 }

--- a/supabase/functions/_shared/metrics.ts
+++ b/supabase/functions/_shared/metrics.ts
@@ -1,0 +1,66 @@
+import { createClient } from './supabase.ts';
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+
+const metricsClient = supabaseUrl && serviceKey ? createClient(supabaseUrl, serviceKey) : null;
+
+type EdgeLatencyOutcome = 'success' | 'error' | 'denied';
+
+interface EdgeLatencyMetric {
+  route: string;
+  durationMs: number;
+  status: number;
+  hashedUserId?: string | null;
+  hashedOrgId?: string | null;
+  stage?: string | null;
+  outcome?: EdgeLatencyOutcome;
+  error?: string | null;
+}
+
+function sanitizeMetricNumber(value: number): number {
+  if (!Number.isFinite(value) || value < 0) {
+    return 0;
+  }
+  return Math.round(value);
+}
+
+function resolveOutcome(metric: EdgeLatencyMetric): EdgeLatencyOutcome {
+  if (metric.outcome) {
+    return metric.outcome;
+  }
+  if (metric.status >= 500) {
+    return 'error';
+  }
+  if (metric.status >= 400) {
+    return 'denied';
+  }
+  return 'success';
+}
+
+export async function recordEdgeLatencyMetric(metric: EdgeLatencyMetric): Promise<void> {
+  if (!metricsClient) {
+    return;
+  }
+
+  const eventData = {
+    route: metric.route,
+    duration_ms: sanitizeMetricNumber(metric.durationMs),
+    status: metric.status,
+    outcome: resolveOutcome(metric),
+    stage: metric.stage ?? null,
+    user: metric.hashedUserId ?? null,
+    org: metric.hashedOrgId ?? null,
+    error: metric.error ?? null,
+  } as Record<string, unknown>;
+
+  try {
+    await metricsClient.from('analytics_events').insert({
+      event_type: 'edge.latency',
+      event_data: eventData,
+      created_at: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.warn('[observability] failed to record latency metric', error);
+  }
+}

--- a/supabase/functions/_shared/sentry.ts
+++ b/supabase/functions/_shared/sentry.ts
@@ -1,10 +1,115 @@
+import { hash } from './hash_user.ts';
+
 const SENTRY_DSN = Deno.env.get('SENTRY_DSN');
 const SENTRY_ENVIRONMENT = Deno.env.get('SENTRY_ENVIRONMENT') ?? 'edge';
 const SENTRY_RELEASE = Deno.env.get('SENTRY_RELEASE');
-const TRACES_SAMPLE_RATE = Number.parseFloat(Deno.env.get('SENTRY_TRACES_SAMPLE_RATE') ?? '0');
+const TRACES_SAMPLE_RATE = Number.parseFloat(Deno.env.get('SENTRY_TRACES_SAMPLE_RATE') ?? '');
 const IS_NODE_RUNTIME = typeof process !== 'undefined' && Boolean(process.versions?.node);
 
 let sentry: typeof import('https://esm.sh/@sentry/deno@8.22.0') | null = null;
+
+const EMAIL_REGEX = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
+const PHONE_REGEX = /(?:\+?\d[\s-.]?)?(?:\(?\d{2,3}\)?[\s-.]?)?\d{2,4}[\s-.]?\d{2,4}[\s-.]?\d{2,4}/g;
+const UUID_REGEX = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
+
+function clampSampleRate(rate: number | null): number {
+  if (!Number.isFinite(rate) || rate === null) {
+    return 0.15;
+  }
+  if (rate < 0.1) {
+    return 0.1;
+  }
+  if (rate > 0.2) {
+    return 0.2;
+  }
+  return rate;
+}
+
+function redactString(value: string): string {
+  if (!value) {
+    return value;
+  }
+  let sanitized = value
+    .replace(EMAIL_REGEX, '[email]')
+    .replace(UUID_REGEX, '[id]')
+    .replace(PHONE_REGEX, '[tel]');
+
+  if (sanitized.length > 80) {
+    try {
+      const digest = hash(sanitized);
+      return `[hash:${digest.slice(0, 16)}]`;
+    } catch {
+      return '[hash:redacted]';
+    }
+  }
+
+  return sanitized;
+}
+
+function sanitizeValue(value: unknown, depth = 0): unknown {
+  if (value === null || value === undefined) {
+    return value ?? null;
+  }
+
+  if (typeof value === 'string') {
+    return redactString(value);
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      return null;
+    }
+    return Math.round(value * 1000) / 1000;
+  }
+
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    if (depth >= 2) {
+      return value.length;
+    }
+    return value.slice(0, 10).map((entry) => sanitizeValue(entry, depth + 1));
+  }
+
+  if (typeof value === 'object') {
+    if (depth >= 2) {
+      return '[object]';
+    }
+    const entries = Object.entries(value as Record<string, unknown>)
+      .slice(0, 10)
+      .map(([key, val]) => [key, sanitizeValue(val, depth + 1)])
+      .filter(([, val]) => val !== undefined);
+    return Object.fromEntries(entries);
+  }
+
+  return null;
+}
+
+function sanitizeBreadcrumb(crumb: {
+  category: string;
+  message?: string;
+  data?: Record<string, unknown>;
+}) {
+  const sanitizedData = crumb.data ? sanitizeValue(crumb.data) : undefined;
+  return {
+    category: redactString(crumb.category),
+    message: crumb.message ? redactString(crumb.message) : undefined,
+    data:
+      sanitizedData && typeof sanitizedData === 'object'
+        ? (sanitizedData as Record<string, unknown>)
+        : undefined,
+  };
+}
+
+function sanitizeContext(context?: Record<string, unknown>) {
+  if (!context) {
+    return undefined;
+  }
+  const sanitized = sanitizeValue(context);
+  return typeof sanitized === 'object' && sanitized !== null ? (sanitized as Record<string, unknown>) : undefined;
+}
 
 if (SENTRY_DSN && !IS_NODE_RUNTIME) {
   try {
@@ -13,7 +118,30 @@ if (SENTRY_DSN && !IS_NODE_RUNTIME) {
       dsn: SENTRY_DSN,
       environment: SENTRY_ENVIRONMENT,
       release: SENTRY_RELEASE,
-      tracesSampleRate: Number.isFinite(TRACES_SAMPLE_RATE) ? Math.max(0, Math.min(1, TRACES_SAMPLE_RATE)) : 0,
+      tracesSampleRate: clampSampleRate(Number.isFinite(TRACES_SAMPLE_RATE) ? TRACES_SAMPLE_RATE : null),
+      beforeSend(event) {
+        if (event?.request?.headers) {
+          event.request.headers = {};
+        }
+        if (event?.request?.cookies) {
+          event.request.cookies = undefined;
+        }
+        if (event?.user) {
+          event.user = undefined;
+        }
+        if (event?.extra) {
+          event.extra = sanitizeContext(event.extra);
+        }
+        if (event?.tags) {
+          const sanitizedTags = sanitizeContext(event.tags);
+          event.tags = sanitizedTags
+            ? Object.fromEntries(
+                Object.entries(sanitizedTags).map(([key, value]) => [key, String(value ?? '')]),
+              )
+            : undefined;
+        }
+        return event;
+      },
     });
     sentry = mod;
     console.info('[observability] Sentry initialised for edge assessments');
@@ -44,10 +172,11 @@ export function addSentryBreadcrumb(crumb: { category: string; message?: string;
     return;
   }
   try {
+    const sanitized = sanitizeBreadcrumb(crumb);
     sentry.addBreadcrumb({
-      category: crumb.category,
-      message: crumb.message,
-      data: crumb.data,
+      category: sanitized.category,
+      message: sanitized.message,
+      data: sanitized.data,
       level: 'info',
       timestamp: Date.now() / 1000,
     });
@@ -62,8 +191,9 @@ export function captureSentryException(error: unknown, context?: Record<string, 
   }
   try {
     withSentryScope((scope) => {
-      if (context) {
-        for (const [key, value] of Object.entries(context)) {
+      const sanitizedContext = sanitizeContext(context);
+      if (sanitizedContext) {
+        for (const [key, value] of Object.entries(sanitizedContext)) {
           scope.setContext(key, { value } as Record<string, unknown>);
         }
       }

--- a/supabase/functions/assess-aggregate/index.ts
+++ b/supabase/functions/assess-aggregate/index.ts
@@ -10,6 +10,7 @@ import { hash } from '../_shared/hash_user.ts';
 import { logAccess } from '../_shared/logging.ts';
 import { addSentryBreadcrumb, captureSentryException } from '../_shared/sentry.ts';
 import { buildRateLimitResponse, enforceEdgeRateLimit } from '../_shared/rate-limit.ts';
+import { recordEdgeLatencyMetric } from '../_shared/metrics.ts';
 
 const aggregateSchema = z.object({
   org_id: z.string().min(1),
@@ -21,23 +22,45 @@ const SUPABASE_URL = Deno.env.get('SUPABASE_URL') ?? '';
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
 
 serve(async (req) => {
+  const startedAt = Date.now();
   const cors = resolveCors(req);
+  let hashedUserId: string | null = null;
+  let hashedOrgId: string | null = null;
+
+  const finalize = async (
+    response: Response,
+    metadata: { outcome?: 'success' | 'error' | 'denied'; stage?: string | null; error?: string | null } = {},
+  ) => {
+    await recordEdgeLatencyMetric({
+      route: 'assess-aggregate',
+      durationMs: Date.now() - startedAt,
+      status: response.status,
+      hashedUserId,
+      hashedOrgId,
+      outcome: metadata.outcome,
+      stage: metadata.stage ?? null,
+      error: metadata.error ?? null,
+    });
+    return response;
+  };
 
   if (req.method === 'OPTIONS') {
-    return preflightResponse(cors);
+    return finalize(preflightResponse(cors));
   }
 
   if (!cors.allowed) {
-    return rejectCors(cors);
+    return finalize(rejectCors(cors), { outcome: 'denied', error: 'origin_not_allowed' });
   }
 
   if (req.method !== 'POST') {
-    return appendCorsHeaders(new Response('Method Not Allowed', { status: 405 }), cors);
+    const response = appendCorsHeaders(new Response('Method Not Allowed', { status: 405 }), cors);
+    return finalize(response, { outcome: 'denied', error: 'method_not_allowed' });
   }
 
   if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
     console.error('[assess-aggregate] missing Supabase configuration');
-    return appendCorsHeaders(json(500, { error: 'configuration_error' }), cors);
+    const response = appendCorsHeaders(json(500, { error: 'configuration_error' }), cors);
+    return finalize(response, { outcome: 'error', error: 'configuration_error' });
   }
 
   try {
@@ -46,8 +69,11 @@ serve(async (req) => {
       if (auth.status === 401 || auth.status === 403) {
         await logUnauthorizedAccess(req, auth.error ?? 'unauthorized');
       }
-      return appendCorsHeaders(json(auth.status, { error: 'unauthorized' }), cors);
+      const response = appendCorsHeaders(json(auth.status, { error: 'unauthorized' }), cors);
+      return finalize(response, { outcome: 'denied', error: 'unauthorized' });
     }
+
+    hashedUserId = hash(auth.user.id);
 
     const rateDecision = await enforceEdgeRateLimit(req, {
       route: 'assess-aggregate',
@@ -55,21 +81,26 @@ serve(async (req) => {
       description: 'aggregate assessment rollups',
     });
     if (!rateDecision.allowed) {
-      return buildRateLimitResponse(rateDecision, cors.headers);
+      const response = buildRateLimitResponse(rateDecision, cors.headers);
+      return finalize(response, { outcome: 'denied', error: 'rate_limited' });
     }
 
     const body = await req.json().catch(() => null);
     if (!body) {
-      return appendCorsHeaders(json(422, { error: 'invalid_body' }), cors);
+      const response = appendCorsHeaders(json(422, { error: 'invalid_body' }), cors);
+      return finalize(response, { outcome: 'denied', error: 'invalid_body' });
     }
 
     const parsed = aggregateSchema.safeParse(body);
     if (!parsed.success) {
-      return appendCorsHeaders(json(422, { error: 'invalid_body', details: 'validation_failed' }), cors);
+      const response = appendCorsHeaders(json(422, { error: 'invalid_body', details: 'validation_failed' }), cors);
+      return finalize(response, { outcome: 'denied', error: 'validation_failed' });
     }
 
     const { org_id: orgId, period, instruments } = parsed.data;
     const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+    hashedOrgId = hash(orgId);
 
     let query = supabase
       .from('org_assess_rollups')
@@ -85,7 +116,8 @@ serve(async (req) => {
     if (error) {
       captureSentryException(error, { route: 'assess-aggregate', stage: 'db_read' });
       console.error('[assess-aggregate] failed to load rollups', { message: error.message });
-      return appendCorsHeaders(json(500, { error: 'read_failed' }), cors);
+      const response = appendCorsHeaders(json(500, { error: 'read_failed' }), cors);
+      return finalize(response, { outcome: 'error', error: 'read_failed', stage: 'db_read' });
     }
 
     const summaries = (data ?? [])
@@ -97,26 +129,30 @@ serve(async (req) => {
       }));
 
     addSentryBreadcrumb({
-      category: 'assess:aggregate',
-      message: 'aggregate served',
-      data: { instruments: summaries.map((entry) => entry.instrument) },
+      category: 'assess',
+      message: 'assess:aggregate:summaries_served',
+      data: {
+        instruments: summaries.map((entry) => entry.instrument),
+        latency_ms: Date.now() - startedAt,
+      },
     });
 
     await logAccess({
-      user_id: hash(auth.user.id),
+      user_id: hashedUserId,
       role: auth.user.user_metadata?.role ?? null,
       route: 'assess-aggregate',
       action: 'assess:aggregate',
       result: 'success',
       user_agent: 'redacted',
-      details: `org=${hash(orgId)};period=${period}`,
+      details: `org=${hashedOrgId};period=${period}`,
     });
 
-    const response = json(200, { summaries });
-    return appendCorsHeaders(response, cors);
+    const response = appendCorsHeaders(json(200, { summaries }), cors);
+    return finalize(response, { outcome: 'success', stage: 'summaries_served' });
   } catch (error) {
     captureSentryException(error, { route: 'assess-aggregate' });
     console.error('[assess-aggregate] unexpected error', { message: error instanceof Error ? error.message : 'unknown' });
-    return appendCorsHeaders(json(500, { error: 'internal_error' }), cors);
+    const response = appendCorsHeaders(json(500, { error: 'internal_error' }), cors);
+    return finalize(response, { outcome: 'error', error: 'internal_error' });
   }
 });

--- a/supabase/functions/assess-start/index.ts
+++ b/supabase/functions/assess-start/index.ts
@@ -9,6 +9,7 @@ import { hash } from '../_shared/hash_user.ts';
 import { logAccess } from '../_shared/logging.ts';
 import { addSentryBreadcrumb, captureSentryException } from '../_shared/sentry.ts';
 import { buildRateLimitResponse, enforceEdgeRateLimit } from '../_shared/rate-limit.ts';
+import { recordEdgeLatencyMetric } from '../_shared/metrics.ts';
 
 const requestSchema = z.object({
   instrument: instrumentSchema,
@@ -16,18 +17,37 @@ const requestSchema = z.object({
 });
 
 serve(async (req) => {
+  const startedAt = Date.now();
   const cors = resolveCors(req);
+  let hashedUserId: string | null = null;
+
+  const finalize = async (
+    response: Response,
+    metadata: { outcome?: 'success' | 'error' | 'denied'; stage?: string | null; error?: string | null } = {},
+  ) => {
+    await recordEdgeLatencyMetric({
+      route: 'assess-start',
+      durationMs: Date.now() - startedAt,
+      status: response.status,
+      hashedUserId,
+      outcome: metadata.outcome,
+      stage: metadata.stage ?? null,
+      error: metadata.error ?? null,
+    });
+    return response;
+  };
 
   if (req.method === 'OPTIONS') {
-    return preflightResponse(cors);
+    return finalize(preflightResponse(cors));
   }
 
   if (!cors.allowed) {
-    return rejectCors(cors);
+    return finalize(rejectCors(cors), { outcome: 'denied', error: 'origin_not_allowed' });
   }
 
   if (req.method !== 'POST') {
-    return appendCorsHeaders(new Response('Method Not Allowed', { status: 405 }), cors);
+    const response = appendCorsHeaders(new Response('Method Not Allowed', { status: 405 }), cors);
+    return finalize(response, { outcome: 'denied', error: 'method_not_allowed' });
   }
 
   try {
@@ -36,8 +56,11 @@ serve(async (req) => {
       if (auth.status === 401 || auth.status === 403) {
         await logUnauthorizedAccess(req, auth.error ?? 'unauthorized');
       }
-      return appendCorsHeaders(json(auth.status, { error: 'unauthorized' }), cors);
+      const response = appendCorsHeaders(json(auth.status, { error: 'unauthorized' }), cors);
+      return finalize(response, { outcome: 'denied', error: 'unauthorized' });
     }
+
+    hashedUserId = hash(auth.user.id);
 
     const rateDecision = await enforceEdgeRateLimit(req, {
       route: 'assess-start',
@@ -45,30 +68,33 @@ serve(async (req) => {
       description: 'start assessment instrument delivery',
     });
     if (!rateDecision.allowed) {
-      return buildRateLimitResponse(rateDecision, cors.headers);
+      const response = buildRateLimitResponse(rateDecision, cors.headers);
+      return finalize(response, { outcome: 'denied', error: 'rate_limited' });
     }
 
     const body = await req.json().catch(() => null);
     if (!body) {
-      return appendCorsHeaders(json(422, { error: 'invalid_body' }), cors);
+      const response = appendCorsHeaders(json(422, { error: 'invalid_body' }), cors);
+      return finalize(response, { outcome: 'denied', error: 'invalid_body' });
     }
 
     const parsed = requestSchema.safeParse(body);
     if (!parsed.success) {
-      return appendCorsHeaders(json(422, { error: 'invalid_body', details: 'validation_failed' }), cors);
+      const response = appendCorsHeaders(json(422, { error: 'invalid_body', details: 'validation_failed' }), cors);
+      return finalize(response, { outcome: 'denied', error: 'validation_failed' });
     }
 
     const { instrument, locale } = parsed.data;
     const catalog = getCatalog(instrument, locale ?? 'fr');
 
     addSentryBreadcrumb({
-      category: 'assess:start',
-      message: 'catalog served',
-      data: { instrument },
+      category: 'assess',
+      message: 'assess:start:catalog_served',
+      data: { instrument, latency_ms: Date.now() - startedAt },
     });
 
     await logAccess({
-      user_id: hash(auth.user.id),
+      user_id: hashedUserId,
       role: auth.user.user_metadata?.role ?? null,
       route: 'assess-start',
       action: 'assess:start',
@@ -77,11 +103,13 @@ serve(async (req) => {
       details: `instrument=${instrument}`,
     });
 
-    const response = json(200, catalog);
-    return appendCorsHeaders(response, cors);
+    const responsePayload = { instrument, locale: locale ?? 'fr', ...catalog };
+    const response = appendCorsHeaders(json(200, responsePayload), cors);
+    return finalize(response, { outcome: 'success', stage: 'catalog_served' });
   } catch (error) {
     captureSentryException(error, { route: 'assess-start' });
     console.error('[assess-start] unexpected error', { message: error instanceof Error ? error.message : 'unknown' });
-    return appendCorsHeaders(json(500, { error: 'internal_error' }), cors);
+    const response = appendCorsHeaders(json(500, { error: 'internal_error' }), cors);
+    return finalize(response, { outcome: 'error', error: 'internal_error' });
   }
 });

--- a/supabase/tests/assess-functions.test.ts
+++ b/supabase/tests/assess-functions.test.ts
@@ -30,6 +30,11 @@ vi.mock('../functions/_shared/sentry.ts', () => ({
   captureSentryException: (...args: unknown[]) => captureSentryExceptionMock(...args),
 }));
 
+const recordEdgeLatencyMetricMock = vi.fn();
+vi.mock('../functions/_shared/metrics.ts', () => ({
+  recordEdgeLatencyMetric: (...args: unknown[]) => recordEdgeLatencyMetricMock(...args),
+}));
+
 vi.mock('../functions/_shared/serve.ts', () => ({
   serve: (handler: (req: Request) => Promise<Response>) => {
     handlerRef.current = handler;
@@ -71,6 +76,7 @@ beforeEach(() => {
   supabaseClientMock.mockReset();
   addSentryBreadcrumbMock.mockReset();
   captureSentryExceptionMock.mockReset();
+  recordEdgeLatencyMetricMock.mockReset();
   resetEdgeRateLimits();
   envStore.SUPABASE_URL = 'https://example.supabase.co';
   envStore.SUPABASE_ANON_KEY = 'anon-key';
@@ -168,7 +174,12 @@ describe('assess-start function', () => {
       result: 'success',
     }));
     expect(addSentryBreadcrumbMock).toHaveBeenCalledWith(expect.objectContaining({
-      category: 'assess:start',
+      category: 'assess',
+      message: 'assess:start:catalog_served',
+    }));
+    expect(recordEdgeLatencyMetricMock).toHaveBeenCalledWith(expect.objectContaining({
+      route: 'assess-start',
+      status: 200,
     }));
   });
 
@@ -260,6 +271,14 @@ describe('assess-submit function', () => {
       route: 'assess-submit',
       action: 'assess:submit',
       result: 'success',
+    }));
+    expect(addSentryBreadcrumbMock).toHaveBeenCalledWith(expect.objectContaining({
+      category: 'assess',
+      message: 'assess:submit:summary_generated',
+    }));
+    expect(recordEdgeLatencyMetricMock).toHaveBeenCalledWith(expect.objectContaining({
+      route: 'assess-submit',
+      status: 200,
     }));
   });
 
@@ -364,11 +383,16 @@ describe('assess-aggregate function', () => {
     expect(payload.summaries[0].text).toContain('•');
     expect(inMock).not.toHaveBeenCalled();
     expect(addSentryBreadcrumbMock).toHaveBeenCalledWith(expect.objectContaining({
-      category: 'assess:aggregate',
+      category: 'assess',
+      message: 'assess:aggregate:summaries_served',
     }));
     expect(logAccessMock).toHaveBeenCalledWith(expect.objectContaining({
       route: 'assess-aggregate',
       action: 'assess:aggregate',
+    }));
+    expect(recordEdgeLatencyMetricMock).toHaveBeenCalledWith(expect.objectContaining({
+      route: 'assess-aggregate',
+      status: 200,
     }));
     expect(supabaseClientMock).toHaveBeenCalledWith('https://example.supabase.co', 'service-role-key');
     expect(fromMock).toHaveBeenCalledWith('org_assess_rollups');


### PR DESCRIPTION
## Summary
- normalize Sentry breadcrumbs for assessment endpoints and orchestrations while scrubbing sensitive fields
- introduce shared edge latency metrics logging and apply latency sampling to assess start/submit/aggregate flows
- capture orchestration hint application breadcrumbs on the client and enhance qualitative summaries/aggregation sanitization

## Testing
- npx vitest run supabase/tests/assess-functions.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ce66622084832da2f12a0911619d5a