### PR TITLE
feat(db): harden assessments rollups rls

### DIFF
--- a/supabase/migrations/202512011000_mig_db_01.sql
+++ b/supabase/migrations/202512011000_mig_db_01.sql
@@ -1,0 +1,109 @@
+-- migrate:up
+-- Ensure query performance indexes exist for assessments and rollups
+create index if not exists idx_assessments_instrument_ts on public.assessments (instrument, ts desc);
+create index if not exists idx_org_rollups_org_period_instrument on public.org_assess_rollups (org_id, period, instrument);
+
+-- Harden RLS for assessments: owner access enforced
+alter table public.assessments enable row level security;
+alter table public.assessments force row level security;
+
+drop policy if exists "assessments_owner_access" on public.assessments;
+drop policy if exists "assessments_select_own" on public.assessments;
+drop policy if exists "assessments_insert_own" on public.assessments;
+drop policy if exists "assess_all_own" on public.assessments;
+drop policy if exists "assess_select_own" on public.assessments;
+
+create policy "assessments_owner_access" on public.assessments
+  for all using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- Harden RLS for clinical_signals: owner access enforced
+alter table public.clinical_signals enable row level security;
+alter table public.clinical_signals force row level security;
+
+drop policy if exists "clinical_signals_owner_access" on public.clinical_signals;
+drop policy if exists "signals_select_own" on public.clinical_signals;
+drop policy if exists "signals_manage_own" on public.clinical_signals;
+
+drop policy if exists "signals_service_access" on public.clinical_signals;
+
+create policy "clinical_signals_owner_access" on public.clinical_signals
+  for all using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "clinical_signals_service_access" on public.clinical_signals
+  for all using (auth.jwt() ->> 'role' = 'service_role')
+  with check (true);
+
+-- Enforce minimum cohort size via RLS on org_assess_rollups
+alter table public.org_assess_rollups enable row level security;
+alter table public.org_assess_rollups force row level security;
+
+drop policy if exists "org_rollups_admin_access" on public.org_assess_rollups;
+
+drop policy if exists "org_rollups_min_n_guard" on public.org_assess_rollups;
+
+create policy "org_rollups_min_n_guard" on public.org_assess_rollups
+  for all using (
+    n >= 5
+    and (
+      auth.jwt() ->> 'role' = 'service_role'
+      or exists (
+        select 1
+        from public.profiles p
+        where p.id = auth.uid()
+          and p.role in ('admin', 'b2b_manager')
+      )
+    )
+  )
+  with check (n >= 5);
+
+-- migrate:down
+-- Roll back indexes
+drop index if exists idx_org_rollups_org_period_instrument;
+drop index if exists idx_assessments_instrument_ts;
+
+-- Restore previous assessment policies
+alter table public.assessments no force row level security;
+alter table public.assessments disable row level security;
+alter table public.assessments enable row level security;
+
+create policy "assessments_select_own" on public.assessments
+  for select using (auth.uid() = user_id);
+
+create policy "assessments_insert_own" on public.assessments
+  for insert with check (auth.uid() = user_id);
+
+create policy "assess_all_own" on public.assessments
+  for all using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- Restore clinical_signals policies
+alter table public.clinical_signals no force row level security;
+alter table public.clinical_signals disable row level security;
+alter table public.clinical_signals enable row level security;
+
+create policy "signals_select_own" on public.clinical_signals
+  for select using (auth.uid() = user_id);
+
+create policy "signals_manage_own" on public.clinical_signals
+  for all using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "signals_service_access" on public.clinical_signals
+  for all using (auth.jwt() ->> 'role' = 'service_role');
+
+-- Restore rollup policy baseline
+alter table public.org_assess_rollups no force row level security;
+alter table public.org_assess_rollups disable row level security;
+alter table public.org_assess_rollups enable row level security;
+
+create policy "org_rollups_admin_access" on public.org_assess_rollups
+  for all using (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.role in ('admin', 'b2b_manager')
+    )
+  );

--- a/supabase/seeds/dev_assessments.sql
+++ b/supabase/seeds/dev_assessments.sql
@@ -22,3 +22,26 @@ values
   (:'demo_org_id'::uuid, '2025-W38', 'WEMWBS', 7, 'semaine plutôt posée'),
   (:'demo_org_id'::uuid, '2025-W38', 'UWES', 6, 'engagement stable')
 on conflict do nothing;
+
+insert into public.clinical_signals (
+  user_id,
+  source_instrument,
+  domain,
+  level,
+  window_type,
+  module_context,
+  metadata,
+  expires_at
+)
+values
+  (
+    :'demo_uid'::uuid,
+    'WHO5',
+    'wellbeing',
+    3,
+    'weekly',
+    'spotlight',
+    '{"note":"signal e2e"}',
+    now() + interval '7 days'
+  )
+on conflict do nothing;

--- a/supabase/tests/assessments_checks.sql
+++ b/supabase/tests/assessments_checks.sql
@@ -26,6 +26,21 @@ where c.relname in ('assessments')
 group by c.relname
 order by c.relname;
 
+\echo '\n== Index coverage (assessments & rollups) =='
+select indexname, tablename
+from pg_indexes
+where schemaname = 'public'
+  and indexname in (
+    'idx_assessments_instrument_ts',
+    'idx_org_rollups_org_period_instrument'
+  )
+order by tablename, indexname;
+
+\echo '\n== RLS policy clauses (org_assess_rollups) =='
+select policyname, cmd, qual, with_check
+from pg_policies
+where schemaname = 'public' and tablename = 'org_assess_rollups';
+
 \echo '\n== Constraint definition (org_assess_rollups) =='
 select conname, pg_get_constraintdef(oid) as definition
 from pg_constraint

--- a/tests/sql/_e2e_seeds.sql
+++ b/tests/sql/_e2e_seeds.sql
@@ -5,3 +5,39 @@ INSERT INTO users (id, email, role) VALUES
   (3, 'b2b_admin@example.com', 'b2b_admin');
 
 -- Additional seed data for modules can be inserted here
+INSERT INTO public.assessments (id, user_id, instrument, score_json, ts)
+VALUES
+  (
+    '00000000-0000-0000-0000-000000000101',
+    '00000000-0000-0000-0000-000000000001',
+    'WHO5',
+    '{"summary":"e2e"}',
+    now()
+  )
+ON CONFLICT DO NOTHING;
+
+INSERT INTO public.org_assess_rollups (id, org_id, period, instrument, n, text_summary)
+VALUES
+  (
+    '00000000-0000-0000-0000-000000000201',
+    '11111111-1111-1111-1111-111111111111',
+    '2025-W38',
+    'WHO5',
+    6,
+    'agrégat e2e'
+  )
+ON CONFLICT DO NOTHING;
+
+INSERT INTO public.clinical_signals (id, user_id, source_instrument, domain, level, window_type, module_context, expires_at)
+VALUES
+  (
+    '00000000-0000-0000-0000-000000000301',
+    '00000000-0000-0000-0000-000000000001',
+    'WHO5',
+    'wellbeing',
+    3,
+    'weekly',
+    'spotlight',
+    now() + interval '7 days'
+  )
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary
- add migration to enforce owner-based RLS on assessments and clinical signals and guard org rollups with n >= 5 while adding supporting indexes
- extend supabase checks and seeds with lightweight data for assessments, rollups, and clinical signals used in e2e flows

## Testing
- npm run test:db *(fails: vitest config vitest.db.config.ts is missing in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce667c85f4832d9d8696fc68e660fb