### PR TITLE
feat: adaptive music presets and persistence

### DIFF
--- a/e2e/adaptive-music.smoke.spec.ts
+++ b/e2e/adaptive-music.smoke.spec.ts
@@ -1,8 +1,68 @@
 import { test, expect } from "@playwright/test";
 
-test("adaptive music smoke", async ({ page }) => {
+const mockPlaylistResponse = {
+  ok: true,
+  data: {
+    playlist_id: "mock-playlist",
+    mood: "relaxed",
+    requested_mood: "relaxed",
+    title: "Sélection douceur",
+    description: "Ambiance apaisante",
+    total_duration: 600,
+    tracks: [
+      {
+        id: "mock-track",
+        title: "Brume matinale",
+        artist: "Studio Calm",
+        url: "/audio/mock.mp3",
+        duration: 180,
+        mood: "calm",
+        energy: 0.3,
+        focus: "breathing",
+        instrumentation: ["piano"],
+        tags: ["douceur"],
+        description: "Ambiance moelleuse pour se déposer.",
+      },
+    ],
+    energy_profile: {
+      baseline: 0.3,
+      requested: 0.4,
+      recommended: 0.35,
+      alignment: 0.9,
+      curve: [],
+    },
+    recommendations: ["Respire calmement"],
+    guidance: { focus: "Laisse-toi bercer", breathwork: "", activities: ["relaxation"] },
+    metadata: { curated_by: "care", tags: ["calm"], dataset_version: "v1" },
+  },
+};
+
+test("adaptive music favorites, reprise et opt-in", async ({ page }) => {
+  await page.route("/api/mood_playlist", async route => {
+    await route.fulfill({
+      status: 200,
+      body: JSON.stringify(mockPlaylistResponse),
+      headers: { "content-type": "application/json" },
+    });
+  });
+
   await page.goto("/modules/adaptive-music");
-  await expect(page).toHaveURL(/\/modules\/adaptive-music/);
-  await page.locator('[data-ui="primary-cta"]').click();
-  // Pas d'assertion audio, juste pas de crash
+  await expect(page.getByTestId("adaptive-music-page")).toBeVisible();
+
+  const skipButton = page.getByRole("button", { name: /Pas maintenant/i });
+  if (await skipButton.isVisible()) {
+    await skipButton.click();
+  }
+
+  await expect(page.getByRole("button", { name: /^Lecture$/ })).toBeVisible();
+
+  const favoriteButton = page.getByRole("button", { name: /Garder cette bulle/i });
+  await favoriteButton.click();
+
+  const playButton = page.getByRole("button", { name: /^Lecture$/ });
+  await playButton.click();
+  await page.waitForTimeout(500);
+  await page.getByRole("button", { name: /^Pause$/ }).click();
+
+  await expect(page.getByRole("button", { name: /Reprendre/ })).toBeVisible();
 });

--- a/src/__tests__/audio.player.snapshot.spec.tsx
+++ b/src/__tests__/audio.player.snapshot.spec.tsx
@@ -1,37 +1,38 @@
-import { beforeEach, describe, it, expect } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
 import { AudioPlayer } from "@/ui/AudioPlayer";
 
 describe("AudioPlayer", () => {
-  beforeEach(() => {
-    window.localStorage.clear();
-  });
-
-  it("renders and exposes volume slider", () => {
+  it("renders, toggles favorite state and exposes volume slider", async () => {
+    const toggle = vi.fn();
     const { container } = render(
-      <AudioPlayer src="/audio/lofi-120.mp3" trackId="test-track" title="Test" />
+      <AudioPlayer
+        src="/audio/lofi-120.mp3"
+        trackId="test-track"
+        title="Test"
+        favorite={{ active: false, onToggle: toggle }}
+      />,
     );
+
     expect(screen.getByLabelText("Volume")).toBeInTheDocument();
     const favorite = screen.getByRole("button", { name: /Ajouter aux favoris/i });
     fireEvent.click(favorite);
-    expect(favorite).toHaveAttribute("aria-pressed", "true");
+    expect(toggle).toHaveBeenCalledTimes(1);
     expect(container).toMatchSnapshot();
   });
 
-  it("restores resume button from persisted playback state", async () => {
-    window.localStorage.setItem(
-      "adaptive-music:playback:test-track",
-      JSON.stringify({ position: 42, volume: 0.4, wasPlaying: false, updatedAt: Date.now() })
-    );
-
+  it("shows resume button when resume prop provided", () => {
     render(
-      <AudioPlayer src="/audio/lofi-120.mp3" trackId="test-track" title="Test" />
+      <AudioPlayer
+        src="/audio/lofi-120.mp3"
+        trackId="test-track"
+        title="Test"
+        resume={{ position: 42, onResume: vi.fn() }}
+      />,
     );
 
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: /Reprendre/ })).toBeInTheDocument();
-    });
-
-    expect(screen.getByText(/Dernière écoute sauvegardée/)).toHaveTextContent("0:42");
+    expect(screen.getByRole("button", { name: /Reprendre/ })).toHaveTextContent("0:42");
+    expect(screen.getByText(/Dernière écoute sauvegardée/)).toBeInTheDocument();
   });
 });

--- a/src/components/dashboard/b2c/MusicTherapyCard.tsx
+++ b/src/components/dashboard/b2c/MusicTherapyCard.tsx
@@ -1,55 +1,50 @@
 
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Play, SkipForward, Volume2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { toast } from 'sonner';
+import { Music2 } from 'lucide-react';
+
+import useMusicFavorites from '@/hooks/useMusicFavorites';
 
 interface MusicTherapyCardProps {
   className?: string;
 }
 
 const MusicTherapyCard: React.FC<MusicTherapyCardProps> = ({ className = '' }) => {
-  const handlePlay = () => {
-    toast('Lancement de la thérapie musicale');
-  };
+  const navigate = useNavigate();
+  const { favorites } = useMusicFavorites();
+  const mainFavorite = favorites[0];
 
   return (
     <Card className={className}>
       <CardHeader>
         <CardTitle>Thérapie musicale</CardTitle>
       </CardHeader>
-      <CardContent>
-        <div className="bg-gradient-to-r from-purple-500/10 to-blue-500/10 rounded-md p-4 mb-4 flex items-center">
-          <div className="bg-primary/10 p-3 rounded-full mr-4">
-            <Volume2 className="h-8 w-8 text-primary" />
+      <CardContent className="space-y-4">
+        <div className="flex items-start gap-3 rounded-md border border-primary/30 bg-primary/5 p-4">
+          <div className="rounded-full bg-primary/10 p-3">
+            <Music2 className="h-6 w-6 text-primary" aria-hidden />
           </div>
-          <div>
-            <h3 className="font-medium">Méditation guidée</h3>
-            <p className="text-sm text-muted-foreground">12 minutes</p>
+          <div className="space-y-1 text-sm">
+            <p className="font-medium">Ta piste repère</p>
+            {mainFavorite ? (
+              <>
+                <p>{mainFavorite.title ?? 'Ambiance personnalisée'}</p>
+                <p className="text-xs text-muted-foreground">Toujours prête à être relancée en douceur.</p>
+              </>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Garde une bulle depuis le module Adaptive Music pour la retrouver ici.
+              </p>
+            )}
           </div>
         </div>
-        
-        <div className="flex justify-center space-x-4 mt-4">
-          <Button variant="outline" size="icon" className="rounded-full h-10 w-10">
-            <SkipForward className="h-4 w-4" />
+
+        <div className="flex justify-center">
+          <Button type="button" onClick={() => navigate('/app/music')}>
+            Ouvrir ma bulle sonore
           </Button>
-          <Button 
-            size="icon" 
-            className="rounded-full h-12 w-12 bg-primary"
-            onClick={handlePlay}
-          >
-            <Play className="h-6 w-6 text-primary-foreground" />
-          </Button>
-          <Button variant="outline" size="icon" className="rounded-full h-10 w-10">
-            <SkipForward className="h-4 w-4" />
-          </Button>
-        </div>
-        
-        <div className="mt-4">
-          <p className="text-sm text-muted-foreground text-center">
-            Musique adaptée à votre état émotionnel actuel
-          </p>
         </div>
       </CardContent>
     </Card>

--- a/src/hooks/music/useAdaptivePlayback.ts
+++ b/src/hooks/music/useAdaptivePlayback.ts
@@ -1,0 +1,118 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+export interface PlaybackState {
+  trackId: string;
+  position: number;
+  volume: number;
+  presetId: string;
+  updatedAt: number;
+  title?: string;
+  url?: string;
+  wasPlaying?: boolean;
+}
+
+const STORAGE_KEY = "adaptive-music:persisted-session";
+
+const readState = (): PlaybackState | null => {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return null;
+    if (!parsed.trackId || typeof parsed.trackId !== "string") return null;
+    return {
+      trackId: parsed.trackId,
+      position: typeof parsed.position === "number" ? Math.max(0, parsed.position) : 0,
+      volume: typeof parsed.volume === "number" ? Math.min(Math.max(parsed.volume, 0), 1) : 0.6,
+      presetId: typeof parsed.presetId === "string" ? parsed.presetId : "ambient_soft",
+      updatedAt: typeof parsed.updatedAt === "number" ? parsed.updatedAt : Date.now(),
+      title: typeof parsed.title === "string" ? parsed.title : undefined,
+      url: typeof parsed.url === "string" ? parsed.url : undefined,
+      wasPlaying: typeof parsed.wasPlaying === "boolean" ? parsed.wasPlaying : false,
+    } satisfies PlaybackState;
+  } catch (error) {
+    console.warn("[useAdaptivePlayback] unable to restore state", error);
+    return null;
+  }
+};
+
+const writeState = (snapshot: PlaybackState | null) => {
+  if (typeof window === "undefined") return;
+  try {
+    if (!snapshot) {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot));
+  } catch (error) {
+    console.warn("[useAdaptivePlayback] unable to persist state", error);
+  }
+};
+
+export const useAdaptivePlayback = () => {
+  const [snapshot, setSnapshot] = useState<PlaybackState | null>(() => readState());
+
+  const update = useCallback((state: Partial<PlaybackState> & { trackId: string }) => {
+    setSnapshot(prev => {
+      const base: PlaybackState = prev ?? {
+        trackId: state.trackId,
+        position: 0,
+        volume: 0.6,
+        presetId: state.presetId ?? "ambient_soft",
+        updatedAt: Date.now(),
+      };
+
+      const merged: PlaybackState = {
+        ...base,
+        ...state,
+        position:
+          typeof state.position === "number"
+            ? Math.max(0, state.position)
+            : base.position,
+        volume:
+          typeof state.volume === "number"
+            ? Math.min(Math.max(state.volume, 0), 1)
+            : base.volume,
+        updatedAt: Date.now(),
+      };
+
+      writeState(merged);
+      return merged;
+    });
+  }, []);
+
+  const clear = useCallback(() => {
+    writeState(null);
+    setSnapshot(null);
+  }, []);
+
+  const refresh = useCallback(() => {
+    setSnapshot(readState());
+  }, []);
+
+  useEffect(() => {
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === STORAGE_KEY) {
+        refresh();
+      }
+    };
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, [refresh]);
+
+  const hasResume = useMemo(() => {
+    if (!snapshot) return false;
+    return snapshot.position > 1;
+  }, [snapshot]);
+
+  return {
+    snapshot,
+    hasResume,
+    update,
+    clear,
+    refresh,
+  };
+};
+
+export default useAdaptivePlayback;

