### PR TITLE
Harden assessment edge functions

### DIFF
--- a/supabase/functions/_shared/http.ts
+++ b/supabase/functions/_shared/http.ts
@@ -1,11 +1,41 @@
 import { authorizeRole } from './auth.ts';
 import { hash } from './hash_user.ts';
 
+const DEFAULT_CACHE_CONTROL = 'private, max-age=60, must-revalidate';
+const SECURITY_HEADERS: Record<string, string> = {
+  'X-Content-Type-Options': 'nosniff',
+  'X-Robots-Tag': 'noindex',
+};
+
 export function json(status: number, body: unknown) {
   return new Response(JSON.stringify(body), {
     status,
     headers: { 'Content-Type': 'application/json' }
   });
+}
+
+export function applySecurityHeaders(
+  response: Response,
+  options?: { cacheControl?: string; extra?: Record<string, string> },
+): Response {
+  const cacheControl = options?.cacheControl ?? DEFAULT_CACHE_CONTROL;
+  if (cacheControl) {
+    response.headers.set('Cache-Control', cacheControl);
+  }
+
+  for (const [key, value] of Object.entries(SECURITY_HEADERS)) {
+    if (!response.headers.has(key)) {
+      response.headers.set(key, value);
+    }
+  }
+
+  if (options?.extra) {
+    for (const [key, value] of Object.entries(options.extra)) {
+      response.headers.set(key, value);
+    }
+  }
+
+  return response;
 }
 
 export function getUserHash(token?: string): string {

--- a/supabase/functions/assess-submit/index.ts
+++ b/supabase/functions/assess-submit/index.ts
@@ -5,7 +5,7 @@ import { createClient } from '../_shared/supabase.ts';
 import { authenticateRequest, logUnauthorizedAccess } from '../_shared/auth-middleware.ts';
 import { getCatalog, instrumentSchema, InstrumentCode, summarizeAssessment } from '../_shared/assess.ts';
 import { appendCorsHeaders, preflightResponse, rejectCors, resolveCors } from '../_shared/cors.ts';
-import { json } from '../_shared/http.ts';
+import { applySecurityHeaders, json } from '../_shared/http.ts';
 import { hash } from '../_shared/hash_user.ts';
 import { logAccess } from '../_shared/logging.ts';
 import { addSentryBreadcrumb, captureSentryException } from '../_shared/sentry.ts';
@@ -32,7 +32,7 @@ type OrchestrationHint = {
   action: string;
   intensity: 'low' | 'medium' | 'high';
   context: string;
-  duration_ms?: number;
+  duration?: 'short' | 'medium' | 'long';
 };
 
 const instrumentDomains: Record<InstrumentCode, string> = {
@@ -103,7 +103,7 @@ function buildOrchestrationHints(
 
     case 'SUDS':
       if (level >= 3) {
-        hints.push({ action: 'extend_session', intensity: 'medium', context: 'flash_glow', duration_ms: 60_000 });
+        hints.push({ action: 'extend_session', intensity: 'medium', context: 'flash_glow', duration: 'medium' });
       } else if (level <= 1) {
         hints.push({ action: 'soft_exit', intensity: 'low', context: 'session_completion' });
       }
@@ -135,22 +135,31 @@ serve(async (req) => {
   };
 
   if (req.method === 'OPTIONS') {
-    return finalize(preflightResponse(cors));
+    return finalize(applySecurityHeaders(preflightResponse(cors), { cacheControl: 'no-store' }));
   }
 
   if (!cors.allowed) {
-    return finalize(rejectCors(cors), { outcome: 'denied', error: 'origin_not_allowed' });
+    return finalize(applySecurityHeaders(rejectCors(cors), { cacheControl: 'no-store' }), {
+      outcome: 'denied',
+      error: 'origin_not_allowed',
+    });
   }
 
   if (req.method !== 'POST') {
     const response = appendCorsHeaders(new Response('Method Not Allowed', { status: 405 }), cors);
-    return finalize(response, { outcome: 'denied', error: 'method_not_allowed' });
+    return finalize(
+      applySecurityHeaders(response, { cacheControl: 'no-store' }),
+      { outcome: 'denied', error: 'method_not_allowed' },
+    );
   }
 
   if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
     console.error('[assess-submit] missing Supabase configuration');
     const response = appendCorsHeaders(json(500, { error: 'configuration_error' }), cors);
-    return finalize(response, { outcome: 'error', error: 'configuration_error' });
+    return finalize(
+      applySecurityHeaders(response, { cacheControl: 'no-store' }),
+      { outcome: 'error', error: 'configuration_error' },
+    );
   }
 
   try {
@@ -160,7 +169,10 @@ serve(async (req) => {
         await logUnauthorizedAccess(req, auth.error ?? 'unauthorized');
       }
       const response = appendCorsHeaders(json(auth.status, { error: 'unauthorized' }), cors);
-      return finalize(response, { outcome: 'denied', error: 'unauthorized' });
+      return finalize(
+        applySecurityHeaders(response, { cacheControl: 'no-store' }),
+        { outcome: 'denied', error: 'unauthorized' },
+      );
     }
 
     hashedUserId = hash(auth.user.id);
@@ -169,28 +181,45 @@ serve(async (req) => {
       route: 'assess-submit',
       userId: auth.user.id,
       description: 'submit assessment answers',
+      limit: 10,
+      windowMs: 60_000,
     });
     if (!rateDecision.allowed) {
+      addSentryBreadcrumb({
+        category: 'assess:submit',
+        message: 'assess:submit:rate_limited',
+        data: { identifier: rateDecision.identifier, retry_after: rateDecision.retryAfterSeconds },
+      });
       const response = buildRateLimitResponse(rateDecision, cors.headers);
-      return finalize(response, { outcome: 'denied', error: 'rate_limited' });
+      return finalize(
+        applySecurityHeaders(response, { cacheControl: 'no-store' }),
+        { outcome: 'denied', error: 'rate_limited', stage: 'rate_limit' },
+      );
     }
 
     const body = await req.json().catch(() => null);
     if (!body) {
       const response = appendCorsHeaders(json(422, { error: 'invalid_body' }), cors);
-      return finalize(response, { outcome: 'denied', error: 'invalid_body' });
+      return finalize(
+        applySecurityHeaders(response, { cacheControl: 'no-store' }),
+        { outcome: 'denied', error: 'invalid_body' },
+      );
     }
 
     const parsed = submitSchema.safeParse(body);
     if (!parsed.success) {
       const response = appendCorsHeaders(json(422, { error: 'invalid_body', details: 'validation_failed' }), cors);
-      return finalize(response, { outcome: 'denied', error: 'validation_failed' });
+      return finalize(
+        applySecurityHeaders(response, { cacheControl: 'no-store' }),
+        { outcome: 'denied', error: 'validation_failed' },
+      );
     }
 
     const { instrument, answers, ts } = parsed.data;
     const summary = summarizeAssessment(instrument, answers);
     const catalog = getCatalog(instrument, 'fr');
     const hints = buildOrchestrationHints(instrument, summary.level, summary.scores);
+    const severity = summary.level >= 3 ? 'high' : summary.level <= 1 ? 'low' : 'moderate';
 
     addSentryBreadcrumb({
       category: 'assess',
@@ -217,7 +246,6 @@ serve(async (req) => {
         focus: summary.focus ?? null,
         instrument_version: catalog.version,
         generated_at: new Date().toISOString(),
-        level: summary.level,
       },
       ts: ts ?? new Date().toISOString(),
     };
@@ -227,18 +255,21 @@ serve(async (req) => {
       captureSentryException(error, { route: 'assess-submit', stage: 'db_insert' });
       console.error('[assess-submit] failed to store summary', { message: error.message });
       const response = appendCorsHeaders(json(500, { error: 'storage_failed' }), cors);
-      return finalize(response, { outcome: 'error', error: 'storage_failed', stage: 'db_insert' });
+      return finalize(
+        applySecurityHeaders(response, { cacheControl: 'no-store' }),
+        { outcome: 'error', error: 'storage_failed', stage: 'db_insert' },
+      );
     }
 
     const signalPayload = {
       user_id: auth.user.id,
       source_instrument: instrument,
       domain: getInstrumentDomain(instrument),
-      level: summary.level,
       module_context: SIGNAL_MODULE_CONTEXT,
       metadata: {
         summary: summary.summary,
         focus: summary.focus ?? null,
+        severity,
         hints,
       },
       expires_at: new Date(Date.now() + SIGNAL_TTL_MS).toISOString(),
@@ -253,7 +284,10 @@ serve(async (req) => {
         captureSentryException(signalError, { route: 'assess-submit', stage: 'signal_insert' });
         console.error('[assess-submit] failed to store orchestration signal', { message: signalError.message });
         const response = appendCorsHeaders(json(500, { error: 'signal_storage_failed' }), cors);
-        return finalize(response, { outcome: 'error', error: 'signal_storage_failed', stage: 'signal_insert' });
+        return finalize(
+          applySecurityHeaders(response, { cacheControl: 'no-store' }),
+          { outcome: 'error', error: 'signal_storage_failed', stage: 'signal_insert' },
+        );
       }
     }
 
@@ -274,11 +308,15 @@ serve(async (req) => {
     });
 
     const response = appendCorsHeaders(json(200, { status: 'ok', stored: true, signal: true }), cors);
+    applySecurityHeaders(response, { cacheControl: 'no-store' });
     return finalize(response, { outcome: 'success', stage: 'summary_stored' });
   } catch (error) {
     captureSentryException(error, { route: 'assess-submit' });
     console.error('[assess-submit] unexpected error', { message: error instanceof Error ? error.message : 'unknown' });
     const response = appendCorsHeaders(json(500, { error: 'internal_error' }), cors);
-    return finalize(response, { outcome: 'error', error: 'internal_error' });
+    return finalize(
+      applySecurityHeaders(response, { cacheControl: 'no-store' }),
+      { outcome: 'error', error: 'internal_error' },
+    );
   }
 });


### PR DESCRIPTION
## Summary
- secure assessment start and submit edge routes with standard security headers, strict CORS handling, and explicit per-route rate limits
- strip raw clinical values from stored summaries and orchestration signals while adding textual severity for downstream hints
- harden assessment aggregate access with role and org scope checks, sanitized responses, tighter validation, and updated tests for the new contracts

## Testing
- npx vitest run supabase/tests/assess-functions.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ce8f05cedc832da7fa819555fdb30f