### PR TITLE
Refactor stores to drop zustand middleware and add memoized selectors

### DIFF
--- a/src/hooks/useMood.ts
+++ b/src/hooks/useMood.ts
@@ -1,7 +1,9 @@
 
 import React from 'react';
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+
+import { persist } from '@/store/utils/createImmutableStore';
+import { createSelectors } from '@/store/utils/createSelectors';
 import { mapMoodToVibe, type MoodVibe } from '@/utils/moodVibes';
 
 interface MoodState {
@@ -21,11 +23,9 @@ interface MoodStore extends MoodState {
   setError: (error: string | null) => void;
 }
 
-// Store Zustand avec persistance
-export const useMoodStore = create<MoodStore>()(
+const moodStoreBase = create<MoodStore>()(
   persist(
     (set, get) => ({
-      // État initial
       valence: 0,
       arousal: 50,
       timestamp: new Date().toISOString(),
@@ -33,7 +33,6 @@ export const useMoodStore = create<MoodStore>()(
       vibe: 'calm',
       error: null,
 
-      // Actions
       updateMood: (valence: number, arousal: number) => {
         const clampedValence = Math.max(-100, Math.min(100, valence));
         const clampedArousal = Math.max(0, Math.min(100, arousal));
@@ -44,28 +43,24 @@ export const useMoodStore = create<MoodStore>()(
           arousal: clampedArousal,
           vibe,
           timestamp,
-          error: null
+          error: null,
         });
 
-        // Publier l'événement mood.updated (simulation)
         if (typeof window !== 'undefined') {
           window.dispatchEvent(new CustomEvent('mood.updated', {
-            detail: { valence: clampedValence, arousal: clampedArousal, vibe, timestamp }
+            detail: { valence: clampedValence, arousal: clampedArousal, vibe, timestamp },
           }));
         }
       },
 
       fetchCurrentMood: async () => {
         set({ isLoading: true, error: null });
-        
+
         try {
-          // Simulation de l'appel API
-          // En production: const response = await fetch('/edge/humeur/current?user_id=' + userId);
           await new Promise(resolve => setTimeout(resolve, 500));
-          
-          // Données mockées pour le développement
-          const mockValence = Math.floor(Math.random() * 201) - 100; // -100 à +100
-          const mockArousal = Math.floor(Math.random() * 101); // 0 à 100
+
+          const mockValence = Math.floor(Math.random() * 201) - 100;
+          const mockArousal = Math.floor(Math.random() * 101);
           const mockTimestamp = new Date().toISOString();
           const mockMood = {
             valence: mockValence,
@@ -77,12 +72,12 @@ export const useMoodStore = create<MoodStore>()(
           set({
             ...mockMood,
             isLoading: false,
-            error: null
+            error: null,
           });
         } catch (error) {
           set({
             isLoading: false,
-            error: error instanceof Error ? error.message : 'Erreur inconnue'
+            error: error instanceof Error ? error.message : 'Erreur inconnue',
           });
         }
       },
@@ -93,12 +88,12 @@ export const useMoodStore = create<MoodStore>()(
           arousal: 50,
           vibe: 'calm',
           timestamp: new Date().toISOString(),
-          error: null
+          error: null,
         });
       },
 
       setLoading: (loading: boolean) => set({ isLoading: loading }),
-      setError: (error: string | null) => set({ error })
+      setError: (error: string | null) => set({ error }),
     }),
     {
       name: 'emotions-care-mood',
@@ -107,23 +102,21 @@ export const useMoodStore = create<MoodStore>()(
   )
 );
 
-// Hook principal pour utiliser le mood
+export const useMoodStore = createSelectors(moodStoreBase);
+
 export const useMood = () => {
   const store = useMoodStore();
 
-  // Auto-fetch au premier montage si pas de données récentes
   React.useEffect(() => {
     const lastUpdate = new Date(store.timestamp);
     const now = new Date();
     const diffMinutes = (now.getTime() - lastUpdate.getTime()) / (1000 * 60);
 
-    // Refresh si les données ont plus de 30 minutes
     if (diffMinutes > 30) {
       store.fetchCurrentMood();
     }
   }, []);
 
-  // Écoute des événements mood.updated (WebSocket simulation)
   React.useEffect(() => {
     const handleMoodUpdate = (event: CustomEvent) => {
       const { valence, arousal, timestamp, vibe } = event.detail as {
@@ -143,7 +136,7 @@ export const useMood = () => {
     };
 
     window.addEventListener('mood.updated', handleMoodUpdate as EventListener);
-    
+
     return () => {
       window.removeEventListener('mood.updated', handleMoodUpdate as EventListener);
     };
@@ -152,13 +145,12 @@ export const useMood = () => {
   return store;
 };
 
-// Helpers pour adapter l'UI selon l'humeur
 export const getMoodColor = (valence: number, arousal: number): string => {
-  if (valence > 50 && arousal > 70) return '#10b981'; // Vert énergique
-  if (valence > 50 && arousal < 30) return '#3b82f6'; // Bleu calme positif
-  if (valence < -50 && arousal > 70) return '#ef4444'; // Rouge agité
-  if (valence < -50 && arousal < 30) return '#6b7280'; // Gris triste
-  return '#8b5cf6'; // Violet neutre
+  if (valence > 50 && arousal > 70) return '#10b981';
+  if (valence > 50 && arousal < 30) return '#3b82f6';
+  if (valence < -50 && arousal > 70) return '#ef4444';
+  if (valence < -50 && arousal < 30) return '#6b7280';
+  return '#8b5cf6';
 };
 
 export const getMoodEmoji = (valence: number, arousal: number): string => {

--- a/src/store/activity.store.ts
+++ b/src/store/activity.store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist } from './utils/createImmutableStore';
+import { createSelectors } from './utils/createSelectors';
 
 type ModuleId =
   | 'boss_grit'|'mood_mixer'|'ambition_arcade'|'bounce_back'|'story_synth'
@@ -50,7 +51,7 @@ const initialFilters: ActivityFilters = {
   search: ''
 };
 
-export const useActivityStore = create<ActivityState>()(
+const useActivityStoreBase = create<ActivityState>()(
   persist(
     (set) => ({
       filters: initialFilters,
@@ -93,3 +94,5 @@ export const useActivityStore = create<ActivityState>()(
     }
   )
 );
+
+export const useActivityStore = createSelectors(useActivityStoreBase);

--- a/src/store/ambition.store.ts
+++ b/src/store/ambition.store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist } from './utils/createImmutableStore';
+import { createSelectors } from './utils/createSelectors';
 
 export interface Upgrade {
   id: string;
@@ -132,7 +133,7 @@ const initialState: AmbitionStoreState = {
   questStartTime: null,
 };
 
-export const useAmbitionStore = create<AmbitionStore>()(
+const useAmbitionStoreBase = create<AmbitionStore>()(
   persist(
     (set, get) => ({
       ...initialState,
@@ -268,3 +269,5 @@ export const useAmbitionStore = create<AmbitionStore>()(
     }
   )
 );
+
+export const useAmbitionStore = createSelectors(useAmbitionStoreBase);

--- a/src/store/ar.store.ts
+++ b/src/store/ar.store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist } from './utils/createImmutableStore';
+import { createSelectors } from './utils/createSelectors';
 
 export type Emotion = 'joy' | 'calm' | 'sad' | 'anger' | 'fear' | 'surprise' | 'neutral';
 
@@ -58,7 +59,7 @@ const initialState: ARState = {
   error: null,
 };
 
-export const useARStore = create<ARStore>()(
+const useARStoreBase = create<ARStore>()(
   persist(
     (set, get) => ({
       ...initialState,
@@ -120,3 +121,5 @@ export const useARStore = create<ARStore>()(
     }
   )
 );
+
+export const useARStore = createSelectors(useARStoreBase);

--- a/src/store/bounce.store.ts
+++ b/src/store/bounce.store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist } from './utils/createImmutableStore';
+import { createSelectors } from './utils/createSelectors';
 
 export interface StimulusSpec {
   kind: 'mail' | 'notif' | 'timer';
@@ -104,7 +105,7 @@ const initialState: BounceStoreState = {
   tipReceived: null,
 };
 
-export const useBounceStore = create<BounceStore>()(
+const useBounceStoreBase = create<BounceStore>()(
   persist(
     (set, get) => ({
       ...initialState,
@@ -305,3 +306,5 @@ export const useBounceStore = create<BounceStore>()(
     }
   )
 );
+
+export const useBounceStore = createSelectors(useBounceStoreBase);

--- a/src/store/collection.store.ts
+++ b/src/store/collection.store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist } from './utils/createImmutableStore';
+import { createSelectors } from './utils/createSelectors';
 import { UserCollection, Reward, RewardType } from '@/types/rewards';
 
 interface CollectionState {
@@ -15,7 +16,7 @@ interface CollectionState {
   getCollectionProgress: () => { [key in RewardType]: number };
 }
 
-export const useCollectionStore = create<CollectionState>()(
+const useCollectionStoreBase = create<CollectionState>()(
   persist(
     (set, get) => ({
       collection: {
@@ -127,3 +128,5 @@ export const useCollectionStore = create<CollectionState>()(
     }
   )
 );
+
+export const useCollectionStore = createSelectors(useCollectionStoreBase);

--- a/src/store/feedback.store.ts
+++ b/src/store/feedback.store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist } from './utils/createImmutableStore';
+import { createSelectors } from './utils/createSelectors';
 
 export type FeedbackCategory = 'bug'|'suggestion'|'other';
 
@@ -33,7 +34,7 @@ type FeedbackState = {
   clearDraft: () => void;
 };
 
-export const useFeedbackStore = create<FeedbackState>()(
+const useFeedbackStoreBase = create<FeedbackState>()(
   persist(
     (set) => ({
       isOpen: false,
@@ -74,3 +75,5 @@ export const useFeedbackStore = create<FeedbackState>()(
     }
   )
 );
+
+export const useFeedbackStore = createSelectors(useFeedbackStoreBase);

--- a/src/store/gamification.store.ts
+++ b/src/store/gamification.store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist } from './utils/createImmutableStore';
+import { createSelectors } from './utils/createSelectors';
 
 export type Scope = 'friends' | 'org' | 'global';
 export type Period = '7d' | '30d';
@@ -71,7 +72,7 @@ const initialState = {
   nextCursor: null,
 };
 
-export const useGamificationStore = create<GamificationState>()(
+const useGamificationStoreBase = create<GamificationState>()(
   persist(
     (set, get) => ({
       ...initialState,
@@ -125,3 +126,5 @@ export const useGamificationStore = create<GamificationState>()(
     }
   )
 );
+
+export const useGamificationStore = createSelectors(useGamificationStoreBase);

--- a/src/store/glow.store.ts
+++ b/src/store/glow.store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist } from './utils/createImmutableStore';
+import { createSelectors } from './utils/createSelectors';
 
 export type GlowPattern = '4-2-4' | '4-6-8' | '5-5';
 
@@ -68,7 +69,7 @@ const initialState: GlowState = {
   enableHaptic: true,
 };
 
-export const useGlowStore = create<GlowStore>()(
+const useGlowStoreBase = create<GlowStore>()(
   persist(
     (set, get) => ({
       ...initialState,
@@ -180,3 +181,5 @@ export const useGlowStore = create<GlowStore>()(
     }
   )
 );
+
+export const useGlowStore = createSelectors(useGlowStoreBase);

--- a/src/store/hr.store.ts
+++ b/src/store/hr.store.ts
@@ -1,5 +1,7 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+
+import { createImmutableStore } from './utils/createImmutableStore';
+import { createSelectors } from './utils/createSelectors';
 
 export type HRSource = 'ble' | 'sim';
 
@@ -58,91 +60,60 @@ const initialState: HRState = {
   isSupported: typeof navigator !== 'undefined' && 'bluetooth' in navigator,
 };
 
-export const useHRStore = create<HRStore>()(
-  persist(
+const hrStoreBase = create<HRStore>()(
+  createImmutableStore(
     (set, get) => ({
       ...initialState,
-      
+
       setBpm: (bpm: number | null) => {
-        // Validate BPM range
         if (bpm !== null && (bpm < 30 || bpm > 220)) {
           console.warn('Invalid BPM value:', bpm);
           return;
         }
         set({ bpm });
       },
-      
-      setSource: (source: HRSource) => {
-        set({ source });
-      },
-      
-      setConnected: (connected: boolean) => {
-        set({ connected });
-      },
-      
-      setConnecting: (connecting: boolean) => {
-        set({ connecting });
-      },
-      
-      setDevice: (device: BluetoothDevice | null) => {
-        set({ device });
-      },
-      
-      setCharacteristic: (characteristic: BluetoothRemoteGATTCharacteristic | null) => {
-        set({ characteristic });
-      },
-      
+
+      setSource: (source: HRSource) => set({ source }),
+      setConnected: (connected: boolean) => set({ connected }),
+      setConnecting: (connecting: boolean) => set({ connecting }),
+      setDevice: (device: BluetoothDevice | null) => set({ device }),
+      setCharacteristic: (characteristic: BluetoothRemoteGATTCharacteristic | null) => set({ characteristic }),
+
       addReading: (reading: HRReading) => {
         const state = get();
         const newReadings = [...state.readings, reading];
-        
-        // Keep only last 50 readings for memory efficiency
+
         if (newReadings.length > 50) {
           newReadings.shift();
         }
-        
+
         set({ readings: newReadings });
         get().updateAvgBpm();
       },
-      
+
       updateAvgBpm: () => {
         const state = get();
         if (state.readings.length === 0) {
           set({ avgBpm: null });
           return;
         }
-        
-        // Calculate EMA (Exponential Moving Average)
-        const alpha = 0.1; // Smoothing factor
+
+        const alpha = 0.1;
         let ema = state.readings[0].bpm;
-        
+
         for (let i = 1; i < state.readings.length; i++) {
           ema = alpha * state.readings[i].bpm + (1 - alpha) * ema;
         }
-        
+
         set({ avgBpm: Math.round(ema) });
       },
-      
-      startSession: () => {
-        set({ sessionStart: Date.now(), readings: [] });
-      },
-      
-      endSession: () => {
-        set({ sessionStart: null });
-      },
-      
-      setReducedMotion: (reducedMotion: boolean) => {
-        set({ reducedMotion });
-      },
-      
-      setError: (error: string | null) => {
-        set({ error });
-      },
-      
-      setSupported: (isSupported: boolean) => {
-        set({ isSupported });
-      },
-      
+
+      startSession: () => set({ sessionStart: Date.now(), readings: [] }),
+      endSession: () => set({ sessionStart: null }),
+      setReducedMotion: (reducedMotion: boolean) => set({ reducedMotion }),
+      setError: (error: string | null) => set({ error }),
+      setSupported: (isSupported: boolean) => set({ isSupported }),
+
       reset: () => {
         const { reducedMotion, isSupported } = get();
         set({
@@ -153,10 +124,14 @@ export const useHRStore = create<HRStore>()(
       },
     }),
     {
-      name: 'hr-store',
-      partialize: (state) => ({
-        reducedMotion: state.reducedMotion,
-      }),
+      persist: {
+        name: 'hr-store',
+        partialize: (state) => ({
+          reducedMotion: state.reducedMotion,
+        }),
+      },
     }
   )
 );
+
+export const useHRStore = createSelectors(hrStoreBase);

--- a/src/store/marketing.store.ts
+++ b/src/store/marketing.store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist } from './utils/createImmutableStore';
+import { createSelectors } from './utils/createSelectors';
 
 export type Segment = 'b2c' | 'b2b';
 
@@ -22,7 +23,7 @@ type MarketingState = {
   reset: () => void;
 };
 
-export const useMarketingStore = create<MarketingState>()(
+const useMarketingStoreBase = create<MarketingState>()(
   persist(
     (set) => ({
       segment: 'b2c', // Default to B2C
@@ -49,3 +50,5 @@ export const useMarketingStore = create<MarketingState>()(
     }
   )
 );
+
+export const useMarketingStore = createSelectors(useMarketingStoreBase);

--- a/src/store/mood.store.ts
+++ b/src/store/mood.store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist } from './utils/createImmutableStore';
+import { createSelectors } from './utils/createSelectors';
 
 export interface BrsAnswer {
   id: string;
@@ -60,7 +61,7 @@ const initialState: MoodStoreState = {
   currentPromptId: null,
 };
 
-export const useMoodStore = create<MoodStore>()(
+const useMoodStoreBase = create<MoodStore>()(
   persist(
     (set, get) => ({
       ...initialState,
@@ -169,3 +170,5 @@ export const useMoodStore = create<MoodStore>()(
     }
   )
 );
+
+export const useMoodStore = createSelectors(useMoodStoreBase);

--- a/src/store/notify.store.ts
+++ b/src/store/notify.store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist } from './utils/createImmutableStore';
+import { createSelectors } from './utils/createSelectors';
 
 export type ChannelPrefs = {
   push: boolean;
@@ -61,7 +62,7 @@ const initialState = {
   error: null
 };
 
-export const useNotifyStore = create<NotifyState>()(
+const useNotifyStoreBase = create<NotifyState>()(
   persist(
     (set, get) => ({
       ...initialState,
@@ -126,3 +127,5 @@ export const useNotifyStore = create<NotifyState>()(
     }
   )
 );
+
+export const useNotifyStore = createSelectors(useNotifyStoreBase);

--- a/src/store/onboarding.store.ts
+++ b/src/store/onboarding.store.ts
@@ -1,5 +1,7 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+
+import { createImmutableStore } from './utils/createImmutableStore';
+import { createSelectors } from './utils/createSelectors';
 
 export type OnboardingStep = 0 | 1 | 2 | 3 | 4 | 5;
 
@@ -34,20 +36,20 @@ interface OnboardingState {
   currentStep: OnboardingStep;
   completed: boolean;
   flowId?: string;
-  
+
   // Draft data
   profileDraft?: ProfileDraft;
   goalsDraft?: GoalsDraft;
   sensorsDraft?: SensorsDraft;
   notificationsEnabled: boolean;
-  
+
   // Suggestions
   moduleSuggestions: ModuleSuggestion[];
-  
+
   // UI state
   loading: boolean;
   error: string | null;
-  
+
   // Actions
   setStep: (step: OnboardingStep) => void;
   nextStep: () => void;
@@ -77,27 +79,27 @@ const initialState = {
   error: null,
 };
 
-export const useOnboardingStore = create<OnboardingState>()(
-  persist(
+const onboardingStoreBase = create<OnboardingState>()(
+  createImmutableStore(
     (set, get) => ({
       ...initialState,
-      
+
       setStep: (currentStep) => set({ currentStep }),
-      
+
       nextStep: () => {
         const current = get().currentStep;
         if (current < 5) {
           set({ currentStep: (current + 1) as OnboardingStep });
         }
       },
-      
+
       prevStep: () => {
         const current = get().currentStep;
         if (current > 0) {
           set({ currentStep: (current - 1) as OnboardingStep });
         }
       },
-      
+
       setCompleted: (completed) => set({ completed }),
       setFlowId: (flowId) => set({ flowId }),
       setProfileDraft: (profileDraft) => set({ profileDraft }),
@@ -107,19 +109,23 @@ export const useOnboardingStore = create<OnboardingState>()(
       setModuleSuggestions: (moduleSuggestions) => set({ moduleSuggestions }),
       setLoading: (loading) => set({ loading }),
       setError: (error) => set({ error }),
-      
+
       reset: () => set(initialState),
     }),
     {
-      name: 'onboarding-store',
-      partialize: (state) => ({
-        currentStep: state.currentStep,
-        completed: state.completed,
-        profileDraft: state.profileDraft,
-        goalsDraft: state.goalsDraft,
-        sensorsDraft: state.sensorsDraft,
-        notificationsEnabled: state.notificationsEnabled,
-      }),
+      persist: {
+        name: 'onboarding-store',
+        partialize: (state) => ({
+          currentStep: state.currentStep,
+          completed: state.completed,
+          profileDraft: state.profileDraft,
+          goalsDraft: state.goalsDraft,
+          sensorsDraft: state.sensorsDraft,
+          notificationsEnabled: state.notificationsEnabled,
+        }),
+      },
     }
   )
 );
+
+export const useOnboardingStore = createSelectors(onboardingStoreBase);

--- a/src/store/privacy.store.ts
+++ b/src/store/privacy.store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist } from './utils/createImmutableStore';
+import { createSelectors } from './utils/createSelectors';
 
 export type PrivacyKey = 'cam' | 'mic' | 'hr' | 'gps' | 'social' | 'nft';
 export type PrivacyPrefs = Record<PrivacyKey, boolean>;
@@ -29,7 +30,7 @@ const initialPrefs: PrivacyPrefs = {
   nft: false,
 };
 
-export const usePrivacyStore = create<PrivacyState>()(
+const usePrivacyStoreBase = create<PrivacyState>()(
   persist(
     (set, get) => ({
       prefs: initialPrefs,
@@ -136,3 +137,5 @@ export const usePrivacyStore = create<PrivacyState>()(
     }
   )
 );
+
+export const usePrivacyStore = createSelectors(usePrivacyStoreBase);

--- a/src/store/rewards.store.ts
+++ b/src/store/rewards.store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist } from './utils/createImmutableStore';
+import { createSelectors } from './utils/createSelectors';
 
 export type RewardType = 'aura' | 'constellation' | 'flower' | 'flame' | 'pearl' | 'lantern' | 'crystal' | 'bubble' | 'sticker';
 
@@ -36,7 +37,7 @@ interface RewardsState {
   getNewRewardsCount: () => number;
 }
 
-export const useRewardsStore = create<RewardsState>()(
+const useRewardsStoreBase = create<RewardsState>()(
   persist(
     (set, get) => ({
       rewards: [],
@@ -103,3 +104,5 @@ export const useRewardsStore = create<RewardsState>()(
     }
   )
 );
+
+export const useRewardsStore = createSelectors(useRewardsStoreBase);

--- a/src/store/settings.store.ts
+++ b/src/store/settings.store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist } from './utils/createImmutableStore';
+import { createSelectors } from './utils/createSelectors';
 import {
   safeClassAdd,
   safeClassRemove,
@@ -94,7 +95,7 @@ const applyA11yToDocument = (a11y: A11y) => {
   }
 };
 
-export const useSettingsStore = create<SettingsState>()(
+const useSettingsStoreBase = create<SettingsState>()(
   persist(
     (set, get) => ({
       profile: initialState,
@@ -170,3 +171,5 @@ export const useSettingsStore = create<SettingsState>()(
     }
   )
 );
+
+export const useSettingsStore = createSelectors(useSettingsStoreBase);

--- a/src/store/story.store.ts
+++ b/src/store/story.store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist } from './utils/createImmutableStore';
+import { createSelectors } from './utils/createSelectors';
 
 export type StoryChoice = { 
   id: string; 
@@ -74,7 +75,7 @@ const initialState: StoryState = {
   transcriptUrl: null,
 };
 
-export const useStoryStore = create<StoryStore>()(
+const useStoryStoreBase = create<StoryStore>()(
   persist(
     (set, get) => ({
       ...initialState,
@@ -136,3 +137,5 @@ export const useStoryStore = create<StoryStore>()(
     }
   )
 );
+
+export const useStoryStore = createSelectors(useStoryStoreBase);

--- a/src/store/utils/createImmutableStore.ts
+++ b/src/store/utils/createImmutableStore.ts
@@ -1,0 +1,149 @@
+import type { StateCreator, StoreApi } from 'zustand';
+
+type ImmutableSet<T extends object> = (
+  partial: Partial<T> | ((state: T) => Partial<T>),
+  replace?: boolean,
+) => void;
+
+type ImmutableCreator<T extends object> = (
+  set: ImmutableSet<T>,
+  get: () => T,
+  api: StoreApi<T>,
+) => T;
+
+interface PersistedPayload<T extends object> {
+  state: Partial<T>;
+  version: number;
+}
+
+export interface PersistOptions<T extends object> {
+  name: string;
+  storage?: () => Storage;
+  partialize?: (state: T) => Partial<T>;
+  version?: number;
+  migrate?: (persistedState: Partial<T> | undefined, version: number) => Partial<T>;
+}
+
+export interface ImmutableStoreOptions<T extends object> {
+  persist?: PersistOptions<T>;
+}
+
+const toSerializable = <T extends object>(state: T): Partial<T> => {
+  return Object.fromEntries(
+    Object.entries(state).filter(([, value]) => typeof value !== 'function'),
+  ) as Partial<T>;
+};
+
+const resolveStorage = (factory?: () => Storage) => {
+  if (typeof window === 'undefined') return undefined;
+  try {
+    return factory ? factory() : window.localStorage;
+  } catch {
+    return undefined;
+  }
+};
+
+const parsePersistedState = <T extends object>(
+  raw: string | null,
+): PersistedPayload<T> | undefined => {
+  if (!raw) return undefined;
+
+  try {
+    const parsed = JSON.parse(raw) as PersistedPayload<T> | Partial<T>;
+
+    if (parsed && 'state' in parsed && 'version' in parsed) {
+      return parsed as PersistedPayload<T>;
+    }
+
+    return {
+      state: parsed as Partial<T>,
+      version: 0,
+    };
+  } catch {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('[zustand:persist] unable to parse stored value');
+    }
+
+    return undefined;
+  }
+};
+
+export const createImmutableStore = <T extends object>(
+  initializer: ImmutableCreator<T>,
+  options?: ImmutableStoreOptions<T>,
+): StateCreator<T, [], []> => {
+  return (set, get, api) => {
+    const persistOptions = options?.persist;
+    const storage = persistOptions ? resolveStorage(persistOptions.storage) : undefined;
+
+    if (persistOptions) {
+      Object.defineProperty(api, 'persist', {
+        configurable: false,
+        enumerable: false,
+        writable: false,
+        value: {
+          getOptions: () => persistOptions,
+        },
+      });
+    }
+
+    const persistSnapshot = (state: T) => {
+      if (!persistOptions || !storage) return;
+
+      try {
+        const snapshot = persistOptions.partialize
+          ? persistOptions.partialize(state)
+          : toSerializable(state);
+
+        const payload: PersistedPayload<T> = {
+          state: snapshot,
+          version: persistOptions.version ?? 0,
+        };
+
+        storage.setItem(persistOptions.name, JSON.stringify(payload));
+      } catch (error) {
+        if (process.env.NODE_ENV !== 'production') {
+          console.warn(`[zustand:persist] unable to store state for ${persistOptions.name}`, error);
+        }
+      }
+    };
+
+    const immutableSet: typeof set = (partial, replace) => {
+      const currentState = get();
+      const partialState =
+        typeof partial === 'function'
+          ? (partial as (state: T) => Partial<T>)(currentState)
+          : (partial as Partial<T>);
+
+      const nextState = replace
+        ? (partialState as T)
+        : ({ ...currentState, ...partialState } as T);
+
+      set(nextState as T, true);
+      persistSnapshot(nextState);
+    };
+
+    let state = initializer(immutableSet, get, api);
+
+    if (persistOptions && storage) {
+      const payload = parsePersistedState<T>(storage.getItem(persistOptions.name));
+
+      if (payload) {
+        const migrated = persistOptions.migrate
+          ? persistOptions.migrate(payload.state, payload.version)
+          : payload.state;
+
+        state = { ...state, ...migrated };
+      } else {
+        persistSnapshot(state);
+      }
+    }
+
+    return state;
+  };
+};
+
+export const persist = <T extends object>(
+  initializer: ImmutableCreator<T>,
+  options: PersistOptions<T>,
+) => createImmutableStore(initializer, { persist: options });

--- a/src/store/utils/createSelectors.ts
+++ b/src/store/utils/createSelectors.ts
@@ -1,0 +1,26 @@
+import { useStore } from 'zustand';
+import type { StoreApi } from 'zustand';
+
+type ExtractState<TStore> = TStore extends { getState: () => infer TState } ? TState : never;
+
+type UseSelectors<TStore extends StoreApi<object>> = TStore & {
+  use: {
+    [K in keyof ExtractState<TStore>]: () => ExtractState<TStore>[K];
+  };
+};
+
+export const createSelectors = <TStore extends StoreApi<object>>(store: TStore) => {
+  const useBoundStore = store as unknown as UseSelectors<TStore>;
+  useBoundStore.use = useBoundStore.use ?? ({} as UseSelectors<TStore>['use']);
+
+  const state = store.getState();
+  (Object.keys(state) as Array<keyof ExtractState<TStore>>).forEach((key) => {
+    Object.defineProperty(useBoundStore.use, key, {
+      configurable: false,
+      enumerable: true,
+      get: () => () => useStore(store, (state) => state[key]),
+    });
+  });
+
+  return useBoundStore;
+};

--- a/src/store/vrSafety.store.ts
+++ b/src/store/vrSafety.store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist } from './utils/createImmutableStore';
+import { createSelectors } from './utils/createSelectors';
 
 export type VRSafetyLevel = 'clear' | 'caution' | 'alert';
 export type VRParticleMode = 'standard' | 'soft' | 'minimal';
@@ -25,7 +26,7 @@ const defaultState: Omit<VRSafetyState, 'setPendingPrompt' | 'recordCheck' | 'se
   pendingPrompt: false,
 };
 
-export const useVRSafetyStore = create<VRSafetyState>()(
+const useVRSafetyStoreBase = create<VRSafetyState>()(
   persist(
     (set, get) => ({
       ...defaultState,
@@ -92,3 +93,5 @@ if (typeof window !== 'undefined') {
     useVRSafetyStore.getState().setPrefersReducedMotion(event.matches);
   });
 }
+
+export const useVRSafetyStore = createSelectors(useVRSafetyStoreBase);

--- a/src/store/vrbreath.store.ts
+++ b/src/store/vrbreath.store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist } from './utils/createImmutableStore';
+import { createSelectors } from './utils/createSelectors';
 
 export type VRBreathPattern = '4-2-4' | '4-6-8' | '5-5';
 
@@ -45,7 +46,7 @@ const initialState = {
   audioEnabled: false, // Mute par défaut comme spécifié
 };
 
-export const useVRBreathStore = create<VRBreathState>()(
+const useVRBreathStoreBase = create<VRBreathState>()(
   persist(
     (set, get) => ({
       ...initialState,
@@ -106,3 +107,5 @@ if (typeof window !== 'undefined') {
     useVRBreathStore.getState().setReduceMotion(e.matches);
   });
 }
+
+export const useVRBreathStore = createSelectors(useVRBreathStoreBase);


### PR DESCRIPTION
## Summary
- add immutable store utility and selector factory helpers to replace zustand middleware usage
- refactor persisted stores to consume the new helpers and expose memoized selectors
- keep app store persistence metadata available for tests and consumers

## Testing
- npx vitest run src/store/__tests__ --reporter=default
- npm run lint *(fails: existing parse error in src/hooks/useAssessment.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ce7bbcb2f8832d98bb20d7404214b9