--- a/src/hooks/useCurrentMood.ts
+++ b/src/hooks/useCurrentMood.ts
@@ -1,0 +1,112 @@
+import { useMemo } from "react";
+
+import { useMood } from "@/contexts/MoodContext";
+import { getVibeEmoji, getVibeLabel, type MoodVibe } from "@/utils/moodVibes";
+
+interface MoodDescriptor {
+  title: string;
+  description: string;
+}
+
+const VIBE_DESCRIPTIONS: Record<MoodVibe, MoodDescriptor> = {
+  calm: {
+    title: "Souffle paisible",
+    description: "Un flux régulier et rassurant enveloppe la pièce.",
+  },
+  focus: {
+    title: "Clarté attentive",
+    description: "Une présence nette qui accompagne les pensées avec douceur.",
+  },
+  bright: {
+    title: "Élan lumineux",
+    description: "Une énergie positive et chaleureuse qui rayonne sans brusquer.",
+  },
+  reset: {
+    title: "Cocon réparateur",
+    description: "Une bulle protectrice qui invite au relâchement complet.",
+  },
+};
+
+const clamp = (value: number, min: number, max: number) => {
+  return Math.min(Math.max(value, min), max);
+};
+
+export interface CurrentMoodSnapshot {
+  vibe: MoodVibe;
+  label: string;
+  emoji: string;
+  title: string;
+  description: string;
+  headline: string;
+  valence: number | null;
+  arousal: number | null;
+  normalized: {
+    valence: number;
+    arousal: number;
+  };
+  updatedAt: string;
+  isLoading: boolean;
+  hasError: boolean;
+}
+
+export const useCurrentMood = (): CurrentMoodSnapshot => {
+  const { currentMood } = useMood();
+
+  const valence = Number.isFinite(currentMood.valence)
+    ? (currentMood.valence as number)
+    : null;
+  const arousal = Number.isFinite(currentMood.arousal)
+    ? (currentMood.arousal as number)
+    : null;
+
+  const normalized = useMemo(() => {
+    const safeValence = valence ?? 0;
+    const safeArousal = arousal ?? 50;
+    const valencePercent = clamp(Math.round(((safeValence + 100) / 200) * 100), 0, 100);
+    const arousalPercent = clamp(Math.round(safeArousal), 0, 100);
+    return { valence: valencePercent, arousal: arousalPercent };
+  }, [valence, arousal]);
+
+  const descriptor = VIBE_DESCRIPTIONS[currentMood.vibe];
+
+  const headline = useMemo(() => {
+    if (valence === null || arousal === null) {
+      return "Ambiance stable et enveloppante";
+    }
+
+    if (arousal < 25) {
+      return "Tempo très doux pour accompagner le relâchement";
+    }
+
+    if (arousal < 45) {
+      return "Cadence souple qui laisse de l'espace à la respiration";
+    }
+
+    if (valence > 50 && arousal > 60) {
+      return "Belle dynamique, on prolonge cet élan lumineux";
+    }
+
+    if (valence < -30 && arousal > 60) {
+      return "On adoucit le flux pour guider la décharge du stress";
+    }
+
+    return "Nous ajustons la texture pour rester dans le confort";
+  }, [valence, arousal]);
+
+  return {
+    vibe: currentMood.vibe,
+    label: getVibeLabel(currentMood.vibe),
+    emoji: getVibeEmoji(currentMood.vibe),
+    title: descriptor.title,
+    description: descriptor.description,
+    headline,
+    valence,
+    arousal,
+    normalized,
+    updatedAt: currentMood.timestamp,
+    isLoading: currentMood.isLoading,
+    hasError: Boolean(currentMood.error),
+  };
+};
+
+export default useCurrentMood;

