### PR TITLE
feat: final adaptive music experience

### DIFF
--- a/src/__tests__/__snapshots__/adaptive-music.snapshot.spec.tsx.snap
+++ b/src/__tests__/__snapshots__/adaptive-music.snapshot.spec.tsx.snap
@@ -5,7 +5,14 @@ exports[`AdaptiveMusicPage > rend la page et la playlist adaptative 1`] = `
   <main
     aria-label="Adaptive Music"
     class="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-6 md:px-8"
+    data-testid="adaptive-music-page"
   >
+    <div
+      aria-live="polite"
+      class="sr-only"
+    >
+      Brume velours. Intensité velours, tout en rondeur.
+    </div>
     <div
       class="relative overflow-hidden rounded-2xl p-6 mb-8 bg-gradient-to-r from-primary/10 via-primary/5 to-background"
       style="opacity: 0; transform: translateY(-20px) translateZ(0);"
@@ -62,7 +69,7 @@ exports[`AdaptiveMusicPage > rend la page et la playlist adaptative 1`] = `
                 <p
                   class="text-muted-foreground"
                 >
-                  Une playlist générée pour soutenir votre état émotionnel actuel.
+                  Une bulle sonore qui se cale sur ton souffle et tes ressentis du moment.
                 </p>
               </div>
             </div>
@@ -171,30 +178,73 @@ exports[`AdaptiveMusicPage > rend la page et la playlist adaptative 1`] = `
         class="rounded-xl border bg-card text-card-foreground shadow"
       >
         <div
-          class="flex flex-col p-6 space-y-6"
+          class="flex flex-col space-y-1.5 p-6"
+        >
+          <h3
+            class="font-semibold leading-none tracking-tight"
+          >
+            Horizon sonore du moment
+          </h3>
+          <p
+            class="text-sm text-muted-foreground"
+          >
+            Nous ajustons la texture pour rester dans le confort
+          </p>
+        </div>
+        <div
+          class="p-6 pt-0 space-y-4"
         >
           <div
-            class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between"
+            class="rounded-lg border border-muted/60 bg-muted/20 p-4"
           >
-            <div>
-              <h3
-                class="font-semibold leading-none tracking-tight"
+            <div
+              class="flex items-center justify-between"
+            >
+              <div>
+                <p
+                  class="text-sm text-muted-foreground"
+                >
+                  Une présence nette qui accompagne les pensées avec douceur.
+                </p>
+                <p
+                  class="text-lg font-semibold"
+                >
+                  🎯
+                   
+                  Brume velours
+                </p>
+              </div>
+              <div
+                class="inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80"
               >
-                Playlist adaptative
-              </h3>
-              <p
-                class="text-sm text-muted-foreground"
-              >
-                Ajustez les paramètres pour générer une session ciblée et reprendre où vous voulez.
-              </p>
+                Focus
+              </div>
             </div>
-            <button
-              class="inline-flex items-center justify-center whitespace-nowrap font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed focus-enhanced border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground hover:shadow-md active:scale-95 h-8 rounded-md px-3 text-xs"
-              type="button"
+            <p
+              class="mt-3 text-sm text-muted-foreground"
+            >
+              Ambiance souple qui chuchote et laisse respirer.
+            </p>
+            <p
+              class="text-xs text-muted-foreground"
+            >
+              Le flux reste régulier, sans heurt.
+            </p>
+            <p
+              class="text-xs text-muted-foreground"
+            >
+              Intensité velours, tout en rondeur.
+            </p>
+          </div>
+          <div
+            class="rounded-lg border border-muted/60 bg-muted/10 p-4"
+          >
+            <div
+              class="flex items-center gap-2 text-sm font-medium"
             >
               <svg
                 aria-hidden="true"
-                class="lucide lucide-refresh-cw mr-2 h-4 w-4"
+                class="lucide lucide-sparkles h-4 w-4"
                 fill="none"
                 height="24"
                 stroke="currentColor"
@@ -206,513 +256,109 @@ exports[`AdaptiveMusicPage > rend la page et la playlist adaptative 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"
+                  d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"
                 />
                 <path
-                  d="M21 3v5h-5"
+                  d="M5 3v4"
                 />
                 <path
-                  d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"
+                  d="M19 17v4"
                 />
                 <path
-                  d="M8 16H3v5"
+                  d="M3 5h4"
+                />
+                <path
+                  d="M17 19h4"
                 />
               </svg>
