### PR TITLE
Optimize entry flows for performance monitoring

### DIFF
--- a/src/pages/B2CDashboardPage.tsx
+++ b/src/pages/B2CDashboardPage.tsx
@@ -1,12 +1,9 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { Suspense, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
 import { Badge } from '@/components/ui/badge';
-import RecentEmotionScansWidget from '@/components/dashboard/widgets/RecentEmotionScansWidget';
-import JournalSummaryCard from '@/components/dashboard/widgets/JournalSummaryCard';
-import WeeklyPlanCard from '@/components/dashboard/widgets/WeeklyPlanCard';
 import {
   Brain,
   Music,
@@ -28,6 +25,11 @@ import { useDashboardStore } from '@/store/dashboard.store';
 import { useFlags } from '@/core/flags';
 import { useAdaptivePlayback } from '@/hooks/music/useAdaptivePlayback';
 import { PRESET_DETAILS } from '@/services/music/presetMetadata';
+import { Skeleton } from '@/components/ui/skeleton';
+
+const WeeklyPlanCard = React.lazy(() => import('@/components/dashboard/widgets/WeeklyPlanCard'));
+const RecentEmotionScansWidget = React.lazy(() => import('@/components/dashboard/widgets/RecentEmotionScansWidget'));
+const JournalSummaryCard = React.lazy(() => import('@/components/dashboard/widgets/JournalSummaryCard'));
 
 type QuickAction = {
   id: string;
@@ -88,6 +90,39 @@ const QUICK_ACTIONS: QuickAction[] = [
     accent: 'bg-green-500/10 text-green-600',
   },
 ];
+
+const WeeklyPlanSkeleton: React.FC = () => (
+  <Card aria-hidden className="border-dashed">
+    <CardHeader className="space-y-2">
+      <Skeleton className="h-4 w-32" />
+      <Skeleton className="h-5 w-56" />
+    </CardHeader>
+    <CardContent className="space-y-3">
+      <Skeleton className="h-3 w-full" />
+      <Skeleton className="h-3 w-5/6" />
+      <Skeleton className="h-3 w-3/4" />
+      <div className="grid gap-3 sm:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <Skeleton key={index} className="h-16 w-full" />
+        ))}
+      </div>
+    </CardContent>
+  </Card>
+);
+
+const DashboardWidgetSkeleton: React.FC<{ lines?: number }> = ({ lines = 4 }) => (
+  <Card aria-hidden className="border-dashed">
+    <CardHeader className="space-y-2">
+      <Skeleton className="h-4 w-40" />
+      <Skeleton className="h-3 w-1/2" />
+    </CardHeader>
+    <CardContent className="space-y-3">
+      {Array.from({ length: lines }).map((_, index) => (
+        <Skeleton key={index} className="h-3 w-full" />
+      ))}
+    </CardContent>
+  </Card>
+);
 
 export default function B2CDashboardPage() {
   const { runAudit } = useAccessibilityAudit();
@@ -231,7 +266,15 @@ export default function B2CDashboardPage() {
           <h2 id="weekly-plan" className="sr-only">
             Plan de la semaine
           </h2>
-          <WeeklyPlanCard />
+          <Suspense
+            fallback={(
+              <div aria-busy="true" aria-live="polite">
+                <WeeklyPlanSkeleton />
+              </div>
+            )}
+          >
+            <WeeklyPlanCard />
+          </Suspense>
         </section>
 
 
@@ -349,14 +392,30 @@ export default function B2CDashboardPage() {
           <h2 id="recent-scans-section" className="sr-only">
             Historique Emotion Scan
           </h2>
-          <RecentEmotionScansWidget />
+          <Suspense
+            fallback={(
+              <div aria-busy="true" aria-live="polite">
+                <DashboardWidgetSkeleton lines={6} />
+              </div>
+            )}
+          >
+            <RecentEmotionScansWidget />
+          </Suspense>
         </section>
 
         <section aria-labelledby="journal-summary-section" className="mb-8">
           <h2 id="journal-summary-section" className="sr-only">
             Synthèse du journal émotionnel
           </h2>
-          <JournalSummaryCard />
+          <Suspense
+            fallback={(
+              <div aria-busy="true" aria-live="polite">
+                <DashboardWidgetSkeleton lines={5} />
+              </div>
+            )}
+          >
+            <JournalSummaryCard />
+          </Suspense>
         </section>
 
         {/* Recommandations personnalisées */}

--- a/src/pages/B2CHomePage.tsx
+++ b/src/pages/B2CHomePage.tsx
@@ -1,9 +1,10 @@
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Header } from "@/components/layout";
 import { useNavigate } from "react-router-dom";
+import { useMemo } from "react";
 import { 
   Scan, 
   Music, 
@@ -34,8 +35,9 @@ import { CopyBadge } from "@/components/transverse";
  */
 export default function B2CHomePage() {
   const navigate = useNavigate();
+  const shouldReduceMotion = useReducedMotion();
 
-  const moduleCategories = [
+  const moduleCategories = useMemo(() => [
     {
       title: "Mesure & Analyse",
       description: "Comprendre vos émotions",
@@ -222,7 +224,19 @@ export default function B2CHomePage() {
         }
       ]
     }
-  ];
+  ], []);
+
+  const getFadeInProps = (delay = 0, duration = 0.5) =>
+    shouldReduceMotion
+      ? { initial: { opacity: 1, y: 0 }, animate: { opacity: 1, y: 0 }, transition: { duration: 0 } }
+      : { initial: { opacity: 0, y: 20 }, animate: { opacity: 1, y: 0 }, transition: { duration, delay } };
+
+  const getScaleInProps = (delay = 0, duration = 0.3) =>
+    shouldReduceMotion
+      ? { initial: { opacity: 1, scale: 1 }, animate: { opacity: 1, scale: 1 }, transition: { duration: 0 } }
+      : { initial: { opacity: 0, scale: 0.95 }, animate: { opacity: 1, scale: 1 }, transition: { duration, delay } };
+
+  const hoverEffect = shouldReduceMotion ? undefined : { scale: 1.02 };
 
   return (
     <div className="min-h-screen bg-background" data-testid="page-root">
@@ -245,12 +259,7 @@ export default function B2CHomePage() {
       <Header />
       
       <main id="main-content" role="main" className="container mx-auto px-4 py-8">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-          className="space-y-8"
-        >
+        <motion.div {...getFadeInProps()} className="space-y-8">
           {/* Welcome Section */}
           <header className="text-center space-y-4">
             <h1 className="text-3xl lg:text-4xl font-bold">
@@ -266,9 +275,7 @@ export default function B2CHomePage() {
           {moduleCategories.map((category, categoryIndex) => (
             <motion.section
               key={category.title}
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, delay: categoryIndex * 0.1 }}
+              {...getFadeInProps(categoryIndex * 0.1)}
               className="space-y-4"
               aria-labelledby={`category-${categoryIndex}`}
             >
@@ -281,22 +288,17 @@ export default function B2CHomePage() {
                 {category.modules.map((module, moduleIndex) => (
                   <motion.div
                     key={module.name}
-                    initial={{ opacity: 0, scale: 0.95 }}
-                    animate={{ opacity: 1, scale: 1 }}
-                    transition={{ 
-                      duration: 0.3, 
-                      delay: categoryIndex * 0.1 + moduleIndex * 0.05 
-                    }}
-                    whileHover={{ scale: 1.02 }}
+                    {...getScaleInProps(categoryIndex * 0.1 + moduleIndex * 0.05)}
+                    whileHover={hoverEffect}
                     className="cursor-pointer"
                     onClick={() => navigate(module.path)}
                   >
-                     <Card 
-                       className="h-full hover:shadow-lg transition-all duration-300 border-l-4 border-l-transparent hover:border-l-primary"
-                       tabIndex={0}
-                       role="button"
-                       aria-describedby={`module-desc-${moduleIndex}`}
-                     >
+                    <Card
+                      className="h-full hover:shadow-lg transition-all duration-300 border-l-4 border-l-transparent hover:border-l-primary"
+                      tabIndex={0}
+                      role="button"
+                      aria-describedby={`module-desc-${categoryIndex}-${moduleIndex}`}
+                    >
                        <CardHeader className="pb-3">
                          <div className="flex items-start justify-between">
                            <div className="flex items-center space-x-3">
@@ -315,8 +317,8 @@ export default function B2CHomePage() {
                          </div>
                        </CardHeader>
                        <CardContent>
-                         <CardDescription 
-                           id={`module-desc-${moduleIndex}`}
+                         <CardDescription
+                           id={`module-desc-${categoryIndex}-${moduleIndex}`}
                            className="text-sm leading-relaxed"
                          >
                            {module.description}


### PR DESCRIPTION
## Summary
- add a safe preloading map for the highest traffic routes so RouterV2 only fetches the chunks we care about and cleans up stale entries
- push Core Web Vitals (CLS, LCP, FID) to Sentry alongside the existing DOM monitors to track page quality regressions
- defer heavy dashboard widgets with Suspense-driven skeletons and memoise the home modules while respecting reduced-motion users

## Testing
- `npm run lint` *(fails: existing parsing error in src/services/b2b/reportsApi.ts)*
- `npx eslint src/pages/B2CHomePage.tsx src/pages/B2CDashboardPage.tsx src/routerV2/performance.ts src/lib/sentry-config.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ceb7e80cac832da8bb20081d4b8224