--- a/src/hooks/useMusicFavorites.ts
+++ b/src/hooks/useMusicFavorites.ts
@@ -1,0 +1,62 @@
+import { useCallback } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  fetchFavoriteRecords,
+  toggleFavoriteRecord,
+  type FavoriteRecord,
+} from "@/services/music/favoritesService";
+
+const QUERY_KEY = ["adaptive-music", "favorites"] as const;
+
+export const useMusicFavorites = () => {
+  const queryClient = useQueryClient();
+
+  const query = useQuery<FavoriteRecord[]>({
+    queryKey: QUERY_KEY,
+    queryFn: fetchFavoriteRecords,
+    staleTime: 60_000,
+    initialData: [],
+  });
+
+  const mutation = useMutation({
+    mutationFn: ({
+      trackId,
+      presetId,
+      metadata,
+    }: {
+      trackId: string;
+      presetId: string;
+      metadata?: { title?: string; url?: string };
+    }) => toggleFavoriteRecord(trackId, presetId, metadata),
+    onSuccess: data => {
+      queryClient.setQueryData(QUERY_KEY, data);
+    },
+  });
+
+  const isFavorite = useCallback(
+    (trackId: string | null | undefined) => {
+      if (!trackId) return false;
+      return (query.data ?? []).some(entry => entry.trackId === trackId);
+    },
+    [query.data],
+  );
+
+  const toggle = useCallback(
+    async (trackId: string, presetId: string, metadata?: { title?: string; url?: string }) => {
+      await mutation.mutateAsync({ trackId, presetId, metadata });
+    },
+    [mutation],
+  );
+
+  return {
+    favorites: query.data ?? [],
+    isLoading: query.isLoading,
+    refetch: query.refetch,
+    isFavorite,
+    toggleFavorite: toggle,
+    isToggling: mutation.isPending,
+  };
+};
+
+export default useMusicFavorites;

--- a/src/services/music/__tests__/presetMapper.spec.ts
+++ b/src/services/music/__tests__/presetMapper.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "vitest";
+
+import { mapStateToPreset } from "../presetMapper";
+
+describe("mapStateToPreset", () => {
+  test("prefers very calm preset when arousal is very low", () => {
+    const recommendation = mapStateToPreset({ valence: -10, arousal: 10 });
+    expect(recommendation.presetId).toBe("calm_very_low");
+    expect(recommendation.intensity).toBe("feather");
+  });
+
+  test("brightens when valence and arousal are high", () => {
+    const recommendation = mapStateToPreset({ valence: 80, arousal: 85 });
+    expect(recommendation.presetId).toBe("bright_mist");
+    expect(recommendation.intensity).toBe("glow");
+  });
+
+  test("softens and shortens intensity when fatigue rises", () => {
+    const recommendation = mapStateToPreset(
+      { valence: 20, arousal: 55 },
+      { fatigueTrend: "up", tensionTrend: "steady", note: "besoin de repos" },
+    );
+
+    expect(recommendation.presetId).toBe("calm_very_low");
+    expect(recommendation.adjustments.softenedForFatigue).toBe(true);
+    expect(recommendation.narrative).toMatch(/nuage très doux/);
+  });
+
+  test("extends crossfade and exposes CTA when tension decreases", () => {
+    const recommendation = mapStateToPreset(
+      { valence: 30, arousal: 40 },
+      { tensionTrend: "down", fatigueTrend: "steady" },
+    );
+
+    expect(recommendation.cta).toBe("encore_2_min");
+    expect(recommendation.adjustments.extendedForTensionRelease).toBe(true);
+    expect(recommendation.crossfadeMs).toBeGreaterThan(2800);
+  });
+});