-              Actualiser
-            </button>
-          </div>
-          <div
-            class="grid gap-4 md:grid-cols-2"
-          >
-            <div
-              class="space-y-2"
-            >
-              <label
-                class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                for="adaptive-mood"
-              >
-                Humeur cible
-              </label>
-              <button
-                aria-autocomplete="none"
-                aria-controls="radix-:r0:"
-                aria-expanded="false"
-                class="flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1"
-                data-state="closed"
-                dir="ltr"
-                id="adaptive-mood"
-                role="combobox"
-                type="button"
-              >
-                <span
-                  style="pointer-events: none;"
-                >
-                  <div
-                    class="flex flex-col"
-                  >
-                    <span
-                      class="font-medium"
-                    >
-                      😌
-                       
-                      Apaisement
-                    </span>
-                    <span
-                      class="text-xs text-muted-foreground"
-                    >
-                      Texturé et doux pour relâcher la pression
-                    </span>
-                  </div>
-                </span>
-                <svg
-                  aria-hidden="true"
-                  class="lucide lucide-chevron-down h-4 w-4 opacity-50"
-                  fill="none"
-                  height="24"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="m6 9 6 6 6-6"
-                  />
-                </svg>
-              </button>
-            </div>
-            <div
-              class="space-y-2"
-            >
-              <label
-                class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                for="adaptive-duration"
-              >
-                Durée de session
-              </label>
-              <button
-                aria-autocomplete="none"
-                aria-controls="radix-:r1:"
-                aria-expanded="false"
-                class="flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1"
-                data-state="closed"
-                dir="ltr"
-                id="adaptive-duration"
-                role="combobox"
-                type="button"
-              >
-                <span
-                  style="pointer-events: none;"
-                >
-                  20
-                   minutes
-                </span>
-                <svg
-                  aria-hidden="true"
-                  class="lucide lucide-chevron-down h-4 w-4 opacity-50"
-                  fill="none"
-                  height="24"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="m6 9 6 6 6-6"
-                  />
-                </svg>
-              </button>
-            </div>
-            <div
-              class="md:col-span-2 flex items-center justify-between rounded-md border px-3 py-2"
-            >
-              <div
-                class="space-y-1"
-              >
-                <label
-                  class="peer-disabled:cursor-not-allowed peer-disabled:opacity-70 text-sm font-medium"
-                  for="adaptive-instrumental"
-                >
-                  Instrumental uniquement
-                </label>
-                <p
-                  class="text-xs text-muted-foreground"
-                >
-                  Supprime les pistes avec voix pour favoriser la concentration ou la relaxation profonde.
-                </p>
-              </div>
-              <button
-                aria-checked="true"
-                aria-label="Activer uniquement les pistes instrumentales"
-                class="peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input"
-                data-state="checked"
-                id="adaptive-instrumental"
-                role="switch"
-                type="button"
-                value="on"
-              >
-                <span
-                  class="pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
-                  data-state="checked"
-                />
-              </button>
-            </div>
-          </div>
-        </div>
-        <div
-          class="p-6 pt-0 space-y-4"
-        >
-          <div
-            class="space-y-6"
-          >
-            <div
-              class="rounded-lg border bg-muted/30 p-4"
-            >
-              <div
-                class="flex items-center gap-2 text-sm text-muted-foreground"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="lucide lucide-sparkles h-4 w-4"
-                  fill="none"
-                  height="24"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"
-                  />
-                  <path
-                    d="M5 3v4"
-                  />
-                  <path
-                    d="M19 17v4"
-                  />
-                  <path
-                    d="M3 5h4"
-                  />
-                  <path
-                    d="M17 19h4"
-                  />
-                </svg>
-                Mock Playlist
-              </div>
-              <h3
-                class="mt-2 text-lg font-semibold"
-              >
-                First track
-              </h3>
-              <p
-                class="text-sm text-muted-foreground"
-              >
-                A calm testing track
-              </p>
-              <div
-                class="mt-3 flex flex-wrap gap-3 text-xs text-muted-foreground"
-              >
-                <span
-                  class="inline-flex items-center gap-1"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="lucide lucide-clock h-3.5 w-3.5"
-                    fill="none"
-                    height="24"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <circle
-                      cx="12"
-                      cy="12"
-                      r="10"
-                    />
-                    <polyline
-                      points="12 6 12 12 16 14"
-                    />
-                  </svg>
-                  5:00
-                </span>
-                <span>
-                  25
-                  % énergie
-                </span>
-                <span>
-                  Focus : 
-                  Respiration
-                </span>
-                <span>
-                  Artiste : 
-                  EmotionsCare
-                </span>
-              </div>
-            </div>
-            <div
-              aria-label="First track"
-              style="display: grid; gap: 8px;"
-            >
-              <div
-                style="display: grid; gap: 6px;"
-              >
-                <strong>
-                  First track
-                </strong>
-                <div
-                  style="display: flex; flex-wrap: wrap; gap: 8px; align-items: center;"
-                >
-                  <button
-                    aria-pressed="false"
-                    data-ui="primary-cta"
-                    type="button"
-                  >
-                    Lecture
-                  </button>
-                  <button
-                    aria-pressed="false"
-                    data-ui="favorite-toggle"
-                    type="button"
-                  >
-                    Ajouter aux favoris
-                  </button>
-                </div>
-              </div>
-              <label
-                style="display: flex; gap: 8px; align-items: center;"
-              >
-                Volume
-                <input
-                  data-ui="volume-slider"
-                  max="1"
-                  min="0"
-                  step="0.01"
-                  type="range"
-                  value="0.75"
-                />
-              </label>
+              Partage ton ressenti quand tu le souhaites pour affiner encore la texture.
             </div>
           </div>
         </div>
       </div>
       <div
-        class="grid gap-6"
+        class="rounded-xl border bg-card text-card-foreground shadow"
       >
         <div
-          class="rounded-xl border bg-card text-card-foreground shadow"
+          class="flex flex-col space-y-1.5 p-6"
         >
-          <div
-            class="flex flex-col space-y-1.5 p-6"
+          <h3
+            class="font-semibold leading-none tracking-tight"
           >
