### PR TITLE
feat: verbal SUDS flow and adaptive Flash Glow session

### DIFF
--- a/src/lib/flags/flags.json
+++ b/src/lib/flags/flags.json
@@ -3,5 +3,7 @@
   "data-delete": false, 
   "scores-v2": false, 
   "telemetry-opt-in": false,
-  "new-audio-engine": false 
+  "new-audio-engine": false,
+  "FF_FLASH": true,
+  "FF_ASSESS_SUDS": true
 }


### PR DESCRIPTION
## Summary
- gate Flash Glow behind FF_FLASH and add the verbal SUDS opt-in flow with 24h cooldown plus the "Encore 60 s" post-session decision when tension stays high
- refresh the session experience with a discrete progress ring, an always-on "Effets doux" toggle, and prefers-reduced-motion handling across the flow
- log Flash Glow completions with a textual mood delta narrative and journal toast to keep the experience number-free

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ceaf3ac374832d81e9db0d13439808