--- a/src/services/music/favoritesService.ts
+++ b/src/services/music/favoritesService.ts
@@ -1,0 +1,144 @@
+import { supabase } from "@/integrations/supabase/client";
+
+export interface FavoriteRecord {
+  trackId: string;
+  presetId: string;
+  createdAt: string;
+  title?: string;
+  url?: string;
+}
+
+const LOCAL_STORAGE_KEY = "adaptive-music:favorites-sync";
+
+const readLocalFallback = (): FavoriteRecord[] => {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(LOCAL_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((entry: any) => entry && typeof entry.trackId === "string");
+  } catch (error) {
+    console.warn("[favoritesService] unable to read fallback", error);
+    return [];
+  }
+};
+
+const writeLocalFallback = (records: FavoriteRecord[]) => {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(records));
+  } catch (error) {
+    console.warn("[favoritesService] unable to persist fallback", error);
+  }
+};
+
+const getUserId = async (): Promise<string | null> => {
+  try {
+    const { data, error } = await supabase.auth.getUser();
+    if (error) {
+      console.warn("[favoritesService] user lookup error", error);
+      return null;
+    }
+    return data.user?.id ?? null;
+  } catch (error) {
+    console.warn("[favoritesService] user lookup failure", error);
+    return null;
+  }
+};
+
+export const fetchFavoriteRecords = async (): Promise<FavoriteRecord[]> => {
+  const fallback = readLocalFallback();
+  const userId = await getUserId();
+  if (!userId) {
+    return fallback;
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from("favorites")
+      .select("track_id, preset, created_at, metadata")
+      .eq("user_id", userId)
+      .order("created_at", { ascending: false })
+      .limit(24);
+
+    if (error) {
+      console.warn("[favoritesService] query error", error);
+      return fallback;
+    }
+
+    const records: FavoriteRecord[] = (data ?? []).map(entry => ({
+      trackId: entry.track_id as string,
+      presetId: (entry.preset as string) ?? "ambient_soft",
+      createdAt: entry.created_at as string,
+      title: typeof entry.metadata?.title === "string" ? entry.metadata.title : undefined,
+      url: typeof entry.metadata?.url === "string" ? entry.metadata.url : undefined,
+    }));
+
+    writeLocalFallback(records);
+    return records;
+  } catch (error) {
+    console.warn("[favoritesService] unexpected fetch failure", error);
+    return fallback;
+  }
+};
+
+export const toggleFavoriteRecord = async (
+  trackId: string,
+  presetId: string,
+  metadata?: { title?: string; url?: string },
+): Promise<FavoriteRecord[]> => {
+  const userId = await getUserId();
+  const fallback = readLocalFallback();
+
+  if (!userId) {
+    const exists = fallback.find(entry => entry.trackId === trackId);
+    const next = exists
+      ? fallback.filter(entry => entry.trackId !== trackId)
+      : [
+          ...fallback.filter(entry => entry.trackId !== trackId),
+          {
+            trackId,
+            presetId,
+            createdAt: new Date().toISOString(),
+            title: metadata?.title,
+            url: metadata?.url,
+          },
+        ];
+    writeLocalFallback(next);
+    return next;
+  }
+
+  const exists = fallback.find(entry => entry.trackId === trackId);
+  const nextFallback = exists
+    ? fallback.filter(entry => entry.trackId !== trackId)
+    : [
+        ...fallback.filter(entry => entry.trackId !== trackId),
+        {
+          trackId,
+          presetId,
+          createdAt: new Date().toISOString(),
+          title: metadata?.title,
+          url: metadata?.url,
+        },
+      ];
+
+  try {
+    if (exists) {
+      await supabase.from("favorites").delete().eq("user_id", userId).eq("track_id", trackId);
+    } else {
+      await supabase.from("favorites").upsert({
+        user_id: userId,
+        track_id: trackId,
+        preset: presetId,
+        metadata: metadata ?? null,
+      });
+    }
+  } catch (error) {
+    console.warn("[favoritesService] toggle error", error);
+    return fallback;
+  }
+
+  writeLocalFallback(nextFallback);
+  return nextFallback;
+};

--- a/src/services/music/presetMapper.ts
+++ b/src/services/music/presetMapper.ts
@@ -1,0 +1,175 @@
+const clamp = (value: number, min: number, max: number) => {
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+};
+
+export type AdaptivePresetId =
+  | "calm_very_low"
+  | "ambient_soft"
+  | "focus_light"
+  | "bright_mist";
+
+export type AdaptiveIntensity = "feather" | "soft" | "balanced" | "glow";
+
+export interface SamSnapshot {
+  valence?: number | null;
+  arousal?: number | null;
+}
+
+export interface PomsTrendSummary {
+  tensionTrend?: "up" | "down" | "steady" | null;
+  fatigueTrend?: "up" | "down" | "steady" | null;
+  note?: string | null;
+  completed?: boolean;
+}
+
+export interface PresetRecommendation {
+  presetId: AdaptivePresetId;
+  intensity: AdaptiveIntensity;
+  crossfadeMs: number;
+  narrative: string;
+  cta?: "encore_2_min" | null;
+  adjustments: {
+    softenedForFatigue: boolean;
+    extendedForTensionRelease: boolean;
+    source: "sam" | "poms" | "mixed";
+  };
+}
+
+interface BasePresetConfig {
+  presetId: AdaptivePresetId;
+  intensity: AdaptiveIntensity;
+  crossfadeMs: number;
+  narrative: string;
+}
+
+const BASE_PRESETS: Record<AdaptivePresetId, BasePresetConfig> = {
+  calm_very_low: {
+    presetId: "calm_very_low",
+    intensity: "feather",
+    crossfadeMs: 3600,
+    narrative: "Un souffle quasi immobile qui berce doucement l'espace sonore.",
+  },
+  ambient_soft: {
+    presetId: "ambient_soft",
+    intensity: "soft",
+    crossfadeMs: 2800,
+    narrative: "Une nappe veloutée qui détend sans jamais écraser l'attention.",
+  },
+  focus_light: {
+    presetId: "focus_light",
+    intensity: "balanced",
+    crossfadeMs: 2100,
+    narrative: "Une pulsation légère et régulière qui soutient la concentration.",
+  },
+  bright_mist: {
+    presetId: "bright_mist",
+    intensity: "glow",
+    crossfadeMs: 1600,
+    narrative: "Un halo lumineux qui prolonge l'élan positif sans brusquer.",
+  },
+};
+
+const NORMALIZE = (value: number | null | undefined, range: { min: number; max: number }, fallback: number) => {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return fallback;
+  }
+  return clamp(Math.round(value), range.min, range.max);
+};
+
+const normalizeValence = (valence: number | null | undefined): number => {
+  if (typeof valence !== "number" || Number.isNaN(valence)) {
+    return 50;
+  }
+  const clamped = clamp(valence, -100, 100);
+  return Math.round(((clamped + 100) / 200) * 100);
+};
+
+const selectBasePreset = (sam: SamSnapshot): BasePresetConfig => {
+  const arousal = NORMALIZE(sam.arousal, { min: 0, max: 100 }, 50);
+  const valence = normalizeValence(sam.valence);
+
+  if (arousal <= 25) {
+    return BASE_PRESETS.calm_very_low;
+  }
+
+  if (arousal <= 45) {
+    return BASE_PRESETS.ambient_soft;
+  }
+
+  if (arousal >= 78 && valence >= 60) {
+    return BASE_PRESETS.bright_mist;
+  }
+
+  if (arousal >= 65) {
+    return BASE_PRESETS.focus_light;
+  }
+
+  if (valence >= 72) {
+    return BASE_PRESETS.bright_mist;
+  }
+
+  if (valence <= 35 && arousal >= 55) {
+    return BASE_PRESETS.ambient_soft;
+  }
+
+  return BASE_PRESETS.ambient_soft;
+};
+
+export const mapStateToPreset = (
+  sam: SamSnapshot,
+  summary?: PomsTrendSummary | null,
+): PresetRecommendation => {
+  const base = selectBasePreset(sam);
+  const result: PresetRecommendation = {
+    presetId: base.presetId,
+    intensity: base.intensity,
+    crossfadeMs: base.crossfadeMs,
+    narrative: base.narrative,
+    cta: null,
+    adjustments: {
+      softenedForFatigue: false,
+      extendedForTensionRelease: false,
+      source: "sam",
+    },
+  };
+
+  if (!summary) {
+    return result;
+  }
+
+  const { fatigueTrend, tensionTrend } = summary;
+  const fromPoms = fatigueTrend || tensionTrend;
+  if (fromPoms) {
+    result.adjustments.source = "mixed";
+  }
+
+  if (fatigueTrend === "up") {
+    result.presetId = "calm_very_low";
+    result.intensity = "feather";
+    result.crossfadeMs = Math.max(result.crossfadeMs, BASE_PRESETS.calm_very_low.crossfadeMs);
+    result.narrative =
+      "On enveloppe la séance d'un nuage très doux pour apaiser la fatigue ressentie.";
+    result.adjustments.softenedForFatigue = true;
+  }
+
+  if (tensionTrend === "down") {
+    result.crossfadeMs = Math.min(result.crossfadeMs + 900, 5200);
+    result.narrative = `${result.narrative} La transition se prolonge pour savourer cette détente.`;
+    result.cta = "encore_2_min";
+    result.adjustments.extendedForTensionRelease = true;
+  }
+
+  if (summary.note) {
+    result.narrative = `${result.narrative} ${summary.note}`.trim();
+  }
+
+  if (!result.adjustments.softenedForFatigue && !result.adjustments.extendedForTensionRelease) {
+    result.adjustments.source = fromPoms ? "poms" : "sam";
+  }
+
+  return result;
+};
+
+export default mapStateToPreset;