-            <h3
-              class="font-semibold leading-none tracking-tight"
-            >
-              Favoris & reprise
-            </h3>
-            <p
-              class="text-sm text-muted-foreground"
-            >
-              Accédez rapidement à vos pistes sauvegardées et reprenez vos écoutes en cours.
-            </p>
-          </div>
-          <div
-            class="p-6 pt-0 space-y-4"
+            Favoris & reprise
+          </h3>
+          <p
+            class="text-sm text-muted-foreground"
           >
-            <div
-              class="rounded-md border bg-muted/20 p-3"
-            >
-              <div
-                class="flex items-center gap-2 text-sm font-medium"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="lucide lucide-music2 h-4 w-4"
-                  fill="none"
-                  height="24"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <circle
-                    cx="8"
-                    cy="18"
-                    r="4"
-                  />
-                  <path
-                    d="M12 18V2l7 4"
-                  />
-                </svg>
-                Dernière lecture
-              </div>
-              <p
-                class="mt-2 text-xs text-muted-foreground"
-              >
-                Lancez une piste pour activer la reprise automatique.
-              </p>
-            </div>
-            <div
-              class="space-y-2"
-            >
-              <div
-                class="flex items-center gap-2 text-sm font-medium"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="lucide lucide-heart h-4 w-4"
-                  fill="none"
-                  height="24"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z"
-                  />
-                </svg>
-                Favoris récents
-              </div>
-              <p
-                class="text-xs text-muted-foreground"
-              >
-                Utilisez le bouton « Ajouter aux favoris » du lecteur pour retrouver rapidement vos pistes préférées.
-              </p>
-            </div>
-          </div>
+            Retrouve ton cocon et tes bulles gardées précieusement.
+          </p>
         </div>
         <div
-          class="rounded-xl border bg-card text-card-foreground shadow"
+          class="p-6 pt-0 space-y-4"
         >
           <div
-            class="flex flex-col space-y-1.5 p-6"
-          >
-            <h3
-              class="font-semibold leading-none tracking-tight"
-            >
-              Guidance de la session
-            </h3>
-            <p
-              class="text-sm text-muted-foreground"
-            >
-              Suggestions d'utilisation basées sur l'énergie recommandée.
-            </p>
-          </div>
-          <div
-            class="p-6 pt-0 space-y-4 text-sm"
+            class="rounded-md border bg-muted/20 p-4"
           >
             <div
-              class="rounded-md border bg-muted/20 p-3"
+              class="flex items-center gap-2 text-sm font-semibold"
             >
-              <div
-                class="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground"
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-music2 h-4 w-4"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-hidden="true"
-                  class="lucide lucide-sparkles h-3.5 w-3.5"
-                  fill="none"
-                  height="24"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"
-                  />
-                  <path
-                    d="M5 3v4"
-                  />
-                  <path
-                    d="M19 17v4"
-                  />
-                  <path
-                    d="M3 5h4"
-                  />
-                  <path
-                    d="M17 19h4"
-                  />
-                </svg>
-                Energie recommandée
-              </div>
-              <p
-                class="mt-2 text-sm font-medium"
-              >
-                Alignement 
-                90
-                %
-              </p>
-              <p
-                class="text-xs text-muted-foreground"
-              >
-                Énergie cible 
-                30
-                % — baseline 
-                20
-                %
-              </p>
-            </div>
-            <div>
-              <h4
-                class="font-semibold"
-              >
-                Recommandations
-              </h4>
-              <ul
-                class="mt-2 space-y-2 text-xs text-muted-foreground"
-              >
-                <li>
-                  • 
-                  Respirez profondément avec la première piste.
-                </li>
-              </ul>
-            </div>
-            <div>
-              <h4
-                class="font-semibold"
-              >
-                Activités suggérées
-              </h4>
-              <ul
-                class="mt-2 flex flex-wrap gap-2"
-              >
-                <div
-                  class="inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 text-foreground"
-                >
-                  Journal
-                </div>
-                <div
-                  class="inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 text-foreground"
-                >
-                  Étirements
-                </div>
-              </ul>
+                <circle
+                  cx="8"
+                  cy="18"
+                  r="4"
+                />
+                <path
+                  d="M12 18V2l7 4"
+                />
+              </svg>
+              Ton dernier cocon
             </div>
             <p
-              class="text-xs text-muted-foreground"
+              class="mt-2 text-xs text-muted-foreground"
             >
-              Stabiliser votre système nerveux avec des textures calmes.
+              Lance une piste et nous garderons la reprise pour toi.
+            </p>
+          </div>
+          <div>
+            <div
+              class="flex items-center gap-2 text-sm font-semibold"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-heart h-4 w-4"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z"
+                />
+              </svg>
+              Tes bulles gardées
+            </div>
+            <p
+              class="mt-2 text-xs text-muted-foreground"
+            >
+              Ajoute une bulle pour la retrouver ici à chaque visite.
             </p>
           </div>
         </div>
