### PR TITLE
feat: hook B2B heatmap page to aggregate query

### DIFF
--- a/src/pages/b2b/reports/index.tsx
+++ b/src/pages/b2b/reports/index.tsx
@@ -2,13 +2,11 @@ import React from 'react';
 import * as Sentry from '@sentry/react';
 import dayjs from 'dayjs';
 import isoWeek from 'dayjs/plugin/isoWeek';
-import { useQuery } from '@tanstack/react-query';
 import { Printer } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { B2BHeatmap } from '@/features/b2b/reports/B2BHeatmap';
 import { ExportButton } from '@/features/b2b/reports/ExportButton';
-import { DEFAULT_INSTRUMENTS, getHeatmap } from '@/services/b2b/reportsApi';
-import { type HeatmapCell } from '@/features/b2b/reports/utils';
+import { DEFAULT_INSTRUMENTS, useHeatmap } from '@/services/b2b/reportsApi';
 import { performanceMonitor } from '@/lib/performance/performanceMonitor';
 import { Button } from '@/components/ui/button';
 import {
@@ -59,26 +57,10 @@ export default function B2BReportsHeatmapPage() {
     return () => mediaQuery.removeEventListener('change', handleChange);
   }, []);
 
-  const query = useQuery<HeatmapCell[]>({
-    queryKey: ['b2b-heatmap', orgId, period, selectedInstrument],
-    enabled: Boolean(orgId && period),
-    staleTime: 60_000,
-    refetchOnWindowFocus: false,
-    queryFn: async () => {
-      if (!orgId) {
-        return [];
-      }
-      const start = typeof performance !== 'undefined' ? performance.now() : null;
-      const cells = await getHeatmap({
-        orgId,
-        period,
-        instruments: selectedInstrument === INSTRUMENT_OPTION_ALL ? undefined : [selectedInstrument],
-      });
-      if (start != null && typeof performance !== 'undefined') {
-        performanceMonitor.recordMetric('b2b_reports.fetch_latency', performance.now() - start);
-      }
-      return cells;
-    },
+  const query = useHeatmap({
+    orgId,
+    period,
+    instruments: selectedInstrument === INSTRUMENT_OPTION_ALL ? undefined : [selectedInstrument],
   });
 
   const teamOptions = React.useMemo(() => {


### PR DESCRIPTION
## Summary
- expose a `useHeatmap` React Query hook in the B2B reports service backed by the `/assess/aggregate` edge function
- reuse the new hook inside `/b2b/reports` while keeping the existing filters, PNG export and print integration

## Testing
- npx eslint src/services/b2b/reportsApi.ts src/pages/b2b/reports/index.tsx
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68ce666e585c832dbd827073e62dd77e