--- a/src/ui/AudioPlayer.tsx
+++ b/src/ui/AudioPlayer.tsx
@@ -1,73 +1,77 @@
 "use client";
+
 import React from "react";
 import * as Sentry from "@sentry/react";
-import { useSound } from "@/ui/hooks/useSound";
+
+import { useMotionPrefs } from "@/hooks/useMotionPrefs";
 import { clamp01 } from "@/lib/audio/utils";
+import { useSound } from "@/ui/hooks/useSound";
 
-export const ADAPTIVE_MUSIC_FAVORITES_EVENT = "adaptive-music:favorites-changed";
-export const ADAPTIVE_MUSIC_PLAYBACK_EVENT = "adaptive-music:playback-changed";
-
-type FavoriteEntry = {
-  id: string;
-  title?: string;
-  src: string;
-  addedAt: string;
+export type FavoriteControls = {
+  active: boolean;
+  onToggle: () => Promise<void> | void;
+  busy?: boolean;
+  addLabel?: string;
+  removeLabel?: string;
 };
 
-export type AudioPlayerFavoriteEntry = FavoriteEntry;
+export type ResumeControls = {
+  position: number;
+  onResume: () => Promise<void> | void;
+  label?: string;
+  allow?: boolean;
+};
 
-type PlaybackPersistedState = {
+export interface PlaybackSnapshot {
+  trackId: string;
   position: number;
   volume: number;
   wasPlaying: boolean;
   updatedAt: number;
-  trackTitle?: string;
-  trackSrc?: string;
+  presetId?: string;
+  title?: string;
+  src: string;
+}
+
+type AudioPlayerProps = {
+  src: string;
+  title?: string;
+  trackId?: string;
+  loop?: boolean;
+  defaultVolume?: number;
+  presetId?: string;
+  crossfadeMs?: number;
+  favorite?: FavoriteControls;
+  resume?: ResumeControls;
+  onProgress?: (snapshot: PlaybackSnapshot) => void;
+  onPause?: () => void;
 };
 
-const FAVORITES_STORAGE_KEY = "adaptive-music:favorites";
-
-const formatTime = (totalSeconds: number) => {
+const formatTime = (totalSeconds: number): string => {
   if (!Number.isFinite(totalSeconds) || totalSeconds <= 0) return "0:00";
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = Math.floor(totalSeconds % 60);
   return `${minutes}:${seconds.toString().padStart(2, "0")}`;
 };
 
-type Props = {
-  src: string;
-  title?: string;
-  trackId?: string;
-  loop?: boolean;
-  defaultVolume?: number; // 0..1
-  haptics?: boolean;
-};
+const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 export function AudioPlayer({
   src,
   title,
   trackId,
   loop,
-  defaultVolume = 0.8,
-  haptics = false
-}: Props) {
-  const safeDefaultVolume = clamp01(defaultVolume);
+  defaultVolume = 0.75,
+  presetId,
+  crossfadeMs,
+  favorite,
+  resume,
+  onProgress,
+  onPause,
+}: AudioPlayerProps) {
   const trackKey = React.useMemo(() => trackId ?? src, [trackId, src]);
-  const playbackStorageKey = React.useMemo(
-    () => `adaptive-music:playback:${trackKey}`,
-    [trackKey]
-  );
-  const defaultPlaybackState = React.useMemo<PlaybackPersistedState>(
-    () => ({
-      position: 0,
-      volume: safeDefaultVolume,
-      wasPlaying: false,
-      updatedAt: Date.now(),
-      trackSrc: src,
-      trackTitle: title,
-    }),
-    [safeDefaultVolume, src, title]
-  );
+  const safeDefaultVolume = clamp01(defaultVolume);
+  const { prefersReducedMotion } = useMotionPrefs();
 
   const {
     ready,
@@ -76,34 +80,91 @@ export function AudioPlayer({
     setVolume: setSoundVolume,
     seek,
     getTime,
-    onEnded
+    onEnded,
   } = useSound(src, { loop, volume: safeDefaultVolume });
 
   const [playing, setPlaying] = React.useState(false);
   const [volume, setVolume] = React.useState(safeDefaultVolume);
-  const [favorites, setFavorites] = React.useState<FavoriteEntry[]>([]);
-  const [resumePosition, setResumePosition] = React.useState(0);
+  const [resumePosition, setResumePosition] = React.useState(resume?.position ?? 0);
 
-  const playbackRef = React.useRef<PlaybackPersistedState>(defaultPlaybackState);
+  const fadingRef = React.useRef(false);
+  const currentVolumeRef = React.useRef(safeDefaultVolume);
 
-  const logPlaybackBreadcrumb = React.useCallback(
-    (message: string, level: 'info' | 'error' = 'info', data?: Record<string, unknown>) => {
-      const client = Sentry.getCurrentHub().getClient();
-      if (!client) {
+  const updateAudioVolume = React.useCallback(
+    (next: number) => {
+      const clamped = clamp01(next);
+      currentVolumeRef.current = clamped;
+      setSoundVolume?.(clamped);
+    },
+    [setSoundVolume],
+  );
+
+  React.useEffect(() => {
+    setResumePosition(resume?.position ?? 0);
+  }, [resume?.position, trackKey]);
+
+  React.useEffect(() => {
+    if (fadingRef.current) return;
+    updateAudioVolume(volume);
+  }, [volume, updateAudioVolume]);
+
+  const fadeToVolume = React.useCallback(
+    async (target: number, durationMs: number) => {
+      if (!setSoundVolume || durationMs <= 0) {
+        updateAudioVolume(target);
         return;
       }
+
+      fadingRef.current = true;
+      const start = currentVolumeRef.current;
+      const duration = Math.max(80, durationMs);
+      const steps = Math.max(1, Math.round(duration / 80));
+      for (let index = 1; index <= steps; index += 1) {
+        const ratio = index / steps;
+        const value = start + (target - start) * ratio;
+        updateAudioVolume(value);
+        await wait(duration / steps);
+      }
+      updateAudioVolume(target);
+      fadingRef.current = false;
+    },
+    [setSoundVolume, updateAudioVolume],
+  );
+
+  const logBreadcrumb = React.useCallback(
+    (message: string, data?: Record<string, unknown>) => {
+      const client = Sentry.getCurrentHub().getClient();
+      if (!client) return;
       Sentry.addBreadcrumb({
-        category: 'music',
-        level,
+        category: "music",
+        level: "info",
         message,
-        data: { trackId: trackKey, ...(data ?? {}) },
+        data: { trackId: trackKey, presetId, ...(data ?? {}) },
       });
     },
-    [trackKey],
+    [trackKey, presetId],
+  );
+
+  const persist = React.useCallback(
+    (update: Partial<PlaybackSnapshot>) => {
+      const payload: PlaybackSnapshot = {
+        trackId: trackKey,
+        position: typeof update.position === "number" ? Math.max(0, update.position) : getTime?.() ?? 0,
+        volume: typeof update.volume === "number" ? clamp01(update.volume) : volume,
+        wasPlaying: typeof update.wasPlaying === "boolean" ? update.wasPlaying : playing,
+        updatedAt: Date.now(),
+        presetId,
+        title,
+        src,
+      };
+
+      setResumePosition(payload.position);
+      onProgress?.(payload);
+    },
+    [getTime, onProgress, playing, presetId, src, title, trackKey, volume],
   );
 
   const applyHaptics = React.useCallback(() => {
-    if (!haptics) return;
     if (typeof window === "undefined" || typeof navigator === "undefined") return;
     const prefersReduced = window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches;
     if (!prefersReduced && "vibrate" in navigator) {
@@ -113,353 +174,171 @@ export function AudioPlayer({
         console.warn("Haptics unavailable", error);
       }
     }
-  }, [haptics]);
-
-  const dispatchFavoritesChanged = React.useCallback((entries: FavoriteEntry[]) => {
-    if (typeof window === "undefined") return;
-    try {
-      window.dispatchEvent(new CustomEvent(ADAPTIVE_MUSIC_FAVORITES_EVENT, { detail: entries }));
-    } catch (error) {
-      console.warn("Unable to broadcast favorites", error);
-    }
   }, []);
 
-  const dispatchPlaybackChanged = React.useCallback(
-    (state: PlaybackPersistedState) => {
-      if (typeof window === "undefined") return;
-      try {
-        window.dispatchEvent(
-          new CustomEvent(ADAPTIVE_MUSIC_PLAYBACK_EVENT, {
-            detail: {
-              trackId: trackKey,
-              title,
-              src,
-              state,
-            },
-          })
-        );
-      } catch (error) {
-        console.warn("Unable to broadcast playback", error);
-      }
-    },
-    [trackKey, title, src]
-  );
-
-  const persistPlayback = React.useCallback(
-    (update: Partial<PlaybackPersistedState>, options?: { skipState?: boolean }) => {
-      const nextPosition =
-        typeof update.position === "number"
-          ? Math.max(0, update.position)
-          : playbackRef.current.position;
-      const nextVolume =
-        typeof update.volume === "number"
-          ? clamp01(update.volume)
-          : playbackRef.current.volume;
-      const nextWasPlaying =
-        typeof update.wasPlaying === "boolean"
-          ? update.wasPlaying
-          : playbackRef.current.wasPlaying;
-
-      const nextState: PlaybackPersistedState = {
-        position: nextPosition,
-        volume: nextVolume,
-        wasPlaying: nextWasPlaying,
-        updatedAt: Date.now(),
-        trackSrc: src,
-        trackTitle: title,
-      };
-
-      playbackRef.current = nextState;
-
-      if (typeof window !== "undefined") {
-        try {
-          window.localStorage.setItem(playbackStorageKey, JSON.stringify(nextState));
-        } catch (error) {
-          console.warn("Unable to persist playback state", error);
-        }
+  const startPlayback = React.useCallback(
+    async (targetPosition?: number) => {
+      if (typeof targetPosition === "number") {
+        seek?.(targetPosition);
       }
 
-      dispatchPlaybackChanged(nextState);
+      await playSound?.();
+      setPlaying(true);
+      applyHaptics();
+      logBreadcrumb("music:play", { resume: targetPosition ?? 0 });
 
-      if (!options?.skipState && typeof update.position === "number") {
-        const safePosition = Math.max(0, update.position);
-        setResumePosition(prev =>
-          Math.abs(prev - safePosition) < 0.01 ? prev : safePosition
-        );
+      const fadeDuration = prefersReducedMotion ? 0 : crossfadeMs ?? 0;
+      if (fadeDuration > 0) {
+        updateAudioVolume(0);
+        await fadeToVolume(volume, fadeDuration);
+      } else {
+        updateAudioVolume(volume);
       }
+
+      const position = typeof targetPosition === "number" ? targetPosition : getTime?.() ?? 0;
+      persist({ wasPlaying: true, position });
     },
-    [playbackStorageKey, dispatchPlaybackChanged, src, title]
+    [applyHaptics, crossfadeMs, fadeToVolume, getTime, logBreadcrumb, persist, playSound, prefersReducedMotion, seek, updateAudioVolume, volume],
   );
 
-  const updateFavorites = React.useCallback(
-    (updater: (prev: FavoriteEntry[]) => FavoriteEntry[]) => {
-      setFavorites(prev => {
-        const next = updater(prev);
-        if (typeof window !== "undefined") {
-          try {
-            window.localStorage.setItem(FAVORITES_STORAGE_KEY, JSON.stringify(next));
-          } catch (error) {
-            console.warn("Unable to persist favorites", error);
-          }
-        }
-        dispatchFavoritesChanged(next);
-        return next;
-      });
-    },
-    [dispatchFavoritesChanged]
-  );
+  const stopPlayback = React.useCallback(async () => {
+    const fadeDuration = prefersReducedMotion ? 0 : (crossfadeMs ?? 0) * 0.6;
+    if (fadeDuration > 0 && playing) {
+      await fadeToVolume(0, fadeDuration);
+    }
 
-  React.useEffect(() => {
+    pauseSound?.();
     setPlaying(false);
-  }, [trackKey]);
+    logBreadcrumb("music:pause");
 
-  React.useEffect(() => {
-    if (typeof window === "undefined") {
-      playbackRef.current = defaultPlaybackState;
-      setResumePosition(defaultPlaybackState.position);
-      setVolume(defaultPlaybackState.volume);
-      return;
-    }
+    updateAudioVolume(volume);
+    const position = getTime?.() ?? 0;
+    persist({ wasPlaying: false, position });
+    onPause?.();
+  }, [crossfadeMs, fadeToVolume, getTime, logBreadcrumb, onPause, pauseSound, persist, playing, prefersReducedMotion, updateAudioVolume, volume]);
 
+  const onTogglePlay = React.useCallback(async () => {
     try {
-      const raw = window.localStorage.getItem(playbackStorageKey);
-      if (!raw) {
-        playbackRef.current = defaultPlaybackState;
-        setResumePosition(defaultPlaybackState.position);
-        setVolume(current =>
-          Math.abs(current - defaultPlaybackState.volume) < 0.001
-            ? current
-            : defaultPlaybackState.volume
-        );
-        return;
-      }
-
-      const parsed = JSON.parse(raw);
-      const normalized: PlaybackPersistedState = {
-        position:
-          typeof parsed?.position === "number"
-            ? Math.max(0, parsed.position)
-            : defaultPlaybackState.position,
-        volume:
-          typeof parsed?.volume === "number"
-            ? clamp01(parsed.volume)
-            : defaultPlaybackState.volume,
-        wasPlaying: typeof parsed?.wasPlaying === "boolean" ? parsed.wasPlaying : false,
-        updatedAt: typeof parsed?.updatedAt === "number" ? parsed.updatedAt : Date.now(),
-        trackSrc: typeof parsed?.trackSrc === "string" ? parsed.trackSrc : src,
-        trackTitle: typeof parsed?.trackTitle === "string" ? parsed.trackTitle : title,
-      };
-
-      playbackRef.current = normalized;
-      setResumePosition(normalized.position);
-      setVolume(current =>
-        Math.abs(current - normalized.volume) < 0.001 ? current : normalized.volume
-      );
-      dispatchPlaybackChanged(normalized);
-    } catch (error) {
-      console.warn("Unable to restore playback state", error);
-      playbackRef.current = defaultPlaybackState;
-      setResumePosition(defaultPlaybackState.position);
-      setVolume(defaultPlaybackState.volume);
-    }
-  }, [playbackStorageKey, defaultPlaybackState, dispatchPlaybackChanged, src, title]);
-
-  React.useEffect(() => {
-    if (typeof window === "undefined") return;
-
-    try {
-      const raw = window.localStorage.getItem(FAVORITES_STORAGE_KEY);
-      if (!raw) return;
-
-      const parsed = JSON.parse(raw);
-      if (!Array.isArray(parsed)) return;
-
-      const seen = new Set<string>();
-      const entries: FavoriteEntry[] = [];
-
-      for (const entry of parsed) {
-        if (!entry || typeof entry !== "object") continue;
-        const id = typeof entry.id === "string" ? entry.id : undefined;
-        const storedSrc = typeof entry.src === "string" ? entry.src : undefined;
-        if (!id || !storedSrc || seen.has(id)) continue;
-        seen.add(id);
-        entries.push({
-          id,
-          src: storedSrc,
-          title: typeof entry.title === "string" ? entry.title : undefined,
-          addedAt:
-            typeof entry.addedAt === "string" ? entry.addedAt : new Date().toISOString()
-        });
-      }
-
-      if (entries.length) {
-        updateFavorites(() => entries.slice(-50));
+      if (!playing) {
+        await startPlayback();
+      } else {
+        await stopPlayback();
       }
     } catch (error) {
-      console.warn("Unable to restore favorites", error);
+      console.warn("Audio toggle error", error);
+      Sentry.captureException(error);
     }
-  }, [updateFavorites]);
+  }, [playing, startPlayback, stopPlayback]);
 
-  React.useEffect(() => {
-    setSoundVolume?.(volume);
-  }, [setSoundVolume, volume]);
-
-  React.useEffect(() => {
-    if (Math.abs(playbackRef.current.volume - volume) < 0.001) return;
-    persistPlayback({ volume });
-  }, [volume, persistPlayback]);
+  const handleResume = React.useCallback(async () => {
+    if (!resume || resume.position <= 0 || resume.allow === false) return;
+    await startPlayback(resume.position);
+    await resume.onResume?.();
+  }, [resume, startPlayback]);
 
   React.useEffect(() => {
     if (!onEnded) return;
     onEnded(() => {
       setPlaying(false);
-      persistPlayback({ wasPlaying: false, position: 0 });
+      persist({ wasPlaying: false, position: 0 });
+      if (loop) {
+        logBreadcrumb("music:loop_restart");
+      }
     });
-  }, [onEnded, persistPlayback]);
+  }, [loop, onEnded, persist, logBreadcrumb]);
 
   React.useEffect(() => {
     if (!playing) return;
     const interval = window.setInterval(() => {
       const position = getTime?.() ?? 0;
-      persistPlayback({ position });
+      persist({ position, wasPlaying: true });
     }, 2000);
     return () => window.clearInterval(interval);
-  }, [playing, getTime, persistPlayback]);
+  }, [getTime, persist, playing]);
 
   React.useEffect(() => {
     return () => {
       const position = getTime?.() ?? 0;
-      persistPlayback({ position, wasPlaying: false }, { skipState: true });
+      persist({ position, wasPlaying: false });
     };
-  }, [getTime, persistPlayback]);
+  }, [getTime, persist]);
 
-  const isFavorite = React.useMemo(
-    () => favorites.some(entry => entry.id === trackKey),
-    [favorites, trackKey]
-  );
+  const hasResume = resume && resume.allow !== false && resumePosition > 1 && !playing;
+  const resumeButtonLabel = resume?.label ?? "Reprendre";
 
-  const toggleFavorite = React.useCallback(() => {
-    updateFavorites(prev => {
-      const exists = prev.some(entry => entry.id === trackKey);
-      if (exists) {
-        logPlaybackBreadcrumb('music:favourite_toggle', 'info', { state: 'removed' });
-        return prev.filter(entry => entry.id !== trackKey);
-      }
-
-      const sanitized = prev.filter(entry => entry.id !== trackKey);
-      const nextEntry: FavoriteEntry = {
-        id: trackKey,
-        title,
-        src,
-        addedAt: new Date().toISOString()
-      };
-
-      const next = [...sanitized, nextEntry];
-      logPlaybackBreadcrumb('music:favourite_toggle', 'info', { state: 'added' });
-      return next.slice(-50);
-    });
-  }, [trackKey, title, src, updateFavorites, logPlaybackBreadcrumb]);
-
-  const handleResume = React.useCallback(async () => {
-    if (resumePosition <= 0.01) return;
-    seek?.(resumePosition);
-    await playSound?.();
-    setPlaying(true);
-    applyHaptics();
-    persistPlayback({ wasPlaying: true, position: resumePosition });
-    logPlaybackBreadcrumb('music:resume', 'info', {
-      position: Number(resumePosition.toFixed(1)),
-    });
-  }, [resumePosition, seek, playSound, applyHaptics, persistPlayback, logPlaybackBreadcrumb]);
-
-  const hasResume = resumePosition > 0.5 && !playing;
-
-  const onTogglePlay = React.useCallback(async () => {
-    try {
-      if (!playing) {
-        await playSound?.();
-        setPlaying(true);
-        applyHaptics();
-        const position = getTime?.() ?? 0;
-        persistPlayback({ wasPlaying: true, position });
-        logPlaybackBreadcrumb('music:play', 'info', {
-          position: Number(position.toFixed(1)),
-        });
-      } else {
-        pauseSound?.();
-        const position = getTime?.() ?? 0;
-        setPlaying(false);
-        persistPlayback({ wasPlaying: false, position });
-        logPlaybackBreadcrumb('music:pause', 'info', {
-          position: Number(position.toFixed(1)),
-        });
-      }
-    } catch (error) {
-      console.warn("Audio toggle error", error);
-      logPlaybackBreadcrumb('music:play_error', 'error', {
-        reason: error instanceof Error ? error.name : 'unknown',
-      });
-    }
-  }, [playing, playSound, pauseSound, getTime, applyHaptics, persistPlayback, logPlaybackBreadcrumb]);
+  const favoriteActive = favorite?.active ?? false;
+  const favoriteAdd = favorite?.addLabel ?? "Ajouter aux favoris";
+  const favoriteRemove = favorite?.removeLabel ?? "Retirer des favoris";
 
   return (
-    <div aria-label={title ?? "Lecteur audio"} style={{ display: "grid", gap: 8 }}>
-      <div style={{ display: "grid", gap: 6 }}>
-        {title && <strong>{title}</strong>}
-        <div style={{ display: "flex", flexWrap: "wrap", gap: 8, alignItems: "center" }}>
+    <div aria-label={title ?? "Lecteur audio"} className="grid gap-3">
+      <div className="grid gap-2">
+        {title && <strong className="text-base font-semibold">{title}</strong>}
+        <div className="flex flex-wrap items-center gap-3">
           <button
             type="button"
             onClick={onTogglePlay}
             aria-pressed={playing}
-            data-ui="primary-cta"
+            className="rounded-full bg-primary px-4 py-2 text-primary-foreground"
           >
-            {playing ? "Pause" : "Lecture"}
+            {playing ? "Pause" : ready ? "Lecture" : "Chargement"}
           </button>
+
           {hasResume && (
             <button
               type="button"
               onClick={handleResume}
-              disabled={!ready}
-              data-ui="resume-button"
+              className="rounded-full border border-primary/40 px-3 py-2 text-sm"
             >
-              Reprendre ({formatTime(resumePosition)})
+              {resumeButtonLabel} ({formatTime(resumePosition)})
             </button>
           )}
+
           <button
             type="button"
-            onClick={toggleFavorite}
-            aria-pressed={isFavorite}
-            data-ui="favorite-toggle"
+            onClick={async () => {
+              if (favorite?.busy) return;
+              try {
+                await favorite?.onToggle?.();
+              } catch (error) {
+                console.warn("Favorite toggle failed", error);
+              }
+            }}
+            aria-pressed={favoriteActive}
+            className="rounded-full border border-muted px-3 py-2 text-sm"
+            disabled={!favorite}
           >
-            {isFavorite ? "Retirer des favoris" : "Ajouter aux favoris"}
+            {favoriteActive ? `★ ${favoriteRemove}` : `☆ ${favoriteAdd}`}
           </button>
         </div>
       </div>
 
-      <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
+      <label className="flex items-center gap-3 text-sm" htmlFor={`${trackKey}-volume`}>
         Volume
         <input
+          id={`${trackKey}-volume`}
           type="range"
           min={0}
           max={1}
           step={0.01}
           value={volume}
           onChange={event => setVolume(clamp01(parseFloat(event.target.value)))}
-          data-ui="volume-slider"
         />
       </label>
 
       {hasResume && (
-        <small aria-live="polite" style={{ opacity: 0.75 }}>
+        <small aria-live="polite" className="text-sm text-muted-foreground">
           Dernière écoute sauvegardée à {formatTime(resumePosition)}.
         </small>
       )}
 
-      {isFavorite && (
-        <small style={{ opacity: 0.75 }}>
-          Sauvegardé dans vos favoris locaux.
-        </small>
-      )}
+      <audio
+        aria-hidden
+        src={src}
+        preload="auto"
+        className="hidden"
+        data-playing={playing}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- rebuild adaptive music page to drive presets from current mood and optional POMS check-ins, add CTA handling, and update playlist UI without numeric metrics
- add hooks and services for current mood snapshot, Supabase-backed favorites, and persisted playback snapshots with resume prompts
- refactor audio player to support external favorites/crossfade, refresh dashboard music card, and cover mapping logic with unit and e2e tests

## Testing
- npx vitest run src/services/music/__tests__/presetMapper.spec.ts
- npx @playwright/test test e2e/adaptive-music.smoke.spec.ts *(fails: playwright binary unavailable)*


------
https://chatgpt.com/codex/tasks/task_e_68ce942f0d20832dafe3f42a6dbb7043