### PR TITLE
feat: integrate SAM express mood signalling

### DIFF
--- a/src/contexts/MoodContext.tsx
+++ b/src/contexts/MoodContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, ReactNode } from 'react';
 import { useMoodStore } from '@/hooks/useMood';
+import type { MoodPalette } from '@/utils/moodSignals';
 import type { MoodVibe } from '@/utils/moodVibes';
 
 interface MoodContextType {
@@ -10,6 +11,9 @@ interface MoodContextType {
     vibe: MoodVibe;
     isLoading: boolean;
     error: string | null;
+    summary: string;
+    microGesture: string;
+    palette: MoodPalette;
   };
   updateMood: (valence: number, arousal: number) => void;
   fetchCurrentMood: () => Promise<void>;
@@ -35,6 +39,9 @@ export const MoodProvider: React.FC<MoodProviderProps> = ({ children }) => {
       vibe: moodStore.vibe,
       isLoading: moodStore.isLoading,
       error: moodStore.error,
+      summary: moodStore.summary,
+      microGesture: moodStore.microGesture,
+      palette: moodStore.palette,
     },
     updateMood: moodStore.updateMood,
     fetchCurrentMood: moodStore.fetchCurrentMood,

--- a/src/core/flags.ts
+++ b/src/core/flags.ts
@@ -7,7 +7,8 @@ interface FeatureFlags {
   FF_COMMUNITY: boolean;
   FF_MANAGER_DASH: boolean;
   FF_SCORES: boolean;
-  
+  FF_SCAN: boolean;
+
   // Clinical Assessment Feature Flags
   FF_ASSESS_WHO5: boolean;
   FF_ASSESS_STAI6: boolean;
@@ -26,7 +27,8 @@ interface FeatureFlags {
   FF_ASSESS_UWES: boolean;
   FF_ASSESS_CBI: boolean;
   FF_ASSESS_CVSQ: boolean;
-  
+  FF_ASSESS_SAM: boolean;
+
   [key: string]: boolean;
 }
 
@@ -38,7 +40,8 @@ const DEFAULT_FLAGS: FeatureFlags = {
   FF_COMMUNITY: true,
   FF_MANAGER_DASH: true,
   FF_SCORES: true,
-  
+  FF_SCAN: true,
+
   // Clinical assessments – disabled by default, opt-in via remote config
   FF_ASSESS_WHO5: false,
   FF_ASSESS_STAI6: false,
@@ -57,6 +60,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   FF_ASSESS_UWES: false,
   FF_ASSESS_CBI: false,
   FF_ASSESS_CVSQ: false,
+  FF_ASSESS_SAM: true,
 };
 
 let flagsCache: FeatureFlags | null = null;

--- a/src/features/dashboard/components/ComprehensiveDashboard.tsx
+++ b/src/features/dashboard/components/ComprehensiveDashboard.tsx
@@ -14,6 +14,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useQuery } from '@tanstack/react-query';
 import { Sparkline } from '@/COMPONENTS.reg';
 import { LastJournalEntriesCard } from './LastJournalEntriesCard';
+import useCurrentMood from '@/hooks/useCurrentMood';
 import {
   getEmotionScanHistory,
   deriveScore10,
@@ -66,6 +67,23 @@ interface ScanResult {
  */
 export function ComprehensiveDashboard() {
   const { user, isAuthenticated } = useAuth();
+  const currentMood = useCurrentMood();
+  const moodSecondaryText = React.useMemo(() => {
+    const normalized = currentMood.palette.text.toLowerCase();
+    if (normalized === '#f8fafc' || normalized === '#ffffff') {
+      return 'rgba(248, 250, 252, 0.78)';
+    }
+    return 'rgba(15, 23, 42, 0.68)';
+  }, [currentMood.palette.text]);
+
+  const moodCardStyle = React.useMemo(
+    () => ({
+      background: `linear-gradient(135deg, ${currentMood.palette.surface}, ${currentMood.palette.glow})`,
+      borderColor: currentMood.palette.border,
+      color: currentMood.palette.text,
+    }),
+    [currentMood.palette.surface, currentMood.palette.glow, currentMood.palette.border, currentMood.palette.text],
+  );
 
   // Requêtes pour les données du dashboard
   const { data: stats, isLoading: statsLoading } = useQuery({
@@ -183,6 +201,46 @@ export function ComprehensiveDashboard() {
           Voici un aperçu de votre parcours bien-être aujourd'hui.
         </p>
       </motion.div>
+
+      <section aria-label="Ambiance du moment">
+        <Card className="border" style={moodCardStyle}>
+          <CardHeader className="flex flex-row items-start justify-between space-y-0">
+            <div className="space-y-2">
+              <CardTitle style={{ color: currentMood.palette.text }}>Ambiance du moment</CardTitle>
+              <p className="text-sm" style={{ color: moodSecondaryText }}>
+                {currentMood.summary}
+              </p>
+            </div>
+            <div className="flex flex-col items-end gap-2">
+              <span
+                aria-label={`Vibe ${currentMood.label}`}
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full shadow-lg"
+                style={{ background: currentMood.palette.base, color: currentMood.palette.text }}
+              >
+                <span aria-hidden="true" className="text-xl">
+                  {currentMood.emoji}
+                </span>
+              </span>
+              <Badge
+                variant="secondary"
+                className="border-0 text-xs font-semibold"
+                style={{ background: currentMood.palette.base, color: currentMood.palette.text }}
+              >
+                {currentMood.label}
+              </Badge>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm" style={{ color: moodSecondaryText }}>
+            <p>{currentMood.headline}</p>
+            <p>
+              Micro-geste suggéré&nbsp;:
+              <span className="ml-1 font-medium" style={{ color: currentMood.palette.text }}>
+                {currentMood.microGesture}
+              </span>
+            </p>
+          </CardContent>
+        </Card>
+      </section>
 
       {/* Statistiques principales */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">

--- a/src/hooks/useCurrentMood.ts
+++ b/src/hooks/useCurrentMood.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 
 import { useMood } from "@/contexts/MoodContext";
 import { getVibeEmoji, getVibeLabel, type MoodVibe } from "@/utils/moodVibes";
+import type { MoodPalette } from "@/utils/moodSignals";
 
 interface MoodDescriptor {
   title: string;
@@ -47,6 +48,9 @@ export interface CurrentMoodSnapshot {
   updatedAt: string;
   isLoading: boolean;
   hasError: boolean;
+  summary: string;
+  microGesture: string;
+  palette: MoodPalette;
 }
 
 export const useCurrentMood = (): CurrentMoodSnapshot => {
@@ -106,6 +110,9 @@ export const useCurrentMood = (): CurrentMoodSnapshot => {
     updatedAt: currentMood.timestamp,
     isLoading: currentMood.isLoading,
     hasError: Boolean(currentMood.error),
+    summary: currentMood.summary,
+    microGesture: currentMood.microGesture,
+    palette: currentMood.palette,
   };
 };
 

--- a/src/utils/moodSignals.ts
+++ b/src/utils/moodSignals.ts
@@ -1,0 +1,187 @@
+import { mapMoodToVibe, type MoodVibe } from "@/utils/moodVibes";
+
+export interface MoodPalette {
+  /** Accent principal appliqué aux éléments dynamiques */
+  base: string;
+  /** Surface douce pour les panneaux de résumé */
+  surface: string;
+  /** Lueur utilisée pour les dégradés */
+  glow: string;
+  /** Couleur du texte adaptée à la surface */
+  text: string;
+  /** Trait léger pour rappeler l'accent */
+  border: string;
+}
+
+export interface MoodSignals {
+  summary: string;
+  microGesture: string;
+  palette: MoodPalette;
+  vibe: MoodVibe;
+}
+
+export interface MoodEventDetail extends MoodSignals {
+  valence: number;
+  arousal: number;
+  timestamp: string;
+}
+
+const clamp = (value: number, min: number, max: number) => {
+  return Math.min(Math.max(value, min), max);
+};
+
+const hslToHex = (h: number, s: number, l: number): string => {
+  const hue = clamp(h, 0, 360);
+  const saturation = clamp(s, 0, 100) / 100;
+  const lightness = clamp(l, 0, 100) / 100;
+
+  const chroma = (1 - Math.abs(2 * lightness - 1)) * saturation;
+  const x = chroma * (1 - Math.abs(((hue / 60) % 2) - 1));
+  const m = lightness - chroma / 2;
+
+  let r = 0;
+  let g = 0;
+  let b = 0;
+
+  if (hue < 60) {
+    r = chroma;
+    g = x;
+  } else if (hue < 120) {
+    r = x;
+    g = chroma;
+  } else if (hue < 180) {
+    g = chroma;
+    b = x;
+  } else if (hue < 240) {
+    g = x;
+    b = chroma;
+  } else if (hue < 300) {
+    r = x;
+    b = chroma;
+  } else {
+    r = chroma;
+    b = x;
+  }
+
+  const toHex = (value: number) => {
+    const channel = Math.round((value + m) * 255);
+    return channel.toString(16).padStart(2, "0");
+  };
+
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+};
+
+const buildPalette = (valence: number, arousal: number): MoodPalette => {
+  const normalizedValence = (clamp(valence, -100, 100) + 100) / 200; // 0..1
+  const normalizedArousal = clamp(arousal, 0, 100) / 100; // 0..1
+
+  const hue = Math.round(220 - normalizedValence * 150); // froid -> chaud
+  const saturation = Math.round(45 + normalizedArousal * 35);
+  const lightness = Math.round(60 - normalizedArousal * 18);
+
+  const surfaceLightness = clamp(lightness + 18, 30, 92);
+  const glowLightness = clamp(lightness + 10, 30, 88);
+
+  const baseHsl = `hsl(${hue} ${saturation}% ${lightness}%)`;
+  const surfaceHsl = `hsl(${hue} ${Math.max(32, saturation - 18)}% ${surfaceLightness}%)`;
+  const glowHsl = `hsl(${(hue + 8) % 360} ${Math.min(96, saturation + 6)}% ${glowLightness}%)`;
+  const borderHex = hslToHex(hue, saturation, clamp(lightness - 12, 12, 88));
+  const textHex = lightness < 50 ? "#F8FAFC" : "#0F172A";
+
+  return {
+    base: baseHsl,
+    surface: surfaceHsl,
+    glow: glowHsl,
+    text: textHex,
+    border: borderHex,
+  };
+};
+
+const describeMood = (valence: number, arousal: number): string => {
+  const v = clamp(valence, -100, 100);
+  const a = clamp(arousal, 0, 100);
+
+  if (v > 55 && a > 65) {
+    return "Belle humeur expansive";
+  }
+
+  if (v > 55) {
+    return "Bonne humeur posée";
+  }
+
+  if (v > 20 && a > 65) {
+    return "Dynamique volontaire";
+  }
+
+  if (v > 20 && a < 35) {
+    return "Tranquillité vigilante";
+  }
+
+  if (v > 20) {
+    return "Élan positif stable";
+  }
+
+  if (v >= -20 && a > 65) {
+    return "Tension constructive";
+  }
+
+  if (v >= -20 && a < 35) {
+    return "Zone de récupération";
+  }
+
+  if (v >= -20) {
+    return "Ambiance équilibrée";
+  }
+
+  if (a > 65) {
+    return "Charge émotionnelle à apaiser";
+  }
+
+  if (a < 35) {
+    return "Tonalité douce à préserver";
+  }
+
+  return "Tonalité plus basse";
+};
+
+const recommendMicroGesture = (valence: number, arousal: number): string => {
+  const v = clamp(valence, -100, 100);
+  const a = clamp(arousal, 0, 100);
+
+  if (v < -25 && a > 60) {
+    return "Proposer une expiration longue avec les épaules qui se relâchent.";
+  }
+
+  if (v < -25 && a < 40) {
+    return "Inviter à poser une main sur le cœur et respirer calmement.";
+  }
+
+  if (v > 55 && a > 65) {
+    return "Suggérer une mini danse ou secouer les poignets.";
+  }
+
+  if (v > 55) {
+    return "Encourager un sourire doux et un étirement latéral.";
+  }
+
+  if (a > 70) {
+    return "Rouler les épaules en conscience pour libérer la tension.";
+  }
+
+  if (a < 35) {
+    return "Étirer doucement la nuque et laisser la mâchoire se détendre.";
+  }
+
+  return "Proposer trois respirations alignées, épaules détendues.";
+};
+
+export const buildMoodSignals = (valence: number, arousal: number): MoodSignals => {
+  const vibe = mapMoodToVibe(valence, arousal);
+
+  return {
+    summary: describeMood(valence, arousal),
+    microGesture: recommendMicroGesture(valence, arousal),
+    palette: buildPalette(valence, arousal),
+    vibe,
+  };
+};


### PR DESCRIPTION
## Summary
- add mood signal helpers and extend the mood store/context to persist summary, palette and micro-gestures while emitting enriched mood.updated events behind FF_SCAN/FF_ASSESS_SAM
- redesign the SAM instant check-in into an accessible "Scan express" widget with timeline and keyboard-friendly pictograms
- tint the dashboard and FlashGlow flows with the current mood palette so the ecosystem reacts instantly to SAM updates

## Testing
- npm run lint *(fails: Parsing error in src/hooks/useAssessment.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cea9e0678c832dade9e18462c3441e