### PR TITLE
feat(scores): verbal charts with canvas export

### DIFF
--- a/src/core/flags.ts
+++ b/src/core/flags.ts
@@ -5,6 +5,7 @@ interface FeatureFlags {
   FF_VR: boolean;
   FF_COMMUNITY: boolean;
   FF_MANAGER_DASH: boolean;
+  FF_SCORES: boolean;
   
   // Clinical Assessment Feature Flags
   FF_ASSESS_WHO5: boolean;
@@ -34,6 +35,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   FF_VR: true,
   FF_COMMUNITY: true,
   FF_MANAGER_DASH: true,
+  FF_SCORES: true,
   
   // Clinical assessments - opt-in by default
   FF_ASSESS_WHO5: true,      // Well-being thermometer - gentle weekly

--- a/src/features/scores/ExportButton.tsx
+++ b/src/features/scores/ExportButton.tsx
@@ -4,7 +4,7 @@ import * as Sentry from '@sentry/react';
 import { Download } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
-import { exportSvgToPng } from '@/lib/export/svgExport';
+import { exportElementToPng } from '@/lib/export/domExport';
 
 export interface ExportButtonProps {
   targetRef: RefObject<HTMLElement | null>;
@@ -25,12 +25,6 @@ export function ExportButton({ targetRef, fileName, label, className, onError, o
       return;
     }
 
-    const svg = container.querySelector('svg');
-    if (!svg || !(svg instanceof SVGSVGElement)) {
-      onError?.('Le graphique ne contient pas de rendu SVG exportable.');
-      return;
-    }
-
     try {
       setIsExporting(true);
       onStart?.();
@@ -40,7 +34,7 @@ export function ExportButton({ targetRef, fileName, label, className, onError, o
         data: { fileName },
         level: 'info',
       });
-      await exportSvgToPng(svg, {
+      await exportElementToPng(container, {
         fileName,
         backgroundColor: '#ffffff',
         padding: 24,

--- a/src/features/scores/Mood30dChart.tsx
+++ b/src/features/scores/Mood30dChart.tsx
@@ -1,36 +1,33 @@
-import { forwardRef, useMemo } from 'react';
+import { forwardRef, useId, useMemo } from 'react';
 import type { ForwardedRef } from 'react';
-import { LineChart, Line, ResponsiveContainer, Tooltip, XAxis, YAxis, Legend } from 'recharts';
+import { Area, ComposedChart, Line, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 
-import { smooth, type MoodPoint } from '@/services/scores/dataApi';
+import type { MoodVerbalPoint } from './verbalizers';
+import { getMoodToneColor } from './verbalizers';
 import { useMotionPrefs } from '@/hooks/useMotionPrefs';
 
-const dateFormatter = new Intl.DateTimeFormat('fr-FR', { month: 'short', day: 'numeric' });
-
 export interface Mood30dChartProps {
-  points: MoodPoint[];
+  series: MoodVerbalPoint[];
   descriptionId: string;
   titleId: string;
 }
 
 export const Mood30dChart = forwardRef<HTMLDivElement, Mood30dChartProps>(function Mood30dChart(
-  { points, descriptionId, titleId },
+  { series, descriptionId, titleId },
   ref: ForwardedRef<HTMLDivElement>,
 ) {
   const { shouldAnimate } = useMotionPrefs();
+  const gradientId = useId();
 
-  const chartData = useMemo(() => {
-    if (points.length === 0) {
+  const chartData = useMemo<ChartMoodPoint[]>(() => {
+    if (!Array.isArray(series)) {
       return [];
     }
-    const valenceSeries = smooth(points.map(point => point.valence));
-    const arousalSeries = smooth(points.map(point => point.arousal));
-    return points.map((point, index) => ({
-      date: dateFormatter.format(new Date(point.date)),
-      Valence: Number.isFinite(valenceSeries[index]) ? valenceSeries[index] : undefined,
-      Arousal: Number.isFinite(arousalSeries[index]) ? arousalSeries[index] : undefined,
+    return series.map(point => ({
+      ...point,
+      color: getMoodToneColor(point.toneId),
     }));
-  }, [points]);
+  }, [series]);
 
   return (
     <figure
@@ -43,36 +40,110 @@ export const Mood30dChart = forwardRef<HTMLDivElement, Mood30dChartProps>(functi
     >
       <div className="h-72 w-full rounded-lg border border-border bg-card p-4">
         <ResponsiveContainer width="100%" height="100%">
-          <LineChart data={chartData} margin={{ top: 12, right: 16, left: 8, bottom: 0 }}>
-            <XAxis dataKey="date" stroke="currentColor" tickLine={false} axisLine={false} interval={4} minTickGap={32} />
-            <YAxis domain={[-1, 1]} stroke="currentColor" tickLine={false} width={40} allowDataOverflow />
-            <Legend formatter={value => (value === 'Valence' ? 'Valence' : 'Énergie')} />
-            <Tooltip
-              cursor={{ strokeDasharray: '3 3' }}
-              formatter={(value: number | undefined) => (typeof value === 'number' ? value.toFixed(2) : '—')}
-              labelFormatter={label => `Jour ${label}`}
+          <ComposedChart data={chartData} margin={{ top: 12, right: 8, left: 8, bottom: 0 }}>
+            <defs>
+              <linearGradient id={`${gradientId}-fill`} x1="0" x2="0" y1="0" y2="1">
+                <stop offset="0%" stopColor="#38bdf8" stopOpacity={0.45} />
+                <stop offset="50%" stopColor="#4ade80" stopOpacity={0.38} />
+                <stop offset="100%" stopColor="#fb7185" stopOpacity={0.32} />
+              </linearGradient>
+            </defs>
+            <XAxis
+              dataKey="dayLabel"
+              stroke="currentColor"
+              tickLine={false}
+              axisLine={false}
+              interval={3}
+              minTickGap={24}
             />
-            <Line
+            <YAxis domain={[0.5, 5.5]} hide allowDataOverflow />
+            <Tooltip cursor={{ strokeDasharray: '3 3' }} content={<MoodTooltip />} />
+            <Area
               type="monotone"
-              dataKey="Valence"
-              stroke="#6366f1"
-              strokeWidth={2}
-              dot={false}
+              dataKey="value"
+              stroke="transparent"
+              fill={`url(#${gradientId}-fill)`}
               isAnimationActive={shouldAnimate}
             />
             <Line
               type="monotone"
-              dataKey="Arousal"
-              stroke="#f97316"
-              strokeWidth={2}
-              dot={false}
+              dataKey="value"
+              stroke="#475569"
+              strokeWidth={1.5}
+              dot={<MoodDot />}
+              activeDot={<MoodActiveDot />}
               isAnimationActive={shouldAnimate}
             />
-          </LineChart>
+          </ComposedChart>
         </ResponsiveContainer>
       </div>
     </figure>
   );
 });
+
+interface ChartMoodPoint extends MoodVerbalPoint {
+  color: string;
+}
+
+interface MoodDotProps {
+  cx?: number;
+  cy?: number;
+  payload?: ChartMoodPoint;
+}
+
+function MoodDot({ cx, cy, payload }: MoodDotProps) {
+  if (typeof cx !== 'number' || typeof cy !== 'number' || !payload) {
+    return null;
+  }
+  return (
+    <circle
+      cx={cx}
+      cy={cy}
+      r={4}
+      stroke="#ffffff"
+      strokeWidth={1}
+      fill={payload.color}
+      aria-hidden="true"
+    />
+  );
+}
+
+function MoodActiveDot({ cx, cy, payload }: MoodDotProps) {
+  if (typeof cx !== 'number' || typeof cy !== 'number' || !payload) {
+    return null;
+  }
+  return (
+    <g aria-hidden="true">
+      <circle cx={cx} cy={cy} r={6} fill={payload.color} opacity={0.28} />
+      <circle cx={cx} cy={cy} r={4} stroke="#ffffff" strokeWidth={1} fill={payload.color} />
+    </g>
+  );
+}
+
+function MoodTooltip({ active, payload }: any) {
+  if (!active || !payload?.length) {
+    return null;
+  }
+  const datum = payload[0]?.payload as ChartMoodPoint | undefined;
+  if (!datum) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-md border border-slate-200 bg-white/95 p-3 text-sm text-slate-700 shadow-lg">
+      <p className="font-medium">{capitalize(datum.longLabel)}</p>
+      <p className="mt-1">
+        {capitalize(datum.toneLabel)} · {datum.nuance}
+      </p>
+    </div>
+  );
+}
+
+function capitalize(value: string) {
+  if (!value) {
+    return value;
+  }
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
 
 export default Mood30dChart;

--- a/src/features/scores/SessionsWeeklyChart.tsx
+++ b/src/features/scores/SessionsWeeklyChart.tsx
@@ -4,6 +4,11 @@ import { BarChart, Bar, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } fro
 
 import type { WeeklySessionPoint } from '@/services/scores/dataApi';
 import { useMotionPrefs } from '@/hooks/useMotionPrefs';
+import {
+  buildSessionVerbalRows,
+  describeSessionType,
+  type SessionVerbalRow,
+} from './verbalizers';
 
 const palette = ['#818cf8', '#34d399', '#fbbf24', '#f472b6', '#38bdf8', '#fb7185'];
 
@@ -33,10 +38,7 @@ export const SessionsWeeklyChart = forwardRef<HTMLDivElement, SessionsWeeklyChar
     }, [rows]);
 
     const chartData = useMemo(() => {
-      return rows.map(row => ({
-        ...row,
-        weekLabel: row.week.replace('W', 'S'),
-      }));
+      return buildSessionVerbalRows(rows);
     }, [rows]);
 
     return (
@@ -51,10 +53,10 @@ export const SessionsWeeklyChart = forwardRef<HTMLDivElement, SessionsWeeklyChar
         <div className="h-64 w-full rounded-lg border border-border bg-card p-4">
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={chartData} margin={{ top: 12, right: 16, left: 8, bottom: 0 }}>
-              <XAxis dataKey="weekLabel" stroke="currentColor" tickLine={false} axisLine={false} interval={0} />
-              <YAxis allowDecimals={false} stroke="currentColor" tickLine={false} width={32} />
-              <Tooltip cursor={{ fill: 'rgba(148, 163, 184, 0.18)' }} />
-              <Legend wrapperStyle={{ fontSize: '0.75rem' }} />
+              <XAxis dataKey="axisLabel" stroke="currentColor" tickLine={false} axisLine={false} interval={0} />
+              <YAxis hide allowDecimals={false} />
+              <Tooltip cursor={{ fill: 'rgba(148, 163, 184, 0.18)' }} content={<SessionsTooltip />} />
+              <Legend wrapperStyle={{ fontSize: '0.75rem' }} formatter={value => describeSessionType(String(value))} />
               {keys.map((key, index) => (
                 <Bar
                   key={key}
@@ -71,5 +73,26 @@ export const SessionsWeeklyChart = forwardRef<HTMLDivElement, SessionsWeeklyChar
     );
   },
 );
+
+function SessionsTooltip({ active, payload }: any) {
+  if (!active || !payload?.length) {
+    return null;
+  }
+  const datum = payload[0]?.payload as SessionVerbalRow | undefined;
+  if (!datum) {
+    return null;
+  }
+
+  const hasHighlights = datum.highlights.length > 0;
+  const highlightText = hasHighlights ? datum.highlights.join(', ') : 'Aucune pratique enregistrée.';
+
+  return (
+    <div className="max-w-xs rounded-md border border-slate-200 bg-white/95 p-3 text-sm text-slate-700 shadow-lg">
+      <p className="font-medium">{datum.longLabel}</p>
+      <p className="mt-1">{datum.rhythm}</p>
+      <p className="mt-1 text-xs text-slate-500">Moments phares : {highlightText}</p>
+    </div>
+  );
+}
 
 export default SessionsWeeklyChart;

--- a/src/features/scores/__tests__/VibesHeatmap.test.tsx
+++ b/src/features/scores/__tests__/VibesHeatmap.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import VibesHeatmap from '../VibesHeatmap';
+
+describe('VibesHeatmap', () => {
+  it('renders a stable accessible grid', () => {
+    const { container } = render(
+      <VibesHeatmap
+        points={[
+          { date: '2024-05-06', vibe: 'calm', intensity: 'medium', meta: { count: 2, total: 3 } },
+          { date: '2024-05-07', vibe: 'bright', intensity: 'deep', meta: { count: 3, total: 3 } },
+          { date: '2024-05-08', vibe: undefined, meta: { count: 0, total: 0 } },
+        ]}
+        titleId="title"
+        descriptionId="desc"
+      />,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+

--- a/src/features/scores/__tests__/__snapshots__/VibesHeatmap.test.tsx.snap
+++ b/src/features/scores/__tests__/__snapshots__/VibesHeatmap.test.tsx.snap
@@ -1,0 +1,216 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`VibesHeatmap > renders a stable accessible grid 1`] = `
+<figure
+  aria-describedby="desc"
+  aria-labelledby="title"
+  class="space-y-3"
+  data-testid="scores-heatmap-chart"
+  role="img"
+>
+  <div
+    class="rounded-lg border border-border bg-card p-4"
+  >
+    <div
+      class="flex gap-4"
+    >
+      <div
+        aria-hidden="true"
+        class="flex flex-col justify-between py-2 text-xs text-muted-foreground"
+      >
+        <span
+          class="h-[22px] leading-[22px]"
+        >
+          Lun
+        </span>
+        <span
+          class="h-[22px] leading-[22px]"
+        >
+          Mar
+        </span>
+        <span
+          class="h-[22px] leading-[22px]"
+        >
+          Mer
+        </span>
+        <span
+          class="h-[22px] leading-[22px]"
+        >
+          Jeu
+        </span>
+        <span
+          class="h-[22px] leading-[22px]"
+        >
+          Ven
+        </span>
+        <span
+          class="h-[22px] leading-[22px]"
+        >
+          Sam
+        </span>
+        <span
+          class="h-[22px] leading-[22px]"
+        >
+          Dim
+        </span>
+      </div>
+      <div
+        aria-label="Vibes quotidiennes"
+        class="grid"
+        role="grid"
+        style="grid-template-columns: repeat(1, 22px); gap: 6px; grid-auto-rows: 22px; grid-auto-flow: column;"
+      >
+        <div
+          aria-label="Lundi 6 mai : vibe Posé, nuance présente."
+          class="h-[22px] w-[22px] rounded-md outline-none transition-[box-shadow] focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          data-testid="heatmap-cell-2024-05-06-0-0"
+          role="gridcell"
+          style="background-color: rgb(52, 211, 153);"
+          tabindex="0"
+          title="Lundi 6 mai — Posé (nuance présente)"
+        >
+          <span
+            class="sr-only"
+          >
+            Lundi 6 mai — Posé (nuance présente)
+          </span>
+        </div>
+        <div
+          aria-label="Mardi 7 mai : vibe Lumineux, nuance intense."
+          class="h-[22px] w-[22px] rounded-md outline-none transition-[box-shadow] focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          data-testid="heatmap-cell-2024-05-07-0-1"
+          role="gridcell"
+          style="background-color: rgb(194, 65, 12);"
+          tabindex="0"
+          title="Mardi 7 mai — Lumineux (nuance intense)"
+        >
+          <span
+            class="sr-only"
+          >
+            Mardi 7 mai — Lumineux (nuance intense)
+          </span>
+        </div>
+        <div
+          aria-label="Mercredi 8 mai : aucune vibe dominante."
+          class="h-[22px] w-[22px] rounded-md outline-none transition-[box-shadow] focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          data-testid="heatmap-cell-2024-05-08-0-2"
+          role="gridcell"
+          style="background-color: rgb(226, 232, 240);"
+          tabindex="0"
+          title="Mercredi 8 mai — aucune vibe dominante"
+        >
+          <span
+            class="sr-only"
+          >
+            Mercredi 8 mai — aucune vibe dominante
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      aria-label="Légende des vibes"
+      class="mt-4 flex flex-wrap gap-3"
+      role="list"
+    >
+      <div
+        class="flex items-center gap-2"
+        role="listitem"
+      >
+        <span
+          aria-hidden="true"
+          class="inline-flex h-3 w-3 rounded-sm"
+          style="background-color: rgb(52, 211, 153);"
+        />
+        <span
+          class="text-xs text-muted-foreground"
+        >
+          Posé
+        </span>
+      </div>
+      <div
+        class="flex items-center gap-2"
+        role="listitem"
+      >
+        <span
+          aria-hidden="true"
+          class="inline-flex h-3 w-3 rounded-sm"
+          style="background-color: rgb(14, 165, 233);"
+        />
+        <span
+          class="text-xs text-muted-foreground"
+        >
+          Focalisé
+        </span>
+      </div>
+      <div
+        class="flex items-center gap-2"
+        role="listitem"
+      >
+        <span
+          aria-hidden="true"
+          class="inline-flex h-3 w-3 rounded-sm"
+          style="background-color: rgb(249, 115, 22);"
+        />
+        <span
+          class="text-xs text-muted-foreground"
+        >
+          Lumineux
+        </span>
+      </div>
+      <div
+        class="flex items-center gap-2"
+        role="listitem"
+      >
+        <span
+          aria-hidden="true"
+          class="inline-flex h-3 w-3 rounded-sm"
+          style="background-color: rgb(168, 85, 247);"
+        />
+        <span
+          class="text-xs text-muted-foreground"
+        >
+          Régénérant
+        </span>
+      </div>
+      <div
+        class="flex items-center gap-2"
+        role="listitem"
+      >
+        <span
+          aria-hidden="true"
+          class="inline-flex h-3 w-3 rounded-sm bg-muted"
+        />
+        <span
+          class="text-xs text-muted-foreground"
+        >
+          Aucune vibe détectée
+        </span>
+      </div>
+      <div
+        class="flex items-center gap-2"
+        role="listitem"
+      >
+        <div
+          aria-hidden="true"
+          class="flex h-3 overflow-hidden rounded-sm border border-border"
+        >
+          <span
+            class="h-full w-3 bg-slate-200"
+          />
+          <span
+            class="h-full w-3 bg-slate-400"
+          />
+          <span
+            class="h-full w-3 bg-slate-600"
+          />
+        </div>
+        <span
+          class="text-xs text-muted-foreground"
+        >
+          Intensité de la vibe
+        </span>
+      </div>
+    </div>
+  </div>
+</figure>
+`;

--- a/src/features/scores/__tests__/verbalizers.test.ts
+++ b/src/features/scores/__tests__/verbalizers.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildMoodVerbalSeries,
+  buildSessionVerbalRows,
+  describeSessionRhythm,
+  describeSessionType,
+  describeVibeIntensity,
+  getMoodToneColor,
+  getVibeColor,
+  summarizeMoodVerbalSeries,
+} from '../verbalizers';
+
+describe('scores verbalizers', () => {
+  it('transforms mood points into verbal series', () => {
+    const series = buildMoodVerbalSeries([
+      { date: '2024-05-01', valence: 0.5, arousal: 0.2 },
+      { date: '2024-05-02', valence: 0.1, arousal: 0.7 },
+    ]);
+
+    expect(series).toHaveLength(2);
+    expect(['cotonneux', 'calme']).toContain(series[0].toneLabel);
+    expect(['actif', 'éveillé']).toContain(series[1].toneLabel);
+    expect(getMoodToneColor(series[0].toneId)).toMatch(/^#/);
+    expect(summarizeMoodVerbalSeries(series)).toMatch(/Ambiance/);
+  });
+
+  it('verbalizes session rows with rhythm and highlights', () => {
+    const rows = buildSessionVerbalRows([
+      { week: '2024-W20', breath: 1, music: 2 },
+      { week: '2024-W21' },
+    ]);
+
+    expect(rows[0].highlights).toContain('Musique immersive');
+    expect(rows[0].rhythm).toBeTypeOf('string');
+    expect(describeSessionRhythm(0)).toContain('pause');
+    expect(describeSessionType('flashglow')).toBe('Flash Glow');
+  });
+
+  it('returns palette-driven colors for vibes and intensity labels', () => {
+    expect(getVibeColor('calm', 'deep')).toBe('#047857');
+    expect(getVibeColor(undefined as any, 'medium')).toBe('#d1d5db');
+    expect(describeVibeIntensity('light')).toBe('nuance douce');
+  });
+});
+

--- a/src/features/scores/verbalizers.ts
+++ b/src/features/scores/verbalizers.ts
@@ -1,0 +1,367 @@
+import { addDays, addWeeks, format, parseISO, startOfISOWeek } from 'date-fns';
+import { fr } from 'date-fns/locale';
+
+import type { MoodPoint, VibeIntensity, VibePoint, WeeklySessionPoint } from '@/services/scores/dataApi';
+
+export type MoodToneId = 'cotonneux' | 'calme' | 'posé' | 'actif' | 'éveillé';
+
+export interface MoodVerbalPoint {
+  date: string;
+  dayLabel: string;
+  longLabel: string;
+  toneId: MoodToneId;
+  toneLabel: string;
+  nuance: string;
+  value: number;
+}
+
+interface MoodToneDescriptor {
+  label: string;
+  color: string;
+  baseline: string;
+  value: number;
+}
+
+const MOOD_TONE_DESCRIPTORS: Record<MoodToneId, MoodToneDescriptor> = {
+  cotonneux: {
+    label: 'cotonneux',
+    color: '#c4b5fd',
+    baseline: 'moments feutrés, tournés vers soi',
+    value: 1,
+  },
+  calme: {
+    label: 'calme',
+    color: '#38bdf8',
+    baseline: 'respiration régulière et douce',
+    value: 2,
+  },
+  posé: {
+    label: 'posé',
+    color: '#4ade80',
+    baseline: 'équilibre rassurant et ancré',
+    value: 3,
+  },
+  actif: {
+    label: 'actif',
+    color: '#facc15',
+    baseline: 'élan tonique mais maîtrisé',
+    value: 4,
+  },
+  éveillé: {
+    label: 'éveillé',
+    color: '#fb7185',
+    baseline: 'énergie lumineuse et expansive',
+    value: 5,
+  },
+};
+
+const VIBE_INTENSITY_LABELS: Record<VibeIntensity, string> = {
+  light: 'nuance douce',
+  medium: 'nuance présente',
+  deep: 'nuance intense',
+};
+
+export interface VibeDescriptor {
+  key: string;
+  label: string;
+  description: string;
+  palette: Record<VibeIntensity, string>;
+}
+
+export const VIBE_DESCRIPTORS: Record<string, VibeDescriptor> = {
+  calm: {
+    key: 'calm',
+    label: 'posé',
+    description: 'ancrage tranquille',
+    palette: {
+      light: '#bbf7d0',
+      medium: '#34d399',
+      deep: '#047857',
+    },
+  },
+  focus: {
+    key: 'focus',
+    label: 'focalisé',
+    description: 'attention concentrée',
+    palette: {
+      light: '#bae6fd',
+      medium: '#0ea5e9',
+      deep: '#0369a1',
+    },
+  },
+  bright: {
+    key: 'bright',
+    label: 'lumineux',
+    description: 'élan joyeux',
+    palette: {
+      light: '#fed7aa',
+      medium: '#f97316',
+      deep: '#c2410c',
+    },
+  },
+  reset: {
+    key: 'reset',
+    label: 'régénérant',
+    description: 'mise à zéro réparatrice',
+    palette: {
+      light: '#e9d5ff',
+      medium: '#a855f7',
+      deep: '#6b21a8',
+    },
+  },
+};
+
+export function getMoodToneDescriptor(tone: MoodToneId): MoodToneDescriptor {
+  return MOOD_TONE_DESCRIPTORS[tone];
+}
+
+export function getMoodToneColor(tone: MoodToneId): string {
+  return MOOD_TONE_DESCRIPTORS[tone].color;
+}
+
+const SESSION_LABELS: Record<string, string> = {
+  breath: 'Respiration guidée',
+  breathwork: 'Respiration guidée',
+  flashglow: 'Flash Glow',
+  music: 'Musique immersive',
+  journal: 'Écriture',
+  vr: 'Exploration VR',
+  autre: 'Autres pratiques',
+};
+
+export interface SessionVerbalRow extends WeeklySessionPoint {
+  weekKey: string;
+  axisLabel: string;
+  longLabel: string;
+  total: number;
+  rhythm: string;
+  highlights: string[];
+}
+
+export function buildMoodVerbalSeries(points: MoodPoint[]): MoodVerbalPoint[] {
+  if (!Array.isArray(points)) {
+    return [];
+  }
+
+  return points
+    .map(point => {
+      const date = safeParseDate(point.date);
+      const toneId = resolveMoodTone(point);
+      const descriptor = MOOD_TONE_DESCRIPTORS[toneId];
+      const valence = typeof point.valence === 'number' ? point.valence : 0;
+      const arousal = typeof point.arousal === 'number' ? point.arousal : 0.5;
+
+      return {
+        date: point.date,
+        toneId,
+        toneLabel: descriptor.label,
+        nuance: describeMoodNuance(toneId, valence, arousal),
+        value: descriptor.value,
+        dayLabel: date ? format(date, 'd MMM', { locale: fr }) : point.date,
+        longLabel: date ? format(date, "EEEE d MMMM", { locale: fr }) : point.date,
+      } satisfies MoodVerbalPoint;
+    })
+    .sort((a, b) => (a.date < b.date ? -1 : 1));
+}
+
+export function summarizeMoodVerbalSeries(series: MoodVerbalPoint[]): string {
+  if (!series.length) {
+    return 'Humeur en attente de nouveaux scans.';
+  }
+
+  const ranking = series.reduce<Record<MoodToneId, number>>((acc, point) => {
+    acc[point.toneId] = (acc[point.toneId] ?? 0) + 1;
+    return acc;
+  }, {} as Record<MoodToneId, number>);
+
+  const ordered = Object.entries(ranking).sort(([, a], [, b]) => b - a) as Array<[MoodToneId, number]>;
+  if (!ordered.length) {
+    return 'Ambiance stable et discrète.';
+  }
+
+  const [primary] = ordered[0];
+  const secondary = ordered[1]?.[0];
+  const mainLabel = capitalize(MOOD_TONE_DESCRIPTORS[primary].label);
+
+  if (secondary) {
+    const secondaryLabel = MOOD_TONE_DESCRIPTORS[secondary].label;
+    return `Ambiance surtout ${mainLabel}, avec des touches ${secondaryLabel}.`;
+  }
+
+  return `Ambiance surtout ${mainLabel}.`;
+}
+
+export function buildSessionVerbalRows(rows: WeeklySessionPoint[]): SessionVerbalRow[] {
+  if (!Array.isArray(rows)) {
+    return [];
+  }
+
+  return rows.map(row => {
+    const counts = Object.entries(row)
+      .filter(([key, value]) => key !== 'week' && typeof value === 'number')
+      .map(([key, value]) => ({ type: key, count: Number(value) }));
+
+    const total = counts.reduce((acc, item) => acc + item.count, 0);
+    const highlights = counts
+      .filter(item => item.count > 0)
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 2)
+      .map(item => describeSessionType(item.type));
+
+    const { axisLabel, longLabel } = describeWeek(row.week);
+
+    return {
+      ...row,
+      weekKey: row.week,
+      axisLabel,
+      longLabel,
+      total,
+      rhythm: describeSessionRhythm(total),
+      highlights,
+    } satisfies SessionVerbalRow;
+  });
+}
+
+export function describeSessionRhythm(total: number): string {
+  if (total <= 0) {
+    return 'Semaine en pause douce.';
+  }
+  if (total <= 2) {
+    return 'Quelques pratiques ponctuent la semaine.';
+  }
+  if (total <= 4) {
+    return 'Rythme régulier et ancré.';
+  }
+  return 'Pratiques nombreuses et élan dynamique.';
+}
+
+export function describeSessionType(type: string): string {
+  const sanitized = type.toLowerCase();
+  if (SESSION_LABELS[sanitized]) {
+    return SESSION_LABELS[sanitized];
+  }
+  return capitalize(type.replace(/[-_]/g, ' '));
+}
+
+export function describeVibe(vibe?: string) {
+  if (!vibe) {
+    return undefined;
+  }
+  return VIBE_DESCRIPTORS[vibe];
+}
+
+export function describeVibeIntensity(intensity: VibeIntensity | undefined): string {
+  if (!intensity) {
+    return 'nuance neutre';
+  }
+  return VIBE_INTENSITY_LABELS[intensity];
+}
+
+export function getVibeColor(vibe: string | undefined, intensity: VibeIntensity = 'medium'): string {
+  const descriptor = vibe ? VIBE_DESCRIPTORS[vibe] : undefined;
+  if (!descriptor) {
+    return '#d1d5db';
+  }
+  return descriptor.palette[intensity] ?? descriptor.palette.medium;
+}
+
+export function buildHeatmapIntensity(point: VibePoint): VibeIntensity | undefined {
+  if (point?.intensity) {
+    return point.intensity as VibeIntensity;
+  }
+
+  const total = point?.meta?.total ?? 0;
+  const count = point?.meta?.count ?? 0;
+  const ratio = total === 0 ? 0 : count / total;
+
+  if (ratio >= 0.66) {
+    return 'deep';
+  }
+  if (ratio >= 0.33) {
+    return 'medium';
+  }
+  if (ratio > 0) {
+    return 'light';
+  }
+  return undefined;
+}
+
+function resolveMoodTone(point: MoodPoint): MoodToneId {
+  const valence = typeof point.valence === 'number' ? point.valence : 0;
+  const arousal = typeof point.arousal === 'number' ? point.arousal : 0.5;
+
+  if (arousal <= 0.25) {
+    return 'cotonneux';
+  }
+  if (arousal <= 0.45) {
+    return valence >= 0 ? 'calme' : 'cotonneux';
+  }
+  if (arousal <= 0.65) {
+    return valence >= 0.1 ? 'posé' : 'calme';
+  }
+  if (arousal <= 0.8) {
+    return valence >= -0.2 ? 'actif' : 'cotonneux';
+  }
+  return valence >= 0 ? 'éveillé' : 'actif';
+}
+
+function describeMoodNuance(tone: MoodToneId, valence: number, arousal: number): string {
+  switch (tone) {
+    case 'cotonneux':
+      return valence < -0.2 ? 'introspection feutrée' : 'pause en apesanteur';
+    case 'calme':
+      return valence >= 0 ? 'calme confiant' : 'calme en recherche';
+    case 'posé':
+      return valence >= 0.4 ? 'stabilité lumineuse' : 'équilibre délicat';
+    case 'actif':
+      return valence >= 0 ? 'élan organisé' : 'mouvement à apprivoiser';
+    case 'éveillé':
+      return arousal > 0.9 ? 'éveil pétillant' : 'éveil doux';
+    default:
+      return MOOD_TONE_DESCRIPTORS[tone].baseline;
+  }
+}
+
+function describeWeek(weekKey: string | undefined) {
+  if (!weekKey) {
+    return { axisLabel: 'Semaine', longLabel: 'Semaine en cours' };
+  }
+
+  const [yearPart, weekPart] = weekKey.split('-W');
+  const year = Number.parseInt(yearPart ?? '', 10);
+  const week = Number.parseInt(weekPart ?? '', 10);
+
+  if (Number.isNaN(year) || Number.isNaN(week)) {
+    return { axisLabel: weekKey, longLabel: `Semaine ${weekKey}` };
+  }
+
+  const january4 = new Date(year, 0, 4);
+  const firstWeekStart = startOfISOWeek(january4);
+  const weekStart = addWeeks(firstWeekStart, Math.max(week - 1, 0));
+  const weekEnd = addDays(weekStart, 6);
+
+  return {
+    axisLabel: `Sem. ${format(weekStart, 'd MMM', { locale: fr })}`,
+    longLabel: `Semaine du ${format(weekStart, 'd MMMM', { locale: fr })} au ${format(weekEnd, 'd MMMM', {
+      locale: fr,
+    })}`,
+  };
+}
+
+function capitalize(value: string): string {
+  if (!value) {
+    return value;
+  }
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function safeParseDate(value: string | Date | undefined): Date | null {
+  if (!value) {
+    return null;
+  }
+  if (value instanceof Date) {
+    return value;
+  }
+  const parsed = parseISO(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}

--- a/src/hooks/useChartExporter.ts
+++ b/src/hooks/useChartExporter.ts
@@ -1,8 +1,8 @@
 import { useCallback, useState } from 'react';
 import type { RefObject } from 'react';
-import { exportSvgToPng, type SvgExportOptions } from '@/lib/export/svgExport';
+import { exportElementToPng, type DomExportOptions } from '@/lib/export/domExport';
 
-export interface ChartExportOptions extends SvgExportOptions {}
+export interface ChartExportOptions extends DomExportOptions {}
 
 export function useChartExporter(defaultOptions?: ChartExportOptions) {
   const [isExporting, setIsExporting] = useState(false);
@@ -16,16 +16,10 @@ export function useChartExporter(defaultOptions?: ChartExportOptions) {
         return;
       }
 
-      const svg = element.querySelector('svg');
-      if (!svg || !(svg instanceof SVGSVGElement)) {
-        setError('Le graphique sélectionné ne contient pas de rendu SVG exportable.');
-        return;
-      }
-
       try {
         setIsExporting(true);
         setError(null);
-        await exportSvgToPng(svg, { ...defaultOptions, ...options });
+        await exportElementToPng(element, { ...defaultOptions, ...options });
       } catch (exportError) {
         console.error('Chart export failed', exportError);
         setError(exportError instanceof Error ? exportError.message : 'Export impossible.');

--- a/src/lib/export/domExport.ts
+++ b/src/lib/export/domExport.ts
@@ -1,0 +1,62 @@
+import html2canvas from 'html2canvas';
+
+import { sanitizeFileName, triggerDownload } from './utils';
+
+export interface DomExportOptions {
+  fileName?: string;
+  backgroundColor?: string;
+  padding?: number;
+  scale?: number;
+}
+
+export async function exportElementToPng(element: HTMLElement, options: DomExportOptions = {}): Promise<void> {
+  if (typeof window === 'undefined') {
+    throw new Error("L'export PNG est uniquement disponible dans le navigateur.");
+  }
+
+  const {
+    fileName = 'chart',
+    backgroundColor = '#ffffff',
+    padding = 24,
+    scale = window.devicePixelRatio || 1,
+  } = options;
+
+  const captureScale = Math.min(3, Math.max(1, scale));
+
+  const canvas = await html2canvas(element, {
+    backgroundColor,
+    scale: captureScale,
+    logging: false,
+    useCORS: true,
+    windowWidth: element.scrollWidth,
+    windowHeight: element.scrollHeight,
+  });
+
+  if (!canvas) {
+    throw new Error('Impossible de capturer cette vue.');
+  }
+
+  const paddingValue = Math.max(0, padding);
+  let exportCanvas = canvas;
+
+  if (paddingValue > 0) {
+    const paddedCanvas = document.createElement('canvas');
+    paddedCanvas.width = canvas.width + paddingValue * 2;
+    paddedCanvas.height = canvas.height + paddingValue * 2;
+
+    const context = paddedCanvas.getContext('2d');
+    if (!context) {
+      throw new Error('Impossible de préparer le rendu PNG.');
+    }
+
+    context.fillStyle = backgroundColor;
+    context.fillRect(0, 0, paddedCanvas.width, paddedCanvas.height);
+    context.drawImage(canvas, paddingValue, paddingValue);
+
+    exportCanvas = paddedCanvas;
+  }
+
+  const dataUrl = exportCanvas.toDataURL('image/png', 0.92);
+  triggerDownload(`${sanitizeFileName(fileName)}.png`, dataUrl);
+}
+

--- a/src/lib/export/svgExport.ts
+++ b/src/lib/export/svgExport.ts
@@ -1,3 +1,5 @@
+import { sanitizeFileName, triggerDownload } from './utils';
+
 export interface SvgExportOptions {
   fileName?: string;
   backgroundColor?: string;
@@ -90,16 +92,5 @@ function loadImage(url: string, width: number, height: number): Promise<HTMLImag
     };
     image.src = url;
   });
-}
-
-function triggerDownload(fileName: string, dataUrl: string) {
-  const link = document.createElement('a');
-  link.download = fileName;
-  link.href = dataUrl;
-  link.click();
-}
-
-function sanitizeFileName(value: string): string {
-  return value.replace(/[^a-z0-9-_]/gi, '-');
 }
 

--- a/src/lib/export/utils.ts
+++ b/src/lib/export/utils.ts
@@ -1,0 +1,15 @@
+export function triggerDownload(fileName: string, dataUrl: string) {
+  const link = document.createElement('a');
+  link.download = fileName;
+  link.href = dataUrl;
+  link.rel = 'noopener';
+  link.style.display = 'none';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
+export function sanitizeFileName(value: string): string {
+  return value.replace(/[^a-z0-9-_]/gi, '-');
+}
+

--- a/src/pages/ScoresPage.tsx
+++ b/src/pages/ScoresPage.tsx
@@ -1,8 +1,25 @@
 import React from 'react';
 import { FadeIn, PageHeader } from '@/COMPONENTS.reg';
+import { useFlags } from '@/core/flags';
 import ScoresV2Panel from '@/modules/scores/ScoresV2Panel';
 
 const ScoresPage: React.FC = () => {
+  const { flags } = useFlags();
+
+  if (!flags.FF_SCORES) {
+    return (
+      <main className="space-y-8 pb-16" aria-label="Scores émotionnels">
+        <PageHeader
+          title="Scores & vibes"
+          subtitle="Visualisation synthétique de vos scans, séances et vibes dominantes sur les dernières semaines"
+        />
+        <section className="rounded-lg border border-dashed bg-muted/30 p-6 text-sm text-muted-foreground">
+          Cette visualisation est en phase de lancement et n'est pas encore activée pour votre espace.
+        </section>
+      </main>
+    );
+  }
+
   return (
     <main className="space-y-8 pb-16" aria-label="Scores émotionnels">
       <PageHeader

--- a/src/services/scores/__tests__/dataApi.test.ts
+++ b/src/services/scores/__tests__/dataApi.test.ts
@@ -67,9 +67,24 @@ describe('buildHeatmap', () => {
     vi.setSystemTime(new Date('2024-05-03T00:00:00.000Z'));
 
     const result = buildHeatmap(rows as any, 3);
-    expect(result[0]).toMatchObject({ date: '2024-05-01', vibe: 'bright' });
-    expect(result[1]).toMatchObject({ date: '2024-05-02', vibe: 'focus' });
-    expect(result[2]).toMatchObject({ date: '2024-05-03', vibe: undefined });
+    expect(result[0]).toMatchObject({
+      date: '2024-05-01',
+      vibe: 'bright',
+      intensity: 'deep',
+      meta: { count: 2, total: 2 },
+    });
+    expect(result[1]).toMatchObject({
+      date: '2024-05-02',
+      vibe: 'focus',
+      intensity: 'deep',
+      meta: { count: 1, total: 1 },
+    });
+    expect(result[2]).toMatchObject({
+      date: '2024-05-03',
+      vibe: undefined,
+      intensity: undefined,
+      meta: { count: 0, total: 0 },
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- verbalize mood and session series with narrative tooltips and accessible heatmap palettes
- capture score visuals via html2canvas, wire export buttons, and gate the page behind FF_SCORES
- extend data API with vibe intensity metadata plus dedicated unit and snapshot coverage

## Testing
- npx vitest run src/features/scores/__tests__/verbalizers.test.ts src/features/scores/__tests__/VibesHeatmap.test.tsx src/services/scores/__tests__/dataApi.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ce944f33f4832d8823a4e5156787ea