@@ -728,135 +374,106 @@ exports[`AdaptiveMusicPage > rend la page et la playlist adaptative 1`] = `
           <h3
             class="font-semibold leading-none tracking-tight"
           >
-            Composition de la playlist
+            Plaisir d'écoute
           </h3>
           <p
             class="text-sm text-muted-foreground"
           >
-            Parcourez les pistes générées et lancez-les instantanément.
+            Lance la piste qui résonne avec ton état du moment.
           </p>
         </div>
         <div
-          class="inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80"
+          class="flex gap-2"
         >
-          Jeu de données 
-          test
+          <button
+            class="inline-flex items-center justify-center whitespace-nowrap font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed focus-enhanced border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground hover:shadow-md active:scale-95 h-8 rounded-md px-3 text-xs"
+            type="button"
+          >
+            Régénérer la sélection
+          </button>
         </div>
+      </div>
+      <div
+        class="p-6 pt-0 space-y-6"
+      >
+        <p
+          class="text-sm text-muted-foreground"
+        >
+          Nous préparons une ambiance sur mesure…
+        </p>
+      </div>
+    </div>
+    <div
+      class="rounded-xl border bg-card text-card-foreground shadow"
+    >
+      <div
+        class="flex flex-col space-y-1.5 p-6"
+      >
+        <h3
+          class="font-semibold leading-none tracking-tight"
+        >
+          Affiner avec POMS (optionnel)
+        </h3>
+        <p
+          class="text-sm text-muted-foreground"
+        >
+          Un micro check-in avant et après permet d'ajuster encore plus finement la texture.
+        </p>
+      </div>
+      <div
+        class="p-6 pt-0 space-y-4"
+      >
+        <div
+          class="flex flex-col gap-3 rounded-lg border border-muted/60 bg-muted/10 p-4"
+        >
+          <p
+            class="text-sm font-medium"
+          >
+            Tu pourras activer le mini point d'entrée quand tu le souhaites.
+          </p>
+          <p
+            class="text-xs text-muted-foreground"
+          >
+            Aucun suivi n'est lancé pour le moment, la musique s'appuie juste sur ton état du jour.
+          </p>
+          <div
+            class="flex gap-2"
+          >
+            <button
+              class="inline-flex items-center justify-center whitespace-nowrap font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed focus-enhanced bg-primary text-primary-foreground shadow hover:bg-primary/90 hover:shadow-md active:scale-95 h-8 rounded-md px-3 text-xs"
+              type="button"
+            >
+              Activer maintenant
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="rounded-xl border bg-card text-card-foreground shadow"
+    >
+      <div
+        class="flex flex-col space-y-1.5 p-6"
+      >
+        <h3
+          class="font-semibold leading-none tracking-tight"
+        >
+          Les textures proposées
+        </h3>
+        <p
+          class="text-sm text-muted-foreground"
+        >
+          Choisis librement la piste qui résonne avec toi, elles restent toutes douces et accueillantes.
+        </p>
       </div>
       <div
         class="p-6 pt-0"
       >
-        <ul
-          class="space-y-4"
+        <p
+          class="text-sm text-muted-foreground"
         >
-          <li
-            class="flex flex-col gap-3 rounded-md border bg-background p-4 md:flex-row md:items-center md:justify-between"
-          >
-            <div
-              class="space-y-1"
-            >
-              <div
-                class="flex items-center gap-2"
-              >
-                <span
-                  class="font-semibold"
-                >
-                  First track
-                </span>
-              </div>
-              <p
-                class="text-sm text-muted-foreground"
-              >
-                EmotionsCare
-              </p>
-              <div
-                class="flex flex-wrap gap-3 text-xs text-muted-foreground"
-              >
-                <span
-                  class="inline-flex items-center gap-1"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="lucide lucide-clock h-3.5 w-3.5"
-                    fill="none"
-                    height="24"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <circle
-                      cx="12"
-                      cy="12"
-                      r="10"
-                    />
-                    <polyline
-                      points="12 6 12 12 16 14"
-                    />
-                  </svg>
-                  5:00
-                </span>
-                <span>
-                  25
-                  % énergie
-                </span>
-                <span>
-                  Focus : 
-                  Respiration
-                </span>
-              </div>
-              <div
-                class="mt-2 flex flex-wrap gap-2"
-              >
-                <div
-                  class="inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 text-foreground"
-                >
-                  calm
-                </div>
-                <div
-                  class="inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 text-foreground"
-                >
-                  test
-                </div>
-              </div>
-            </div>
-            <div
-              class="flex items-center gap-3"
-            >
-              <button
-                class="inline-flex items-center justify-center whitespace-nowrap font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed focus-enhanced bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80 hover:shadow-md active:scale-95 h-8 rounded-md px-3 text-xs"
-                type="button"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="lucide lucide-music2 mr-2 h-4 w-4"
-                  fill="none"
-                  height="24"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <circle
-                    cx="8"
-                    cy="18"
-                    r="4"
-                  />
-                  <path
-                    d="M12 18V2l7 4"
-                  />
-                </svg>
-                En cours
-              </button>
-            </div>
-          </li>
-        </ul>
+          Préparation de la bulle sonore…
+        </p>
       </div>
     </div>
   </main>

--- a/src/services/music/presetMapper.test.ts
+++ b/src/services/music/presetMapper.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { mapStateToPreset, type PomsTrendSummary } from "./presetMapper";
+
+const buildSummary = (overrides: Partial<PomsTrendSummary>): PomsTrendSummary => ({
+  tensionTrend: "steady",
+  fatigueTrend: "steady",
+  note: null,
+  completed: true,
+  ...overrides,
+});
+
+describe("mapStateToPreset", () => {
+  it("choisit un preset très calme lorsque l'arousal est bas", () => {
+    const recommendation = mapStateToPreset({ arousal: 10, valence: 5 });
+
+    expect(recommendation.presetId).toBe("calm_very_low");
+    expect(recommendation.intensity).toBe("feather");
+    expect(recommendation.adjustments.source).toBe("sam");
+  });
+
+  it("maintient un preset lumineux lorsque valence et arousal sont élevés", () => {
+    const recommendation = mapStateToPreset({ arousal: 82, valence: 70 });
+
+    expect(recommendation.presetId).toBe("bright_mist");
+    expect(recommendation.intensity).toBe("glow");
+    expect(recommendation.cta).toBeNull();
+  });
+
+  it("adouci la texture lorsque la fatigue augmente", () => {
+    const recommendation = mapStateToPreset(
+      { arousal: 55, valence: -10 },
+      buildSummary({ fatigueTrend: "up" }),
+    );
+
+    expect(recommendation.presetId).toBe("calm_very_low");
+    expect(recommendation.intensity).toBe("feather");
+    expect(recommendation.adjustments.softenedForFatigue).toBe(true);
+    expect(recommendation.adjustments.source).toBe("mixed");
+  });
+
+  it("allonge le crossfade et propose la relance douce quand la tension diminue", () => {
+    const recommendation = mapStateToPreset(
+      { arousal: 60, valence: 40 },
+      buildSummary({ tensionTrend: "down" }),
+    );
+
+    expect(recommendation.crossfadeMs).toBeGreaterThanOrEqual(3000);
+    expect(recommendation.cta).toBe("encore_2_min");
+    expect(recommendation.adjustments.extendedForTensionRelease).toBe(true);
+  });
+
+  it("cumule les ajustements lorsque la fatigue monte et la tension baisse", () => {
+    const recommendation = mapStateToPreset(
+      { arousal: 72, valence: 20 },
+      buildSummary({ tensionTrend: "down", fatigueTrend: "up" }),
+    );
+
+    expect(recommendation.presetId).toBe("calm_very_low");
+    expect(recommendation.cta).toBe("encore_2_min");
+    expect(recommendation.adjustments.softenedForFatigue).toBe(true);
+    expect(recommendation.adjustments.extendedForTensionRelease).toBe(true);
+  });
+});
+

--- a/src/services/music/presetMetadata.ts
+++ b/src/services/music/presetMetadata.ts
@@ -1,0 +1,61 @@
+import type { AdaptiveIntensity, AdaptivePresetId } from "@/services/music/presetMapper";
+
+export const PRESET_DETAILS: Record<
+  AdaptivePresetId,
+  { label: string; tone: string; accent: string }
+> = {
+  calm_very_low: {
+    label: "Cocon feutré",
+    tone: "Texture presque immobile pour s'abandonner totalement.",
+    accent: "Les transitions restent aériennes et enveloppantes.",
+  },
+  ambient_soft: {
+    label: "Brume velours",
+    tone: "Ambiance souple qui chuchote et laisse respirer.",
+    accent: "Le flux reste régulier, sans heurt.",
+  },
+  focus_light: {
+    label: "Fil de clarté",
+    tone: "Trame précise mais tendre pour guider les pensées.",
+    accent: "La pulsation reste légère et stable.",
+  },
+  bright_mist: {
+    label: "Halo lumineux",
+    tone: "Éclat doux pour prolonger la joie sans agitation.",
+    accent: "L'énergie reste radieuse et fluide.",
+  },
+};
+
+export const PRESET_TO_MOOD: Record<AdaptivePresetId, string> = {
+  calm_very_low: "relaxed",
+  ambient_soft: "relaxed",
+  focus_light: "focus",
+  bright_mist: "joyful",
+};
+
+export const INTENSITY_TO_VALUE: Record<AdaptiveIntensity, number> = {
+  feather: 0.25,
+  soft: 0.4,
+  balanced: 0.55,
+  glow: 0.68,
+};
+
+export const INTENSITY_TEXT: Record<AdaptiveIntensity, string> = {
+  feather: "Intensité plume, presque suspendue.",
+  soft: "Intensité velours, tout en rondeur.",
+  balanced: "Intensité fil de soie, tenue mais apaisée.",
+  glow: "Intensité halo, rayonnante sans jamais forcer.",
+};
+
+export const describePresetChange = (
+  presetId: AdaptivePresetId,
+  intensity: AdaptiveIntensity,
+): string => {
+  const detail = PRESET_DETAILS[presetId];
+  const intensityDetail = INTENSITY_TEXT[intensity];
+  if (!detail || !intensityDetail) {
+    return "Sélection musicale ajustée pour rester confortable.";
+  }
+  return `${detail.label}. ${intensityDetail}`;
+};
+

--- a/src/ui/AudioPlayer.tsx
+++ b/src/ui/AudioPlayer.tsx
@@ -47,13 +47,6 @@ type AudioPlayerProps = {
   onPause?: () => void;
 };
 
-const formatTime = (totalSeconds: number): string => {
-  if (!Number.isFinite(totalSeconds) || totalSeconds <= 0) return "0:00";
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = Math.floor(totalSeconds % 60);
-  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
-};
-
 const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 export function AudioPlayer({
@@ -85,7 +78,7 @@ export function AudioPlayer({
 
   const [playing, setPlaying] = React.useState(false);
   const [volume, setVolume] = React.useState(safeDefaultVolume);
-  const [resumePosition, setResumePosition] = React.useState(resume?.position ?? 0);
+  const [statusMessage, setStatusMessage] = React.useState("Lecteur prêt à diffuser ta bulle sonore.");
 
   const fadingRef = React.useRef(false);
   const currentVolumeRef = React.useRef(safeDefaultVolume);
@@ -98,10 +91,6 @@ export function AudioPlayer({
     },
     [setSoundVolume],
   );
-
-  React.useEffect(() => {
-    setResumePosition(resume?.position ?? 0);
-  }, [resume?.position, trackKey]);
 
   React.useEffect(() => {
     if (fadingRef.current) return;
@@ -158,7 +147,6 @@ export function AudioPlayer({
         src,
       };
 
-      setResumePosition(payload.position);
       onProgress?.(payload);
     },
     [getTime, onProgress, playing, presetId, src, title, trackKey, volume],
@@ -197,6 +185,7 @@ export function AudioPlayer({
 
       const position = typeof targetPosition === "number" ? targetPosition : getTime?.() ?? 0;
       persist({ wasPlaying: true, position });
+      setStatusMessage("Lecture en cours, laisse-toi envelopper.");
     },
     [applyHaptics, crossfadeMs, fadeToVolume, getTime, logBreadcrumb, persist, playSound, prefersReducedMotion, seek, updateAudioVolume, volume],
   );
@@ -215,6 +204,7 @@ export function AudioPlayer({
     const position = getTime?.() ?? 0;
     persist({ wasPlaying: false, position });
     onPause?.();
+    setStatusMessage("Lecture en pause, la bulle reste disponible.");
   }, [crossfadeMs, fadeToVolume, getTime, logBreadcrumb, onPause, pauseSound, persist, playing, prefersReducedMotion, updateAudioVolume, volume]);
 
   const onTogglePlay = React.useCallback(async () => {
@@ -234,6 +224,7 @@ export function AudioPlayer({
     if (!resume || resume.position <= 0 || resume.allow === false) return;
     await startPlayback(resume.position);
     await resume.onResume?.();
+    setStatusMessage("Reprise au bon endroit, respire à ton rythme.");
   }, [resume, startPlayback]);
 
   React.useEffect(() => {
@@ -263,15 +254,58 @@ export function AudioPlayer({
     };
   }, [getTime, persist]);
 
-  const hasResume = resume && resume.allow !== false && resumePosition > 1 && !playing;
+  const hasResume = resume && resume.allow !== false && resume.position > 1 && !playing;
   const resumeButtonLabel = resume?.label ?? "Reprendre";
 
   const favoriteActive = favorite?.active ?? false;
   const favoriteAdd = favorite?.addLabel ?? "Ajouter aux favoris";
   const favoriteRemove = favorite?.removeLabel ?? "Retirer des favoris";
 
+  React.useEffect(() => {
+    const handleKeydown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (target) {
+        const tagName = target.tagName;
+        if (target.isContentEditable || ["INPUT", "TEXTAREA", "SELECT"].includes(tagName)) {
+          return;
+        }
+      }
+
+      const key = event.key;
+      if (key === " " || key === "Spacebar" || key.toLowerCase() === "k") {
+        event.preventDefault();
+        onTogglePlay();
+        return;
+      }
+
+      if (key === "ArrowUp") {
+        event.preventDefault();
+        setVolume(current => clamp01(current + 0.05));
+        setStatusMessage("Volume un peu plus présent, toujours en douceur.");
+        return;
+      }
+
+      if (key === "ArrowDown") {
+        event.preventDefault();
+        setVolume(current => clamp01(current - 0.05));
+        setStatusMessage("Volume encore plus feutré.");
+      }
+    };
+
+    window.addEventListener("keydown", handleKeydown);
+    return () => window.removeEventListener("keydown", handleKeydown);
+  }, [onTogglePlay]);
+
+  React.useEffect(() => {
+    if (!hasResume) return;
+    setStatusMessage("Reprise disponible exactement là où tu t'étais arrêtée.");
+  }, [hasResume]);
+
   return (
-    <div aria-label={title ?? "Lecteur audio"} className="grid gap-3">
+    <div aria-label={title ?? "Lecteur audio"} className="grid gap-3" role="group">
+      <div aria-live="polite" className="sr-only">
+        {statusMessage}
+      </div>
       <div className="grid gap-2">
         {title && <strong className="text-base font-semibold">{title}</strong>}
         <div className="flex flex-wrap items-center gap-3">
@@ -280,6 +314,7 @@ export function AudioPlayer({
             onClick={onTogglePlay}
             aria-pressed={playing}
             className="rounded-full bg-primary px-4 py-2 text-primary-foreground"
+            data-ui="primary-toggle"
           >
             {playing ? "Pause" : ready ? "Lecture" : "Chargement"}
           </button>
@@ -289,8 +324,9 @@ export function AudioPlayer({
               type="button"
               onClick={handleResume}
               className="rounded-full border border-primary/40 px-3 py-2 text-sm"
+              data-ui="resume-button"
             >
-              {resumeButtonLabel} ({formatTime(resumePosition)})
+              {resumeButtonLabel}
             </button>
           )}
 
@@ -307,6 +343,7 @@ export function AudioPlayer({
             aria-pressed={favoriteActive}
             className="rounded-full border border-muted px-3 py-2 text-sm"
             disabled={!favorite}
+            data-ui="favorite-toggle"
           >
             {favoriteActive ? `★ ${favoriteRemove}` : `☆ ${favoriteAdd}`}
           </button>
@@ -327,10 +364,14 @@ export function AudioPlayer({
       </label>
 
       {hasResume && (
-        <small aria-live="polite" className="text-sm text-muted-foreground">
-          Dernière écoute sauvegardée à {formatTime(resumePosition)}.
+        <small className="text-sm text-muted-foreground">
+          Dernière écoute sauvegardée, prête à reprendre quand tu le souhaites.
         </small>
       )}
+
+      <p className="text-xs text-muted-foreground" role="note">
+        Astuce clavier : barre espace ou lettre K pour lecture ou pause, flèches haut et bas pour doser le volume.
+      </p>
 
       <audio
         aria-hidden

--- a/tests/e2e/adaptive-music-favorites.spec.ts
+++ b/tests/e2e/adaptive-music-favorites.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 const playlistResponse = {
   ok: true,
@@ -35,7 +35,7 @@ const playlistResponse = {
         focus: 'flow',
         instrumentation: ['pads'],
         tags: ['relax', 'ambient'],
-        description: 'Synthés enveloppants pour prolonger l'accalmie.',
+        description: "Synthés enveloppants pour prolonger l'accalmie.",
       },
     ],
     energy_profile: {
@@ -50,7 +50,7 @@ const playlistResponse = {
     },
     recommendations: [
       'Planifiez une respiration 4-6 pendant la première piste.',
-      'Prolongez la détente avec une séance journal guidée.',
+      "Prolongez la détente avec une séance journal guidée.",
     ],
     guidance: {
       focus: 'Utilisez la première piste pour ancrer la respiration, puis étirez-vous en douceur.',
@@ -65,57 +65,69 @@ const playlistResponse = {
   },
 };
 
+const seedAdaptiveStorage = () => {
+  try {
+    window.localStorage.setItem(
+      'adaptive-music:persisted-session',
+      JSON.stringify({
+        trackId: 'track-relaxed-01',
+        position: 86,
+        volume: 0.62,
+        presetId: 'ambient_soft',
+        updatedAt: Date.now() - 120_000,
+        title: 'Respiration Alignée',
+        url: 'https://example.com/audio/relaxed-01.mp3',
+        wasPlaying: false,
+      }),
+    );
+    window.localStorage.setItem('adaptive-music:favorites-sync', JSON.stringify([]));
+  } catch (error) {
+    console.warn('Unable to seed adaptive music storage', error);
+  }
+
+  try {
+    delete (window as any).AudioContext;
+    delete (window as any).webkitAudioContext;
+  } catch (error) {
+    console.warn('AudioContext cleanup failed', error);
+  }
+
+  const originalPlay = window.HTMLMediaElement.prototype.play;
+  const originalPause = window.HTMLMediaElement.prototype.pause;
+
+  window.HTMLMediaElement.prototype.play = function play() {
+    return Promise.resolve();
+  };
+  window.HTMLMediaElement.prototype.pause = function pause() {
+    return originalPause.call(this);
+  };
+
+  window.addEventListener('beforeunload', () => {
+    window.HTMLMediaElement.prototype.play = originalPlay;
+    window.HTMLMediaElement.prototype.pause = originalPause;
+  });
+};
+
 test.describe('Adaptive Music favorites and resume', () => {
   test.skip(({}, testInfo) => testInfo.project.name !== 'b2c-chromium');
 
-  test('allows resuming the last track and saving it to favorites', async ({ page }) => {
-    await page.addInitScript(() => {
-      try {
-        window.localStorage.setItem('adaptive-music:favorites', JSON.stringify([]));
-        window.localStorage.setItem(
-          'adaptive-music:playback:track-relaxed-01',
-          JSON.stringify({
-            position: 42.5,
-            volume: 0.7,
-            wasPlaying: false,
-            updatedAt: Date.now() - 60_000,
-            trackTitle: 'Respiration Alignée',
-            trackSrc: 'https://example.com/audio/relaxed-01.mp3',
-          }),
-        );
-      } catch (error) {
-        console.warn('Unable to seed adaptive music storage', error);
-      }
-
-      try {
-        delete (window as any).AudioContext;
-        delete (window as any).webkitAudioContext;
-      } catch (error) {
-        console.warn('AudioContext cleanup failed', error);
-      }
-
-      const originalPlay = window.HTMLMediaElement.prototype.play;
-      const originalPause = window.HTMLMediaElement.prototype.pause;
-
-      window.HTMLMediaElement.prototype.play = function play() {
-        return Promise.resolve();
-      };
-      window.HTMLMediaElement.prototype.pause = function pause() {
-        return originalPause.call(this);
-      };
-
-      window.addEventListener('beforeunload', () => {
-        window.HTMLMediaElement.prototype.play = originalPlay;
-        window.HTMLMediaElement.prototype.pause = originalPause;
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/me/feature_flags', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          flags: { FF_MUSIC: true, FF_ASSESS_POMS: true },
+        }),
       });
     });
 
-    await page.route('**/auth/v1/user**', async (route) => {
+    await page.route('**/auth/v1/user**', async route => {
       if (route.request().method() === 'GET') {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify({ user: { id: 'user-adaptive-music' } }),
+          body: JSON.stringify({ user: null }),
         });
         return;
       }
@@ -123,7 +135,7 @@ test.describe('Adaptive Music favorites and resume', () => {
       await route.continue();
     });
 
-    await page.route('**/api/mood_playlist', async (route) => {
+    await page.route('**/api/mood_playlist', async route => {
       if (route.request().method() === 'POST') {
         await route.fulfill({
           status: 200,
@@ -136,7 +148,7 @@ test.describe('Adaptive Music favorites and resume', () => {
       await route.continue();
     });
 
-    await page.route('**/*.mp3', async (route) => {
+    await page.route('**/*.mp3', async route => {
       if (route.request().method() === 'GET') {
         await route.fulfill({ status: 200, contentType: 'audio/mpeg', body: '' });
         return;
@@ -145,42 +157,54 @@ test.describe('Adaptive Music favorites and resume', () => {
       await route.continue();
     });
 
+    await page.addInitScript(seedAdaptiveStorage);
+  });
+
+  test('allows resuming the last track and saving it to favorites', async ({ page }) => {
     await page.goto('/app/music');
 
-    const heading = page.getByRole('heading', { name: /Adaptive Music/i });
-    await expect(heading).toBeVisible({ timeout: 20000 });
+    await expect(page.getByRole('heading', { name: /Adaptive Music/i })).toBeVisible({ timeout: 20_000 });
 
-    const playlistCard = page.getByText('Respiration Alignée').first();
-    await expect(playlistCard).toBeVisible();
+    await expect(page.getByText('Respiration Alignée').first()).toBeVisible();
 
-    const resumeInfo = page.getByText(/Reprise à 0:42/i);
-    await expect(resumeInfo).toBeVisible();
+    const resumeHint = page.getByText(/Dernière écoute sauvegardée/i);
+    await expect(resumeHint).toBeVisible();
 
-    const resumeButton = page.getByRole('button', { name: /Reprendre \(0:42\)/i });
-    await expect(resumeButton).toBeVisible();
-
+    const resumeButton = page.locator('[data-ui="resume-button"]');
+    await expect(resumeButton).toHaveText(/Reprendre ton écoute/i);
     await resumeButton.click();
 
-    const primaryToggle = page.locator('[data-ui="primary-cta"]');
+    const primaryToggle = page.locator('[data-ui="primary-toggle"]');
     await expect(primaryToggle).toHaveText(/Pause/i);
 
     const favoriteToggle = page.locator('[data-ui="favorite-toggle"]');
     await favoriteToggle.click();
 
-    await expect(page.getByText(/Sauvegardé dans vos favoris locaux/i)).toBeVisible();
-
     const favoritesListItem = page
       .getByRole('listitem')
       .filter({ hasText: 'Respiration Alignée' })
       .first();
-    await expect(favoritesListItem).toBeVisible({ timeout: 10000 });
+    await expect(favoritesListItem).toBeVisible();
 
     const storedFavorites = await page.evaluate(() => {
-      const raw = window.localStorage.getItem('adaptive-music:favorites');
+      const raw = window.localStorage.getItem('adaptive-music:favorites-sync');
       return raw ? JSON.parse(raw) : [];
     });
 
     expect(Array.isArray(storedFavorites)).toBeTruthy();
-    expect(storedFavorites.some((entry: any) => entry?.id === 'track-relaxed-01')).toBeTruthy();
+    expect(storedFavorites.some((entry: any) => entry?.trackId === 'track-relaxed-01')).toBeTruthy();
+  });
+
+  test('allows declining the POMS opt-in', async ({ page }) => {
+    await page.goto('/app/music');
+
+    const optInPrompt = page.getByText(/Envie de partager ton ressenti/i);
+    await expect(optInPrompt).toBeVisible();
+
+    await page.getByRole('button', { name: /Pas maintenant/i }).click();
+
+    await expect(page.getByText(/Tu pourras activer le mini point d'entrée/i)).toBeVisible();
+    await expect(page.getByText(/Avant l'écoute/)).not.toBeVisible();
   });
 });
+


### PR DESCRIPTION
## Summary
- centralize adaptive music preset metadata and announce intensity changes with aria-live updates and softer resume messaging in the module
- enhance the audio player with keyboard shortcuts, accessible status updates, and allow declining the POMS check-in while keeping the CTA flow
- surface the current adaptive track on the dashboard and extend unit/e2e coverage for preset mapping, favorites persistence, and opt-in refusal

## Testing
- npx vitest run src/__tests__/adaptive-music.snapshot.spec.tsx --update
- npx vitest run src/services/music/presetMapper.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68ceaf5b27e4832d80a8336ca2467be3