### PR TITLE
docs: refresh onboarding documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,39 +1,47 @@
-# === SUPABASE (Front & scripts) ===
+# ============================================================================
+#  EmotionsCare – Exemple d'environnement local
+#  Copiez ce fichier en `.env.local` puis remplissez uniquement les champs utiles.
+#  Tous les secrets doivent rester hors du bundle client (ne jamais commit un .env réel).
+# ============================================================================
+
+# === SUPABASE – CLEFS FRONT & EDGE ===
 VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=public-anon-key
-# Optionnel : utilisé par certains scripts CLI
+VITE_SUPABASE_PUBLISHABLE_KEY=public-anon-key   # Compatibilité SDK v2 (SSR/Edge)
+# Facultatif : quelques scripts CLI lisent ce champ pour éviter de dupliquer les clefs
 VITE_SUPABASE_SERVICE_ROLE_KEY=
 
-NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co  # Compat héritage Next.js
 NEXT_PUBLIC_SUPABASE_ANON_KEY=public-anon-key
-# DEMO_SUPABASE_UID=00000000-0000-0000-0000-000000000001  # Utilisé pour les seeds locales (voir supabase/seeds)
-
-# URL directe des Edge Functions (utile pour scripts / tests API)
-SUPABASE_FUNCTIONS_URL=https://your-project.supabase.co/functions/v1
-SUPABASE_GRAPHQL_URL=https://your-project.supabase.co/graphql/v1
-
-# Jeton JWT service (functions & webhooks sécurisés)
-SUPABASE_JWT_SECRET=
 
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_ANON_KEY=public-anon-key
-SUPABASE_SERVICE_ROLE_KEY=
-SUPABASE_SERVICE_ROLE=
-SUPABASE_STORAGE_URL=
+SUPABASE_SERVICE_ROLE_KEY=                               # ⚠️ Edge functions uniquement (ne pas injecter côté client)
+SUPABASE_SERVICE_ROLE=                                   # Alias legacy pour scripts
+SUPABASE_STORAGE_URL=https://your-project.supabase.co/storage/v1
 
-# === API & SERVICES NODE ===
+# URLs dédiées aux Edge Functions / GraphQL (scripts & tests)
+SUPABASE_FUNCTIONS_URL=https://your-project.supabase.co/functions/v1
+SUPABASE_GRAPHQL_URL=https://your-project.supabase.co/graphql/v1
+SUPABASE_JWT_SECRET=
+
+# Identifiants seed pour `npm run db:seed`
+# DEMO_SUPABASE_UID=00000000-0000-0000-0000-000000000001
+# DEMO_SUPABASE_ORG=00000000-0000-0000-0000-0000000000ab
+
+# === API BACKEND & RUNTIME NODE ===
 PORT=3001
 API_PORT=3001
 BACKEND_BASE_URL=http://localhost:3001
 APP_VERSION=
 
 # === DATABASE & TESTS ===
-DATABASE_URL=
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/emotionscare
 DB_HOST=localhost
 DB_PORT=5432
-DB_NAME=
-DB_USER=
-DB_PASS=
+DB_NAME=emotionscare
+DB_USER=postgres
+DB_PASS=postgres
 SUPA_URL=
 SUPA_SERVICE_ROLE_KEY=
 TEST_DB_SECRET=
@@ -49,11 +57,15 @@ VITE_SENTRY_ENVIRONMENT=development
 VITE_SENTRY_TRACES_SAMPLE_RATE=0.1
 VITE_SENTRY_REPLAYS_SESSION_SAMPLE_RATE=0
 VITE_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE=1
+VITE_SENTRY_RELEASE=
 SENTRY_DSN=
 SENTRY_ENVIRONMENT=development
 SENTRY_TRACES_SAMPLE_RATE=0.1
 SENTRY_REPLAYS_SESSION_SAMPLE_RATE=0
 SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE=1
+SENTRY_AUTH_TOKEN=
+SENTRY_ORG=
+SENTRY_PROJECT=
 
 # === OBSERVABILITÉ (HEALTHCHECK) ===
 HEALTHCHECK_TIMEOUT_MS=1500
@@ -66,6 +78,7 @@ VITE_WEB_URL=http://localhost:3000
 VITE_UPLOAD_MAX_SIZE=10485760
 VITE_ALLOWED_IMAGE_TYPES=image/jpeg,image/png,image/webp
 VITE_ALLOWED_AUDIO_TYPES=audio/mpeg,audio/wav
+VITE_ADAPTIVE_MUSIC_PREVIEW_URL=
 
 # === FIREBASE (optionnel) ===
 VITE_FIREBASE_API_KEY=
@@ -79,8 +92,11 @@ VITE_FIREBASE_MEASUREMENT_ID=
 # === IA & INTÉGRATIONS EXTERNES ===
 OPENAI_API_KEY=
 NEXT_PUBLIC_OPENAI_API_KEY=
+VITE_OPENAI_API_KEY=
+VITE_OPENAI_BASE_URL=https://api.openai.com
 HUME_API_KEY=
 NEXT_PUBLIC_HUME_API_KEY=
+VITE_HUME_API_KEY=
 SUNO_API_KEY=
 MUSIC_API_KEY=
 AI_COACH_MODEL=gpt-4o-mini
@@ -92,15 +108,23 @@ VITE_VAPID_PUBLIC_KEY=
 NEXT_PUBLIC_VAPID_KEY=
 VAPID_PUBLIC_KEY=
 VAPID_PRIVATE_KEY=
+RESEND_API_KEY=
+RESEND_DEFAULT_FROM=no-reply@emotionscare.dev
+RESEND_SOCIAL_AUDIENCE_ID=
 
-# === PLAYWRIGHT / QA ===
-PW_BASE_URL=http://localhost:3000
-PW_B2C_EMAIL=
-PW_B2C_PASSWORD=
-PLAYWRIGHT_BASE_URL=http://localhost:3000
-PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=
+# === FEATURE FLAGS (fallback client défini dans src/core/flags.ts) ===
+# Voir DEFAULT_FLAGS pour la vérité terrain ; lors des tests locaux vous pouvez stubber /me/feature_flags.
+# Exemple JSON pour mocks Playwright :
+# {
+#   "FF_JOURNAL": true,
+#   "FF_COMMUNITY": true,
+#   "FF_VR": true,
+#   "FF_ASSESS_PANAS": true
+# }
 
-# === OUTILS & BUILDS ===
+# === BUILD & METADONNÉES ===
+VITE_APP_VERSION=local-dev
+VITE_COMMIT_SHA=
 NODE_ENV=development
 NODE_OPTIONS=
 USE_BUN=
@@ -119,8 +143,14 @@ DISABLE_TSC=
 TSC_NONPOLLING_WATCHER=
 TSC_COMPILE_ON_ERROR=
 
+# === PLAYWRIGHT / QA ===
+PW_BASE_URL=http://localhost:3000
+PW_B2C_EMAIL=
+PW_B2C_PASSWORD=
+PLAYWRIGHT_BASE_URL=http://localhost:3000
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=
+
 # === PUSH & AUDIT MAIL ===
-RESEND_API_KEY=
 STRIPE_SECRET_KEY=
 
 # === DIVERS ===

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,10 @@ git checkout -b docs/api-documentation
 - Suivez les [standards de code](#standards-de-code)
 - Ajoutez des tests pour vos modifications
 - Vérifiez l'accessibilité (WCAG 2.1 AA)
-- Testez localement avec `npm run test` et `npm run build`
+- Testez localement :
+  - `npm run lint`
+  - `npm run test`
+  - `npm run preview` (ou `npm run build` + `npm run preview`)
 
 ### 4. Commit
 Utilisez le format [Conventional Commits](https://www.conventionalcommits.org/) :
@@ -85,11 +88,16 @@ chore(deps): met à jour dépendances sécurité
 git push origin votre-branche
 ```
 
-Puis créez la PR sur GitHub avec :
+Avant de créer la PR, vérifiez :
+- `npm run lint`
+- `npm run test`
+- `npm run preview`
+
+Dans la PR GitHub :
 - **Titre clair** : `type(scope): Description`
 - **Description détaillée** : Que fait votre changement ? Pourquoi ?
 - **Screenshots** : Pour les changements visuels
-- **Tests** : Comment avez-vous testé ?
+- **Tests** : Résumé des commandes exécutées (lint/test/preview)
 - **Breaking changes** : Y a-t-il des changements cassants ?
 
 ## ⚙️ Configuration développement
@@ -134,11 +142,12 @@ npm run storybook        # Interface composants
 
 ### Modules & exports
 - Chaque dossier applicatif dispose d'un `index.ts` (ou `index.tsx`) qui ré-exporte l'API publique du domaine.
-- Les nouveaux composants UI partagés doivent être exposés via les barrels existants (`src/components/ui` et `src/COMPONENTS.reg.tsx`).
-- `COMPONENTS.reg.tsx` reste limité à des wrappers providers & composants purement UI (pas de stores, hooks métier ou accès réseau).
+- Exposez les composants UI partagés dans `src/components/ui/**/*` **et** dans le registre global `src/COMPONENTS.reg.ts` (UI pur uniquement).
+- Exécutez `npm run generate:ui-registry` après toute modification du registre afin de mettre à jour `docs/UI_COMPONENTS_REGISTRY.md`.
+- Les barrels métier (`index.ts`) ne doivent pas ré-exporter de secrets (service-role, clés) ni de stores privés.
 
 ### Imports Node & bundling
-- **Interdiction d'utiliser les imports `node:*`** côté front : privilégier les modules standards (`fs`, `path`…) lorsqu'ils sont bundlés côté Node/scripts.
+- **Interdiction d'utiliser les imports `node:*`** côté front : privilégier les APIs Web (`crypto.subtle`, `File`, `Blob`, etc.).
 - Les scripts Node conservent l'import classique (`import fs from 'fs'`) pour compatibilité tooling.
 - Tout import non tree-shaké doit être justifié dans la PR (bundle size).
 
@@ -173,6 +182,11 @@ const digest = await crypto.subtle.digest('SHA-256', data);
 - **Design system** défini dans index.css
 - **Composants shadcn/ui** comme base
 - **Pas de CSS inline** ou styles custom
+
+### Terminologie & contenu UI
+- Interdiction des termes cliniques explicites en UI (`dépression`, `diagnostic`, etc.) → utiliser un vocabulaire bien-être.
+- Pas de scores chiffrés dans les pages B2C (scans, communauté, social). Préférer des messages qualitatifs.
+- Respecter `docs/COMMUNITY_SAFETY.md`, `docs/SOCIAL_ROOMS.md`, `docs/VR_SAFETY.md` pour tout nouveau contenu sensible.
 
 ### Accessibilité
 - **WCAG 2.1 AA** minimum requis
@@ -219,6 +233,12 @@ Avant de soumettre, vérifiez :
 - [ ] Tests unitaires pour nouvelle logique
 - [ ] Tests E2E pour nouveaux workflows
 - [ ] Edge cases considérés
+
+#### ✅ Performance & QA
+- [ ] `npm run preview` vérifié (no console error)
+- [ ] Audit Lighthouse ou Web Vitals (si changement UI majeur)
+- [ ] Axe-core / outils a11y passés sur les pages modifiées
+- [ ] Temps de chargement / bundle monitoré (`npm run build` + analyse si besoin)
 
 ### Révision automatique
 Notre CI vérifie automatiquement :

--- a/docs/ASSESSMENTS.md
+++ b/docs/ASSESSMENTS.md
@@ -1,0 +1,54 @@
+# 📊 Assessments – Opt-in clinique
+
+L'offre d'assessments (WHO-5, PANAS, STAI-6, etc.) est entièrement opt-in et instrumentée via des Edge Functions.
+Ce guide couvre les flux, la sécurité et les règles produit (zéro score chiffré côté UI, min_n≥5 côté B2B).
+
+## 🌐 Endpoints Edge
+| Endpoint | Rôle | Source |
+| --- | --- | --- |
+| `POST /assess/start` | Sert le catalogue (questions, libellés, métadonnées). | `supabase/functions/assess-start` |
+| `POST /assess/submit` | Reçoit les réponses, calcule les scores, génère des hints orchestrateurs. | `supabase/functions/assess-submit` |
+| `POST /assess/aggregate` | Retourne les agrégats anonymisés pour le reporting B2B. | `supabase/functions/assess-aggregate` |
+
+### Sécurité commune
+- Auth Supabase obligatoire (`authenticateRequest`).
+- CORS restreint + préflight automatique (`resolveCors`).
+- Rate-limit 10 req/min (`enforceEdgeRateLimit`).
+- Hash utilisateur via Web Crypto (`_shared/hash_user.ts` → SHA-256, pas de `node:crypto`).
+- Entêtes de sécurité (`applySecurityHeaders`) injectent `X-Robots-Tag: noindex` et `Cache-Control: no-store`.
+- Sentry breadcrumbs catégorisés (`assess:start`, `assess:submit`, `assess:aggregate`) sans payload texte.
+
+## 🎛️ Feature flags & opt-in
+- Les instruments sont contrôlés par `clinical_feature_flags` (table Supabase). Règles :
+  - `FF_ASSESS_PANAS`, `FF_ASSESS_SSQ`, etc. définis côté client (`src/core/flags.ts`) → permettent d'afficher l'UI.
+  - L'API `/me/feature_flags` fusionne les defaults avec les valeurs remote (RLS public read-only).
+- UI : proposer l'assessment **uniquement** si le flag est actif et l'utilisateur a explicitement consenti (`useClinicalConsent`).
+- `doNotTrack` : `useClinicalConsent` vérifie `navigator.doNotTrack` et désactive l'assessment si DNT actif.
+
+## 🧘 Règle « zéro chiffre » côté UI
+- Les composants présentent des feedbacks qualitatifs (couleurs, phrases) – jamais de score brut.
+- Toute traduction ou message se trouve dans `src/modules/assessments/i18n.json` (pas de nombre affiché).
+- Les scores numériques restent côté Edge/B2B pour calibrer les recommandations (coach, dashboards).
+
+## 🛡️ Agrégations B2B (min_n ≥ 5)
+- `assess-aggregate` et les vues `org_assess_rollups` imposent `min_n ≥ 5` (check constraint + policy `org_rollups_min_n_guard`).
+- Les endpoints `org-dashboard-weekly`, `org-dashboard-export` réinjectent `min_n` dans la réponse (tag Sentry `min_n_pass`).
+- UI B2B (`/app/reports`, `/app/events`, `/app/optimization`) :
+  - Afficher un garde anonymat si `eligible === false` ou `min_n_met === false`.
+  - Ne jamais afficher d'agrégat si la taille d'échantillon est insuffisante (masquer la cellule, message explicite).
+
+## 🔄 Flux complet (B2C)
+1. Opt-in consentement (modal) → stocké en `user_metadata` + localStorage.
+2. `POST /assess/start` pour récupérer le questionnaire (locale `fr` par défaut).
+3. L'utilisateur répond → `POST /assess/submit`.
+4. La réponse contient :
+   - `scores` (JSON anonymisé), `level` (0-4), `orchestration_hints` (ex: `suggest_breathing`).
+   - `ttl` (minutes) pour invalider le cache.
+5. Les hints sont propagés vers les modules concernés (ex. Coach, Flash Glow) via `UnifiedStateManager`.
+
+## 🧪 Tests & QA
+- Tests Edge : `supabase/tests/assess-functions.test.ts` + `supabase/tests/assessments_checks.sql` (vérifie `min_n`).
+- QA UI : lancer `npm run test:e2e` (scénarios assessments) + vérifier `docs/ASSESSMENTS.md` lors de tout nouveau questionnaire.
+- Pour simuler l'API en local, stubber `window.fetch('/assess/...')` dans Playwright (voir exemples dans `tests/e2e` utilisant `route.fulfill`).
+
+> _Tout nouvel instrument doit être ajouté aux flags (`src/core/flags.ts` + `clinical_feature_flags`), documenté ici, et validé par le legal/privacy avant mise en prod._

--- a/docs/COMMUNITY_SAFETY.md
+++ b/docs/COMMUNITY_SAFETY.md
@@ -1,29 +1,37 @@
-# Communauté – Sécurité & Modération douce
+# 🛡️ Communauté – Sécurité & modération douce
 
-Ce document résume la posture de sécurité pour la page `/app/community`.
+La page `/app/community` (et son alias `/app/communaute`) est livrée en production avec des garde-fous stricts. Ce guide rappelle les règles à suivre.
 
-## Lexique sensible surveillé
+## 🔍 Détection & auto-signalement
+- Lexique sensible surveillé (`community:auto-flag` → Sentry) :
+  - « suicide », « me faire mal », « violence grave », « danger immédiat », « harcèlement ».
+- L'auto-signalement envoie uniquement : identifiant hashé, motif, longueur du message (pas de texte brut).
+- Les événements `community:report` (bouton « Signaler doucement ») suivent la même règle.
 
-Les expressions suivantes déclenchent un auto-signalement silencieux (`community:auto-flag`) vers Sentry :
+## 👂 Posture de réponse
+1. Toujours remercier le partage (`Merci pour ta confiance…`).
+2. Formulations non directives (« Je suis là si tu veux parler » plutôt que conseils imposés).
+3. Rediriger vers **Social Cocon** (`routes.b2c.socialCocon()`) quand la solitude est évoquée.
+4. Proposer des ressources d'urgence si le motif « danger immédiat » est détecté (CTA contextuel).
 
-- « suicide »
-- « me faire mal » (et variantes)
-- « violence grave »
-- « danger immédiat »
-- « harcèlement »
+## 🔒 Privacy & données
+- Pas de chiffres affichés (seule la tonalité est visible : « apaisée », « agitée »…).
+- Les cartes du feed n'exposent que des métadonnées anonymes (timestamps arrondis, pas d'ID public).
+- `PageSEO` force `noindex` pour cette page.
+- Les analytics agrègent uniquement le volume (`community:message_posted`, `community:report_submitted`).
 
-Le contenu exact n’est jamais envoyé. Seule la longueur du message et le motif sont tracés.
+## 🧭 Flux modération
+1. L'utilisateur clique « Signaler doucement » → modale avec raisons pré-remplies.
+2. Un ticket Sentry `community:report` est créé (assigned à l'équipe care).
+3. L'équipe suit la procédure :
+   - `danger immédiat` → escalade support 24/7.
+   - `harcèlement` → suspension préventive + message empathique.
+4. Feedback discret à l'utilisateur (« Merci, nous veillons dessus »).
 
-## Processus de signalement utilisateur
+## ✅ Checklist avant merge (feature community)
+- [ ] Les nouvelles cartes respectent la charte (pas de contenu chiffré, pas d'avatar externe).
+- [ ] Les CTA critiques (report, contact) restent en `aria-label` explicites.
+- [ ] Tests e2e/QA vérifient `community:auto-flag` + redirection Social Cocon.
+- [ ] Documentation mise à jour (`docs/SOCIAL_ROOMS.md` si impact).
 
-1. L’usager clique sur **« Signaler doucement »** depuis une carte du feed.
-2. Il sélectionne une raison et, s’il le souhaite, ajoute un message libre.
-3. Un événement `community:report` est envoyé à Sentry (sans texte brut).
-4. L’équipe de veille traite le ticket en priorisant les cas « danger immédiat ».
-
-## Posture de réponse
-
-- Toujours remercier le partage et inviter à l’écoute active.
-- Proposer des formulations non directives (« Je suis là si tu veux parler »).
-- Rediriger vers Social Cocon en rappelant les garde-fous lorsque la solitude est élevée.
-- Préférer la co-construction plutôt que les conseils catégoriques.
+> _La communauté reste un espace de soutien léger. Toute fonctionnalité qui augmente la profondeur des échanges doit repasser par review Care + Privacy._

--- a/docs/COMPONENTS_GUIDE.md
+++ b/docs/COMPONENTS_GUIDE.md
@@ -1,0 +1,56 @@
+# 🧱 Registre UI & composants partagés
+
+Le fichier `src/COMPONENTS.reg.ts` centralise les exports UI (composants purs, hooks UI, providers transverses). Ce guide explique comment le maintenir.
+
+## 🎯 Objectifs
+- Fournir un import unique pour les écrans marketing & app (`import { Button } from '@/COMPONENTS.reg'`).
+- Garantir que seuls des éléments « UI pur » (pas de logique métier) y figurent.
+- Générer automatiquement la documentation (`docs/UI_COMPONENTS_REGISTRY.md`).
+
+## 🗂️ Structure actuelle
+- Les exports sont groupés par famille :
+  - **UI shadcn** (`Button`, `Card`, `Input`, `Textarea`, etc.).
+  - **Animation** (`FadeIn`, `SlideIn`).
+  - **Thème & i18n** (`ThemeProvider`, `useTheme`, `I18nProvider`, `t`).
+  - **Hooks UI** (`usePrefetchOnHover`, `usePulseClock`, `useRaf`, `useTimer`).
+  - **Feature flags** (`flagActive`, `inCohort`, etc.).
+  - **Composants marketing** (`PageHeader`, `NavBar`, `Footer`, `GlowSurface`, `CookieConsent`).
+
+## 🛠️ Génération du registre documentaire
+1. Mettre à jour `src/COMPONENTS.reg.ts` (ajout/suppression d'exports).
+2. Exécuter `npm run generate:ui-registry`.
+3. Le script :
+   - Analyse les exports.
+   - Catégorise (`Composant UI`, `Hook`, `Provider`, etc.).
+   - Génère `docs/UI_COMPONENTS_REGISTRY.md` (statistiques + tableau).
+4. Committer **le fichier TS et le markdown généré**.
+
+## ✅ Règles à respecter
+- Pas d'exports métiers (ex: `useJournalStore`, `createSession`). Garder uniquement UI, theme, i18n, flags.
+- Préférer les chemins relatifs à partir de `src/` (`@/` résout via Vite).
+- Pour tout nouveau composant UI partagé :
+  - Ajouter un export dans `src/components/ui/<component>.tsx`.
+  - L'exposer via le registre (`COMPONENTS.reg.ts`).
+  - Mettre à jour `docs/COMPONENTS_GUIDE.md` si une nouvelle catégorie apparaît.
+- Pour retirer un composant, vérifier qu'aucune page ne l'importe encore (grep repo) avant suppression.
+
+## 🔍 Exemple d'utilisation
+```ts
+import { Button, ThemeProvider, usePrefetchOnHover } from '@/COMPONENTS.reg';
+
+function CTA() {
+  usePrefetchOnHover('/signup');
+  return (
+    <ThemeProvider>
+      <Button variant="primary">Commencer</Button>
+    </ThemeProvider>
+  );
+}
+```
+
+## 📌 Checklist
+- [ ] L'export est purement UI (pas de requête réseau, pas de store métier).
+- [ ] `npm run generate:ui-registry` exécuté après modification.
+- [ ] `docs/UI_COMPONENTS_REGISTRY.md` commit avec la mise à jour.
+
+> _Pour un composant spécifique à une feature (Flash Glow, VR…), ne pas l'ajouter au registre global. Restez sur des imports locaux pour éviter de gonfler le bundle partagé._

--- a/docs/MODULES_LISTING.md
+++ b/docs/MODULES_LISTING.md
@@ -1,138 +1,152 @@
 # 🧩 Modules EmotionsCare
 
-## 🗂️ Légende des statuts
-- **🟢 Livré** : expérience complète branchée (données Supabase/Edge Functions, analytics optionnels).
-- **🟡 Bêta** : parcours opérationnel mais encore en validation (UX ou intégrations tierces en cours).
-- **🟠 Prototype** : module conservé pour la R&D ou les démonstrations internes.
+Ce référentiel couvre l'état courant des modules métiers et les services partagés qui les alimentent.
+Pour chacun : entrées, routes, dépendances clefs (assessments Edge, sessions, favoris, journal) et couverture QA.
 
-## Modules livrés
+## 🔗 Socles partagés
+
+### Assessments (Edge `/assess/*`)
+- **Fonctions** : `assess-start`, `assess-submit`, `assess-aggregate` (cf. `supabase/functions/assess-*`).
+- **Flux** :
+  1. `POST /assess/start` renvoie le catalogue (questions + métadonnées) selon l'instrument & la locale.
+  2. `POST /assess/submit` persiste un hash utilisateur, sérialise les réponses anonymisées, calcule les scores (`summarizeAssessment`).
+  3. `POST /assess/aggregate` expose les agrégats B2B (`org_assess_rollups`) avec contrainte `min_n ≥ 5` (policy `org_rollups_min_n`).
+- **Sécurité** : authentification Supabase obligatoire, rate-limit (10/min), CORS restreint, hash utilisateur Web Crypto (`_shared/hash_user.ts`).
+- **Flags** : instruments activés via `clinical_feature_flags` (flags `FF_ASSESS_*`, opt-in, rollout par instrument).
+
+### Sessions API (`src/services/sessions/sessionsApi.ts`)
+- `createSession` / `listMySessions` / `logAndJournal` centralisent la persistance Supabase (`sessions`) et l'écriture dans `journal_entries`.
+- Nettoie durées et `mood_delta`, limite [-10, +10], ajoute breadcrumbs Sentry `session:*` et `journal:auto:insert`.
+- Utilisé par Flash Glow, Breath Constellation, VR Galaxy, Screen Silk, etc. => toujours importer ce service (pas d'insert SQL direct).
+
+### Favorites Adaptive Music (`src/hooks/useMusicFavorites.ts`)
+- Hook React Query (`QUERY_KEY = ['adaptive-music','favorites']`).
+- Services : `src/services/music/favoritesService.ts` (REST `/favorites`).
+- Fournit `favorites`, `isFavorite`, `toggleFavorite`, `isToggling`. Utilisé sur Dashboard (tuile musique) + page Adaptive Music.
+
+### Journal Service (`src/services/journal/journalApi.ts`)
+- Routines `listEntries`, `createEntry`, `sanitizeContent` + redaction DOMPurify.
+- `logAndJournal` s'appuie dessus pour créer les notes automatique post-session.
+- Tests : `journalApi.spec.ts`, e2e `journal-feed.spec.ts` & `security.xss-journal.spec.ts`.
+
+## 🎯 Modules B2C – Coaching & auto-soin
 
 ### 🧠 Emotion Scan — 🟢 Livré
-- **Entrée** : `src/modules/emotion-scan/EmotionScanPage.tsx` routé via `/app/scan`.
-- **Services** : `invokeEmotionScan`, `getEmotionScanHistory` dans `src/services/emotionScan.service.ts`.
-- **Persistance Supabase** : table `public.emotion_scans` (payload JSONB + `mood_score`), RLS stricte (policies owner-only), indexes `user_id` + `created_at desc`.
-- **Fonctionnalités clés** :
-  - Questionnaire I-PANAS-SF complet avec calcul immédiat du score et libellé d'équilibre.
-  - Mutation React Query vers la fonction edge Supabase (historique distant) et fallback local (`localStorage`) hors ligne.
-  - Rafraîchissement automatique des widgets « recent-scans » et enregistrement analytics optionnels via `recordEvent`.
-  - ✅ QA 06/2025 : scénario e2e `emotion-scan-dashboard.spec.ts` (parcours scan → historique) + suite unitaire `useMoodStore` (7 tests).
-
-### 🎚️ Mood Mixer — 🟢 Livré
-- **Entrée** : `src/pages/B2CMoodMixerPage.tsx` sur `/app/mood-mixer`.
-- **Services** : `src/services/moodPresetsService.ts`, `src/services/moodPlaylist.service.ts` et `adaptiveMusicService`.
-- **Persistance Supabase** : table `public.mood_presets` (nom + sliders JSONB) avec RLS owner-only, indexes `user_id` + `created_at desc`.
-- **Fonctionnalités clés** :
-  - Chargement/sauvegarde des presets `mood_presets` (Supabase) avec clamp des ratios et synchronisation utilisateur.  
-  - Génération de noms de vibes dynamiques et édition en temps réel des curseurs douceur/clarté.  
-  - Pré-écoute Adaptive Music : appel API pour récupérer une piste, contrôle lecture/pause et bascule mock/API suivant la disponibilité.
-  - Gestion accessibilité (particles conditionnels sur `prefers-reduced-motion`).
-  - ✅ QA 06/2025 : scénario e2e `mood-mixer-crud.spec.ts` (CRUD complet) + tests `useMoodMixerStore` (7 cas) et `useJournalStore` (4 cas) pour l'enrichissement historique.
-
-### ⚡ Flash Glow & Ultra — 🟢 Livré
-- **Entrées** : `src/modules/flash-glow/useFlashGlowMachine.ts`, `src/modules/flash-glow/journal.ts`, `src/modules/flash-glow-ultra/FlashGlowUltraPage.tsx`.
-- **Services** : `src/modules/flash-glow/flash-glowService.ts`, intégration journal via `createFlashGlowJournalEntry`, moteur partagé `src/services/sessions/sessionsApi.ts`.
-- **Persistance Supabase** : table `public.sessions` (type, durée, `mood_delta`, `meta` JSONB) avec indexes sur `user_id`, `created_at desc`, `type` + RLS owner-only.
-- **Fonctionnalités clés** :
-  - Machine d'état asynchrone couplée au hook commun `useSessionClock` (start/pause/resume/complete) avec breadcrumbs Sentry `session:*`.
-  - Suivi des humeurs (`moodBaseline`, `moodAfter`) et calcul directionnel via `computeMoodDelta` sérialisé dans `meta`.
-  - Journalisation automatique Supabase via `logAndJournal` (insert `sessions` + entrée `journal_entries` bienveillante) et fallback local.
-  - Interface Flash Glow Ultra migrée sur le moteur partagé (`useSessionClock`) avec région `aria-live`, focus conservé et auto-journal `logAndJournal` (couverture `flashGlowUltraSession.test.tsx`).
-  - Statistiques locales (nombre/temps moyen) et toasts en cas d'interruption.
-  - ✅ QA 06/2025 : scénario e2e `flash-glow-ultra-session.spec.ts` + tests `useGlowStore` (5 cas) couvrant start/pause/resume/reset.
-- **Entrées** : `src/pages/flash-glow/index.tsx` (parcours SESS-01 sur `/app/flash-glow`) & `src/modules/flash-glow-ultra/FlashGlowUltraPage.tsx`.
-- **Services** : `src/hooks/useSessionClock.ts`, `src/modules/flash/useFlashPhases.ts`, `src/modules/flash/sessionService.ts` (`logAndJournal`).
-- **Persistance Supabase** : tables `public.user_activity_sessions` + `public.journal_entries` (RLS owner-only, indexes `user_id`/`created_at`).
-- **Fonctionnalités clés** :
-  - Horloge robuste (tick 1 s, pause sur `visibilitychange`) via `useSessionClock` + phases `warmup → glow → settle` (`useFlashPhases`).
-  - `computeMoodDelta` calcule le delta valence/arousal silencieux, `logAndJournal` enregistre activité + entrée journal par défaut bienveillante.
-  - UI accessible (`aria-live`, CTA contextuel Start/Pause/Reprendre/Relancer, variante `prefers-reduced-motion` sans flash).
-  - Breadcrumbs Sentry `session:*`, `flash:phase_change`, `journal:auto:insert` + toasts succès/erreur.
-  - ✅ QA 06/2025 : e2e `flash-glow-session.spec.ts` (start → pause → reprise → completion) + tests unitaires `useSessionClock` & `useFlashPhases`.
-
-### 🌌 Breath Constellation — 🟢 Livré
-- **Entrée** : `src/modules/breath-constellation/BreathConstellationPage.tsx` via `/app/breath`.
-- **Services** : `src/services/breathworkSessions.service.ts`, moteur partagé `src/services/sessions/sessionsApi.ts`, hook `@/ui/hooks/useBreathPattern`.
-- **Persistance Supabase** : mutualise `public.sessions` (log des séances Breath/FlashGlow) sous RLS owner-only, indexes `user_id`, `created_at`, `type`.
-- **Fonctionnalités clés** :
-
-- Protocoles nommés (cohérence, sommeil profond, carré, triangle) avec cadence calculée et bénéfices contextualisés.
-  - Horloge partagée `useSessionClock` respectant `prefers-reduced-motion` (aria-live, focus conservé, pause/reprise instrumentées Sentry).
-  - Options audio/haptique via `useSound`, enregistrement Supabase (`logBreathworkSession`) + insertion automatique journal via `logAndJournal`.
-
-- Protocoles nommés (cohérence 5-5, 4-7-8, box, triangle) avec cadence calculée et bénéfices contextualisés.
-  - Support `prefers-reduced-motion` : désactive animations complexes et affiche instructions textuelles.
-  - Options audio/haptique via `useSound` + enregistrement Supabase des sessions (gestion erreurs auth/persistance).
-  - Émissions d'events analytics facultatifs (`recordEvent`).
-  - ✅ Tests accessibilité : `BreathConstellationStatus.test.tsx` (annonces `aria-live`) en complément du smoke e2e.
-  - ✅ QA 06/2025 : régression manuelle post build, couverture e2e générale `breath-constellation-session.spec.ts`.
-
-### 🌬️ Breath Guidance — 🟢 Livré
-- **Entrée** : `src/pages/breath/index.tsx` routé via `/breath`.
-- **Modules partagés** : `src/modules/breath/protocols.ts`, `src/modules/breath/useSessionClock.ts`, composants `BreathCircle` & `BreathProgress`, journalisation `src/modules/breath/logging.ts`.
-- **Persistance Supabase** : table `public.sessions` (type `breath`, durée, `mood_delta`, `meta` JSONB) + journal local via `journalService`.
-- **Fonctionnalités clés** :
-  - Protocoles 4-7-8 et cohérence cardiaque (variant 4,5/5,5) avec cadence auto et séquence générée jusqu'à la durée choisie (3–10 min).
-  - Session clock accessible (`useSessionClock`) avec raccourci clavier Espace (start/pause/resume), aria-live, focus management, Sentry breadcrumbs `breath:protocol:*` et `session:*`.
-  - Motion-safe : bascule automatique vers barre de progression si `prefers-reduced-motion` actif, animation cercle sinon ; audio cue opt-in via `useSound`.
-  - Mesure silencieuse STAI-6 opt-in (feature flag `FF_ASSESS_STAI6`) avec appels `POST /assess/start|submit`, aucun score affiché, réponses utilisées pour recommandations.
-  - Fin de séance : `logAndJournal` enregistre la session Supabase + note auto (delta d’humeur calculé, notes utilisateur), toasts doux en cas d'échec Supabase.
-  - ✅ QA 06/2025 : tests unitaires `src/modules/breath/__tests__/*` (protocoles, session clock, mood utils) + e2e `tests/e2e/breath-guided-session.spec.ts` (4-7-8 + cohérence, pause/resume, zéro warning console).
-
-### 📝 Journal — 🟢 Livré
-- **Entrée** : `src/pages/B2CJournalPage.tsx` → `JournalView` (`src/pages/journal/JournalView.tsx`).
-- **Services** : `src/services/journal/journalApi.ts`, hook `src/modules/journal/useJournalComposer.ts`.
-- **Persistance Supabase** : table `public.journal_entries` (texte + tags, mode `text|voice`, résumé IA) + `coach_conversations`/`coach_messages` pour le brouillon.
-- **Fonctionnalités clés** :
-  - Composer accessible (textarea + dictée Web Speech API, fallback upload audio) avec sanitisation stricte (DOMPurify côté rendu, `sanitize-html` côté service).
-  - Feed paginé (`useInfiniteQuery`) avec recherche plein texte, filtres multi-tags, action « Envoyer au coach » (brouillon sans PII) et carte Dashboard synchronisée.
-  - Breadcrumbs Sentry (`journal:insert_text|insert_voice|list|coach_draft`) avec redaction (longueur/tags uniquement) et validation Zod (`NoteSchema`, `FeedQuerySchema`).
-  - ✅ QA 2025-03 : tests unitaires `journalApi.spec.ts` (sanitisation, validation, mappers) + e2e Playwright `journal-feed.spec.ts` & `security.xss-journal.spec.ts` (dictée mockée, recherche, tags, dashboard).
-
-### 🧭 Coach IA — 🟢 Livré
-- **Entrée** : `src/pages/B2CAICoachPage.tsx` (`/app/coach`) rendu via `CoachView`.
-- **Services** : `src/services/coach/coachApi.ts` (SSE + fallback) et fonction edge `supabase/functions/ai-coach/index.ts`.
-- **Persistance Supabase** : table `public.coach_logs` (résumé ≤ 280 caractères, `thread_id`, `mode`) avec RLS owner-only + indexes `user_id`, `thread_id`.
-- **Fonctionnalités clés** :
-  - Consentement explicite (modal opt-in, stockage local + `user_metadata`) avant tout envoi.
-  - Hash utilisateur Web Crypto (SHA-256) pour tagger les sessions sans exposer l’UUID.
-  - Edge sécurisée (JWT obligatoire, CORS restreint, rate-limit 30 req/min, modération + désescalade) et réponses streamées SSE.
-  - UI conversation accessible (`aria-live`, envoi Ctrl+Entrée, actions rapides respiration/journal/musique, badge B2B).
-  - Observabilité safe : breadcrumbs Sentry redacts, logs anonymisés `coach_logs`, refus crise/self-harm avec messages ressources.
-  - ✅ QA 07/2025 : tests unitaires (`hash`, prompts, redaction), Deno guardrails, Playwright `coach.smoke.spec.ts` (consentement → réponse stub).
+- **Entrée** : `src/modules/emotion-scan/EmotionScanPage.tsx` (route `/app/scan`).
+- **Dépendances** :
+  - `invokeEmotionScan` + `getEmotionScanHistory` (`src/services/emotionScan.service.ts`).
+  - Assessments Edge (`instrument = PANAS`, flag `FF_ASSESS_PANAS`).
+  - `useSessionClock` (pour transitions) et `useFlags` (feature toggles).
+- **Persistance** : table `public.emotion_scans` + historique local fallback.
+- **Tests** : e2e `emotion-scan-dashboard.spec.ts`, unitaires `emotionScan.service.test.ts`.
 
 ### 🎵 Adaptive Music — 🟢 Livré
-- **Entrée** : `src/modules/adaptive-music/AdaptiveMusicPage.tsx` sur `/app/music`.
-- **Services** : `src/services/moodPlaylist.service.ts`, `src/hooks/useMusicControls.ts`.
-- **Fonctionnalités clés** :
-  - Builder de requête mood→playlist (mood, intensité, durée, préférences instrumentales & contexte).  
-  - Normalisation stricte de la réponse (tracks, energyProfile, guidance) avec message d'erreur en cas de payload invalide.  
-  - Gestion locale des favoris (persistés en `localStorage`) et reprise de lecture (`playback snapshot`).
-  - Export/partage guidé avec synthèse de la playlist et recommandations.
-  - ✅ QA 06/2025 : scénario e2e `adaptive-music-favorites.spec.ts` + tests `requestMoodPlaylist` (3 cas) sur la normalisation client.
+- **Entrée** : `src/modules/adaptive-music/AdaptiveMusicPage.tsx` (`/app/music`, `/app/music-premium`).
+- **Dépendances** :
+  - Favorites hook (`useMusicFavorites`).
+  - Services `moodPlaylist.service.ts`, `adaptiveMusicService` (IA + pré-écoute), `useMusicControls`.
+  - Feature flag `FF_PREMIUM_SUNO` pour Suno.
+- **Persistance** : favoris local → Supabase (`favorites`), presets via `mood_presets`.
+- **Tests** : e2e `adaptive-music-favorites.spec.ts`, unitaires normalisation (`requestMoodPlaylist.test.ts`).
 
-### 📊 Scores & vibes — 🟢 Livré
-- **Entrées** : `src/pages/ScoresPage.tsx`, `src/app/modules/scores/ScoresV2Panel.tsx`, `src/services/scores/dataApi.ts`, `src/features/scores/*`.
-- **Données Supabase** : `emotion_scans.payload` (valence, arousal, labels) et `sessions` (type, created_at) sous RLS owner-only (aucune donnée textuelle du journal).
-- **Fonctionnalités clés** :
-  - Agrégation React Query (cache 60s) + lissage (moving average) pour les courbes valence/arousal sur 30 jours.
-  - Barres hebdomadaires empilées (8 semaines glissantes) + heatmap SVG personnalisée des vibes dominantes (calm/focus/bright/reset).
-  - Respect accessibility : aria-label/role="img", texte de synthèse pour lecteurs d'écran, animation désactivée si `prefers-reduced-motion`.
-  - Export PNG fiable via bouton dédié (html2canvas-free) + breadcrumbs Sentry `scores:fetch:*` & `scores:export:png`.
-  - ✅ QA 06/2025 : tests unitaires `src/services/scores/__tests__/dataApi.test.ts` (mappers/agrégations) + e2e `tests/e2e/scores-heatmap-dashboard.spec.ts` (chargement, interactions, export).
+### 🤖 Coach IA — 🟢 Livré
+- **Entrée** : `src/pages/B2CAICoachPage.tsx` (`/app/coach` & `/app/coach-micro`).
+- **Dépendances** :
+  - Edge `supabase/functions/ai-coach*` (SSE, modération).
+  - `src/lib/hash.ts` (hash Web Crypto, interdit `node:crypto`).
+  - Feature flag `FF_COACH`.
+- **Sécurité** : consentement explicite, redaction Sentry (`src/lib/sentry-config.ts`), logs anonymisés `coach_logs`.
+- **Tests** : `coach.smoke.spec.ts`, unitaires hash & prompts.
 
-### 🩺 Observabilité — Endpoint `/health`
-- **Entrée** : service Fastify `services/api/server.ts` exposant `/health`, `/healthz` et `/api/healthz`.
-- **Vérifications effectuées** :
-  - Supabase (`auth` + requête REST légère) avec latence et statut (`ok|degraded|down`).
-  - Fonctions critiques (par défaut `ai-emotion-analysis`, `ai-coach`) pingées en `HEAD`.
-  - Stockage public (URL configurable) via requête `HEAD`.
-- **Réponse JSON minifiée** : `{ status, timestamp, checks: { supabase, functions[], storage }, signature }`.
-  - `signature` = SHA-256 du payload + `HEALTH_SIGNING_SECRET` pour détecter toute altération.
-  - Exposition contrôlée par CORS (`HEALTH_ALLOWED_ORIGINS`) et rate-limit mémoire (60 req/min/IP par défaut).
-- **Tests** : `services/api/tests/health.test.ts` simule succès + fonction en panne, vérifie latences et signature.
+### 📝 Journal — 🟢 Livré
+- **Entrée** : `src/pages/journal/JournalView.tsx` (`/app/journal`, `/journal/new`).
+- **Dépendances** : journal service, `useJournalComposer`, `logAndJournal` (auto-brouillon), Auth Supabase.
+- **Sécurité** : sanitisation DOMPurify + `sanitize-html`, interdiction PII Sentry.
+- **Tests** : `journalApi.spec.ts`, e2e `journal-feed.spec.ts`.
 
-## Modules en bêta ou prototypes
-- **B2C fun-first hérités** (`src/pages/modules/*`) : conservés pour démos gamifiées (Story Synth, Bubble Beat…).
-- **Admin & outils** (`src/modules/admin`, `src/modules/screen-silk`) : fonctions internes, statut 🟠.
+### 🌈 Mood Mixer — 🟢 Livré
+- **Entrée** : `src/pages/B2CMoodMixerPage.tsx` (`/app/mood-mixer`).
+- **Dépendances** : presets service (`moodPresetsService`), Adaptive Music API, favorites hook.
+- **Persistance** : `mood_presets` (RLS owner-only).
+- **Tests** : e2e `mood-mixer-crud.spec.ts`, unitaires `useMoodMixerStore`.
 
-> _Mettez à jour ce fichier dès qu'un module change de statut ou qu'un nouveau service partagé est introduit._
+### ⚡ Flash Glow & Ultra — 🟢 Livré
+- **Entrées** : `src/modules/flash-glow/useFlashGlowMachine.ts`, `src/modules/flash-glow-ultra/FlashGlowUltraPage.tsx` (`/app/flash-glow*`).
+- **Dépendances** : `useSessionClock`, Sessions API (`createSession`, `logAndJournal`), `computeMoodDelta`, `useGlowStore` (persist immuable).
+- **Tests** : e2e `flash-glow-ultra-session.spec.ts`, unitaires `useSessionClock`, `useFlashPhases`.
+
+### 🌌 Breath Constellation — 🟢 Livré
+- **Entrée** : `src/modules/breath-constellation/BreathConstellationPage.tsx` (`/app/breath`).
+- **Dépendances** : Sessions API (`type = 'breath'`), `useBreathPattern`, `useSound`.
+- **Tests** : e2e `breath-constellation-session.spec.ts`, unitaires `breathProtocols.test.ts`.
+
+### 🪞 Screen Silk Break — 🟢 Livré
+- **Entrée** : `src/modules/screen-silk/ScreenSilkBreakPage.tsx` (`/app/screen-silk`).
+- **Dépendances** : Sessions API (log micro-pauses), `useScreenSilkStore` (persist, immuable), `usePerformanceGuard`.
+- **Tests** : smoke QA (dev dashboard), assertions store `screenSilk.store.test.ts`.
+
+### 🧩 Prototypes fun-first — 🟠
+- Boss Level Grit (`/app/boss-grit`), Bounce Back (`/app/bounce-back`), Story Synth (`/app/story-synth`), Ambition Arcade (`/app/ambition-arcade`), Bubble Beat (`/app/bubble-beat`), Face AR (`/app/face-ar`).
+- Conservés pour R&D, dépendances limitées (mock data, analytics off).
+
+## 🪐 VR & sécurité immersion
+
+### VR Galaxy / VR Hub — 🟢
+- **Entrée** : `src/pages/B2CVRGalaxyPage.tsx` (`/app/vr`, `/app/vr-galaxy`).
+- **Dépendances** :
+  - Store sécurité VR (`src/store/vrSafety.store.ts` – persist, selectors).
+  - Sessions API (`type = 'vr_galaxy'`).
+  - Assessments opt-in (`FF_ASSESS_SSQ`, `FF_ASSESS_POMS`) pour hints de sécurité.
+  - `useVRPerformanceGuard` (downgrade vers 2D).
+- **Tests** : unitaires store (`vrSafety.store.test.ts`), QA manuelle VR, logs Sentry `vr:*`.
+
+### VR Breath Guide & VR Breath — 🟢
+- **Entrées** : `src/pages/B2CVRBreathGuidePage.tsx`, `src/pages/VRBreathPage.tsx`.
+- **Dépendances** : Sessions API (`vr_breath`), store sécurité VR, `useSessionClock`, `useSound`.
+- **Tests** : scenarios QA VR, check `FF_VR` gating.
+
+## 🤝 Social & communauté
+
+### Community Feed — 🟢
+- **Entrée** : `src/pages/B2CCommunautePage.tsx` (`/app/community`, `/app/communaute`).
+- **Dépendances** :
+  - Signalement doux (`community:auto-flag` via Sentry).
+  - Feature flag `FF_COMMUNITY`.
+  - `useFlags` + `useError` (alias `useErrorHandler`) pour toasts.
+- **Tests** : QA manuelle (liste / report). Security doc `docs/COMMUNITY_SAFETY.md`.
+
+### Social Cocon B2C — 🟢
+- **Entrée** : `src/pages/B2CSocialCoconPage.tsx` (`/app/social-cocon`).
+- **Dépendances** : animations framer-motion, RouterV2 guards, guidelines sécurité `docs/SOCIAL_ROOMS.md`.
+- **Tests** : QA ciblée (modes privacy, animation d'entrée).
+
+### Activity / Scores / Leaderboard — 🟢
+- **Entrées** : `src/pages/B2CActivitePage.tsx`, `src/pages/ScoresPage.tsx`, `src/pages/LeaderboardPage.tsx`.
+- **Dépendances** :
+  - Supabase `sessions`, `emotion_scans`, vues agrégées `org_assess_rollups` (min_n ≥ 5).
+  - Hooks `useOrgWeekly`, `useLeaderboard`, `useScoresData` (React Query + Sentry tags `min_n_pass`).
+- **Tests** : e2e `scores-heatmap-dashboard.spec.ts`, `activity-timeline.spec.ts` (QA).
+
+## 🏢 Modules B2B
+
+### Dashboard collaborateur & Social B2B — 🟡
+- **Entrées** : `src/pages/B2BCollabDashboard.tsx`, `src/pages/B2BSocialCoconPage.tsx` (`/app/collab`, `/app/social`).
+- **Dépendances** :
+  - API Supabase `team_activities`, `wellness_programs` (mock data en dev).
+  - Feature flag `FF_MANAGER_DASH` & `FF_COMMUNITY` (mode B2B).
+- **Tests** : snapshots visuels, QA manuelle (en attente d'e2e).
+
+### Suite Manager (Reports, Events, Optimization, Security, Accessibility) — 🟡
+- **Entrées** : `src/pages/B2BReportsPage.tsx`, `src/pages/B2BReportDetailPage.tsx`, `src/pages/B2BEventsPage.tsx`, `src/pages/B2BOptimisationPage.tsx`, `src/pages/B2BSecurityPage.tsx`, `src/pages/B2BAccessibilityPage.tsx`.
+- **Dépendances** :
+  - Edge `/assess/aggregate` pour agrégats anonymisés.
+  - Services `reportsApi`, `orgWeekly` (`min_n` enforcement, Sentry tag `min_n_pass`).
+  - Export CSV Edge (`org-dashboard-export`).
+- **Tests** : unitaires `reportsApi.test.ts`, QA (tableur, export CSV).
+
+## ✅ Checklist mise à jour
+- [x] Chaque module indique ses entrées, routes et dépendances partagées (assessments, sessions, favorites, journal).
+- [x] Les statuts correspondent aux routes RouterV2 actuelles.
+- [x] Les tests/références QA sont explicitement listés pour l'onboarding (<15 min).
+
+> _Mettre à jour ce document dès qu'un module change de statut ou qu'un nouveau service partagé est introduit. Vérifier également les flags dans `src/core/flags.ts` pour tout nouveau module._

--- a/docs/PAGES_LISTING.md
+++ b/docs/PAGES_LISTING.md
@@ -8,59 +8,83 @@
 ## 🌐 Entrées publiques & marketing
 | Page | Route(s) | Statut | Description | Fichier principal |
 | --- | --- | --- | --- | --- |
-| HomePage | `/` | 🟢 | Landing unifiée qui sert le contenu marketing complet et annonce aux utilisateurs connectés l'accès rapide à leur tableau de bord. | `src/components/HomePage.tsx` |
-| SimpleB2CPage | `/b2c` | 🟢 | Variante allégée de la home pour la cible B2C avec CTA directs vers l'inscription et les offres entreprise. | `src/components/SimpleB2CPage.tsx` |
-| B2BEntreprisePage | `/entreprise` (`/b2b`) | 🟡 | Présentation des programmes entreprise et formulaires d'intérêt, encore en finalisation marketing. | `src/pages/B2BEntreprisePage.tsx` |
-| AboutPage | `/about` | 🟢 | Page « À propos » structurée en sections animées et orientées accessibilité (focus management, badges de valeurs). | `src/pages/AboutPage.tsx` |
-| ContactPage | `/contact` | 🟢 | Formulaire de contact réactif avec coordonnées directes et carte d'engagement. | `src/pages/ContactPage.tsx` |
-| DemoPage | `/demo` | 🟡 | Parcours interactif pas-à-pas qui illustre Emotion Scan, Adaptive Music et Coach via composants motion. | `src/pages/DemoPage.tsx` |
-| HelpPage | `/help` | 🟢 | Centre d'aide listant FAQ, assistance chat et liens rapides. | `src/pages/HelpPage.tsx` |
-| OnboardingPage | `/onboarding` | 🟡 | Présentation guidée des modules clés avant connexion complète. | `src/pages/OnboardingPage.tsx` |
-| LegalTermsPage & LegalPrivacyPage | `/legal/terms`, `/legal/privacy` | 🟢 | Pages légales décorrélées qui reprennent les obligations RGPD et CGU. | `src/pages/LegalTermsPage.tsx`, `src/pages/LegalPrivacyPage.tsx` |
+| HomePage | `/` | 🟢 | Landing unifiée qui adresse B2C & B2B, gère les CTA et les redirections d'utilisateurs déjà authentifiés. | `src/components/HomePage.tsx` |
+| SimpleB2CPage | `/b2c` (alias `/choose-mode`) | 🟢 | Variante orientée particuliers : storytelling + CTA directs vers l'inscription. | `src/components/SimpleB2CPage.tsx` |
+| B2BEntreprisePage | `/entreprise` (alias `/b2b`) | 🟡 | Présentation des parcours entreprises, formulaires d'intérêt et crédibilisation sociale. | `src/pages/B2BEntreprisePage.tsx` |
+| AboutPage | `/about` | 🟢 | Page « À propos » structurée en sections avec focus management et éléments de preuve. | `src/pages/AboutPage.tsx` |
+| ContactPage | `/contact` | 🟢 | Formulaire de contact, coordonnées directes et routage support. | `src/pages/ContactPage.tsx` |
+| DemoPage | `/demo` | 🟡 | Démo guidée des modules Emotion Scan, Coach, Adaptive Music. | `src/pages/DemoPage.tsx` |
+| HelpPage | `/help` | 🟢 | Centre d'aide (FAQ + support) commun aux segments. | `src/pages/HelpPage.tsx` |
+| OnboardingPage | `/onboarding` | 🟡 | Pré-onboarding marketing avant création de compte. | `src/pages/OnboardingPage.tsx` |
+| LegalTermsPage & LegalPrivacyPage | `/legal/terms`, `/legal/privacy` | 🟢 | Pages légales RGPD/CGU décorrélées. | `src/pages/LegalTermsPage.tsx`, `src/pages/LegalPrivacyPage.tsx` |
 
 ## 🔐 Authentification & accès
 | Page | Route(s) | Statut | Description | Fichier principal |
 | --- | --- | --- | --- | --- |
-| UnifiedLoginPage | `/login` (+ alias historiques) | 🟢 | Formulaire multi-segments relié à Supabase Auth, incluant social login et récupération. Validée par le scénario e2e « auth.spec.ts » (connexion B2C 06/2025). | `src/pages/unified/UnifiedLoginPage.tsx` |
-| SignupPage | `/signup` | 🟢 | Inscription progressive avec validations et consentements explicites. | `src/pages/SignupPage.tsx` |
-| ChooseModePage | `/choose-mode` | 🟢 | Sélecteur de mode B2C/B2B utilisé pour router les nouveaux inscrits. | `src/pages/ChooseModePage.tsx` |
-| AppGatePage | `/app` | 🟢 | Dispatcher post-authentification qui redirige selon le rôle normalisé et l'état de consentement. | `src/pages/AppGatePage.tsx` |
-| Pages d'erreur 401/403/404 | `/401`, `/403`, `/404`, `*` | 🟢 | Garde-fous système avec messages contextualisés et CTA retour. | `src/pages/errors/401.tsx`, `src/pages/errors/403.tsx`, `src/pages/errors/404.tsx` |
+| UnifiedLoginPage | `/login` (+ aliases historiques) | 🟢 | Auth Supabase (B2C, B2B user/admin), reset password et social login. Couvert par `auth.spec.ts`. | `src/pages/unified/UnifiedLoginPage.tsx` |
+| SignupPage | `/signup` | 🟢 | Inscription progressive avec consentements explicites. | `src/pages/SignupPage.tsx` |
+| ChooseModePage | `/choose-mode` | 🟢 | Sélecteur de mode B2C/B2B avant création de compte. | `src/pages/ChooseModePage.tsx` |
+| AppGatePage | `/app` | 🟢 | Dispatcher post-authentification : route l'utilisateur selon rôle et consentement. | `src/pages/AppGatePage.tsx` |
+| Error pages | `/401`, `/403`, `/404`, `*` | 🟢 | Pages d'état homogènes (CTA retour, i18n) branchées dans RouterV2. | `src/pages/errors/401.tsx` etc. |
 
-## 🧭 Dashboards & navigation
+## 🧭 Dashboards & navigation authentifiée
 | Page | Route(s) | Statut | Description | Fichier principal |
 | --- | --- | --- | --- | --- |
-| HomePage (consumer) | `/app/home` (+ `/dashboard`) | 🟢 | Hub B2C affichant les tuiles modules et les raccourcis personnalisation. Couverture e2e « dashboard.spec.ts » confirmant les actions rapides et la navigation (06/2025). | `src/components/HomePage.tsx` |
-| B2BCollabDashboard | `/app/collab` | 🟡 | Dashboard collaborateurs avec indicateurs d'engagement et actions rapides. | `src/pages/B2BCollabDashboard.tsx` |
-| B2BRHDashboard | `/app/rh` | 🟡 | Vue manager présentant analytics d'équipe, en attente d'intégration finale Supabase. | `src/pages/B2BRHDashboard.tsx` |
-| B2BReports/B2BEvents/B2BOptimisation | `/app/reports`, `/app/events`, `/app/optimization` | 🟡 | Pivots analytiques côté manager : rapports consolidés, calendrier d'évènements et leviers d'optimisation. | `src/pages/B2BReportsPage.tsx` etc. |
-| ModulesShowcase & NavigationPage | `/modules`, `/navigation` | 🟠 | Explorations conservées pour présenter les composants et scénarios internes. | `src/pages/ModulesPage.tsx`, `src/pages/NavigationPage.tsx` |
+| HomePage (consumer) | `/app/home` (alias `/dashboard`) | 🟢 | Hub B2C avec tuiles modules, shortcuts personnalisation. e2e `dashboard.spec.ts`. | `src/components/HomePage.tsx` |
+| B2BCollabDashboard | `/app/collab` | 🟡 | Dashboard collaborateurs (pulses + recommandations). | `src/pages/B2BCollabDashboard.tsx` |
+| B2BRHDashboard | `/app/rh` | 🟡 | Vue manager RH : analytics équipes, suivi adoption. | `src/pages/B2BRHDashboard.tsx` |
+| B2B User Social Cocon | `/app/social` | 🟡 | Hub social B2B (programmes & activités). | `src/pages/B2BSocialCoconPage.tsx` |
+| B2B Reports suite | `/app/reports`, `/app/reports/:period`, `/app/events`, `/app/optimization`, `/app/security`, `/app/audit`, `/app/accessibility` | 🟡 | Suite manager (rapports anonymisés, calendrier RH, optimisations, posture sécurité/a11y). | `src/pages/B2BReportsPage.tsx`, `src/pages/B2BEventsPage.tsx`, etc. |
+| Teams Directory | `/app/teams` | 🟡 | Vue collaborateurs (B2B) avec jauges bien-être par équipe. | `src/pages/B2BTeamsPage.tsx` |
 
-## 🎯 Modules bien-être B2C
+## 🎯 Modules bien-être B2C (sessions & coaching)
 | Module | Route(s) | Statut | Description | Entrée |
 | --- | --- | --- | --- | --- |
-| Emotion Scan | `/app/scan` | 🟢 | Questionnaire I-PANAS-SF relié à la fonction `invokeEmotionScan`, historique Supabase et fallback local. Couvert par le scénario e2e « emotion-scan-dashboard.spec.ts » (scan → historique). | `src/modules/emotion-scan/EmotionScanPage.tsx` |
-| Mood Mixer | `/app/mood-mixer` | 🟢 | Création/édition de presets `mood_presets` avec pré-écoute Adaptive Music et sauvegarde Supabase. Scénario e2e « mood-mixer-crud.spec.ts » (CRUD complet) validé. | `src/pages/B2CMoodMixerPage.tsx` |
-| Flash Glow & Ultra | `/app/flash-glow`, `/app/flash-glow-ultra` | 🟢 | Séances guidées avec machine d'état, timers, calcul du delta d'humeur et insertion automatique dans le journal. Couverture e2e « flash-glow-ultra-session.spec.ts ». | `src/modules/flash-glow/useFlashGlowMachine.ts`, `src/modules/flash-glow-ultra/FlashGlowUltraPage.tsx` |
-| Breath Constellation | `/app/breath` | 🟢 | Protocoles respiratoires nommés, options audio/haptique, compatibilité reduced motion et logging Supabase. | `src/modules/breath-constellation/BreathConstellationPage.tsx` |
-| Journal | `/app/journal` | 🟢 | Composer texte/voix, recherche + tags, action coach, sanitisation DOMPurify, Dashboard sync. Tests e2e `journal-feed.spec.ts`. | `src/pages/journal/JournalView.tsx` |
-| Coach IA | `/app/coach` | 🟢 | Parcours consentement → prompt AI → réponses normalisées, logs anonymisés (`coach_conversations`). Couvert par « coach-ai-session.spec.ts ». | `src/pages/B2CAICoachPage.tsx`, `src/modules/coach/coachService.ts` |
-| Adaptive Music | `/app/music` | 🟢 | Recommandations mood→playlist, favoris, reprise audio via `moodPlaylist.service`. Scénario e2e « adaptive-music-favorites.spec.ts » validant favoris. | `src/modules/adaptive-music/AdaptiveMusicPage.tsx` |
-| Scores Dashboard | `/app/heatmap`, `/app/activity`, `/app/leaderboard` | 🟢 | Agrégats Supabase (tendances, heatmap, sessions) avec export PNG. | `src/pages/HeatmapPage.tsx`, `src/app/modules/scores/ScoresV2Panel.tsx` |
+| Emotion Scan | `/app/scan` | 🟢 | I-PANAS-SF complet, historique Supabase, fallback offline. e2e `emotion-scan-dashboard.spec.ts`. | `src/modules/emotion-scan/EmotionScanPage.tsx` |
+| Adaptive Music | `/app/music`, `/app/music-premium` | 🟢 | Recommandations mood→playlist, favoris persistés, premium Suno. e2e `adaptive-music-favorites.spec.ts`. | `src/modules/adaptive-music/AdaptiveMusicPage.tsx` |
+| Coach IA | `/app/coach`, `/app/coach-micro` | 🟢 | Conversation SSE, consentement explicite, hash Web Crypto, redaction Sentry. e2e `coach.smoke.spec.ts`. | `src/pages/B2CAICoachPage.tsx` |
+| Journal | `/app/journal`, `/journal/new` | 🟢 | Composer texte/voix, recherche/tags, envoi coach. e2e `journal-feed.spec.ts`. | `src/pages/journal/JournalView.tsx` |
+| Mood Mixer | `/app/mood-mixer` | 🟢 | Création de presets musicaux, sync Supabase. e2e `mood-mixer-crud.spec.ts`. | `src/pages/B2CMoodMixerPage.tsx` |
+| Flash Glow & Ultra | `/app/flash-glow`, `/app/flash-glow-ultra` | 🟢 | Machines d'état (Start/Pause/Resume), journalisation auto. e2e `flash-glow-ultra-session.spec.ts`. | `src/modules/flash-glow/useFlashGlowMachine.ts`, `src/modules/flash-glow-ultra/FlashGlowUltraPage.tsx` |
+| Breath Constellation | `/app/breath` | 🟢 | Protocoles respiration, audio/haptique optionnels, `useSessionClock`. Tests `breath-constellation-session.spec.ts`. | `src/modules/breath-constellation/BreathConstellationPage.tsx` |
+| Screen Silk Break | `/app/screen-silk` | 🟢 | Micro-pauses visuelles, timers adaptatifs. | `src/modules/screen-silk/ScreenSilkBreakPage.tsx` |
+| Boss Level Grit | `/app/boss-grit` | 🟠 | Challenge ludifié (prototype gamifié). | `src/pages/modules/BossLevelGritPage.tsx` |
+| Bounce Back Battle | `/app/bounce-back` | 🟠 | Mini-jeu résilience (prototype). | `src/pages/modules/BounceBackBattlePage.tsx` |
+| Story Synth Lab | `/app/story-synth` | 🟠 | Atelier narratif expérimental. | `src/pages/modules/StorySynthLabPage.tsx` |
+
+## 🪐 Immersion VR & AR
+| Expérience | Route(s) | Statut | Description | Entrée |
+| --- | --- | --- | --- | --- |
+| VR Hub | `/app/vr` | 🟢 | Sélecteur VR qui respecte le store sécurité (fallback 2D, doNotTrack). | `src/pages/B2CVRGalaxyPage.tsx` |
+| VR Galaxy | `/app/vr-galaxy` | 🟢 | Expérience cosmique adaptive, journalisation sessions `vr_galaxy`. | `src/pages/B2CVRGalaxyPage.tsx` |
+| VR Breath Guide | `/app/vr-breath-guide` | 🟢 | Parcours respiratoire guidé VR soft/2D selon tolérance SSQ. | `src/pages/B2CVRBreathGuidePage.tsx` |
+| VR Breath | `/app/vr-breath` | 🟢 | Module respiration immersive connecté aux métriques VR. | `src/pages/VRBreathPage.tsx` |
+| Face AR Filters | `/app/face-ar` | 🟠 | Démo filtres AR (prototype). | `src/pages/modules/FaceARFiltersPage.tsx` |
+
+## 🤝 Social & communauté
+| Module | Route(s) | Statut | Description | Entrée |
+| --- | --- | --- | --- | --- |
+| Community Feed | `/app/community`, `/app/communaute` | 🟢 | Mur bienveillant, auto-signalements Sentry, redirections Social Cocon. | `src/pages/B2CCommunautePage.tsx` |
+| Social Cocon (B2C) | `/app/social-cocon` | 🟢 | Espaces protégés guidés, animations douce et garde-fous. | `src/pages/B2CSocialCoconPage.tsx` |
+| Activity Timeline | `/app/activity` | 🟢 | Journal d'activité (sessions + scans) avec filtrage anonyme et timeline hebdo. | `src/pages/B2CActivitePage.tsx` |
+| Leaderboard | `/app/leaderboard` | 🟢 | Classement gamifié anonymisé (min_n). | `src/pages/LeaderboardPage.tsx` |
+| Scores / Heatmap | `/app/scores` (aliases `/app/heatmap`) | 🟢 | Heatmap vibes, agrégats anonymisés. e2e `scores-heatmap-dashboard.spec.ts`. | `src/pages/ScoresPage.tsx` |
+| Gamification Hub | `/gamification` | 🟠 | Portail ludification (expérience exploratoire). | `src/pages/modules/GamificationPage.tsx` |
 
 ## ⚙️ Paramètres, abonnement & légal
 | Page | Route(s) | Statut | Description | Fichier principal |
 | --- | --- | --- | --- | --- |
-| B2CSettings/B2CProfileSettings | `/settings/general`, `/settings/profile` | 🟢 | Préférences générales, profil et synchronisation avatar. | `src/pages/B2CSettingsPage.tsx`, `src/pages/B2CProfileSettingsPage.tsx` |
-| B2CPrivacyToggles | `/settings/privacy` | 🟢 | Gestion fine des consentements (tracking, newsletters, IA). | `src/pages/B2CPrivacyTogglesPage.tsx` |
-| B2CNotifications | `/settings/notifications` | 🟢 | Paramétrage granularité notifications email/push. | `src/pages/B2CNotificationsPage.tsx` |
-| SubscribePage | `/subscribe` (+ `/billing`) | 🟡 | Parcours d'abonnement et présentation des plans, paiements à brancher. | `src/pages/SubscribePage.tsx` |
+| Settings (général) | `/settings/general` | 🟢 | Préférences globales, opt-out IA. | `src/pages/B2CSettingsPage.tsx` |
+| Settings (profil) | `/settings/profile` | 🟢 | Profil, avatar, préférences langue. | `src/pages/B2CProfileSettingsPage.tsx` |
+| Settings (privacy) | `/settings/privacy` | 🟢 | Consentements tracking, download data. | `src/pages/B2CPrivacyTogglesPage.tsx` |
+| Settings (notifications) | `/settings/notifications` | 🟢 | Fréquence emails/push, do-not-disturb. | `src/pages/B2CNotificationsPage.tsx` |
+| SubscribePage | `/subscribe` (alias `/billing`) | 🟡 | Parcours abonnement (paiement en intégration). | `src/pages/SubscribePage.tsx` |
 
 ## 🛠️ Outils internes & développement
 | Page | Route(s) | Statut | Description | Fichier principal |
 | --- | --- | --- | --- | --- |
-| ValidationPage | `/validation` (dev only) | 🟠 | Boîte à outils QA pour valider les composants et états critiques. | `src/pages/ValidationPage.tsx` |
-| ComprehensiveSystemAuditPage | `/dev/system-audit` (dev only) | 🟠 | Audit système complet (routes, dépendances) destiné aux équipes techniques. | `src/pages/ComprehensiveSystemAuditPage.tsx` |
-| AdminFlagsPage | `/admin/flags` | 🟠 | Gestion expérimentale des feature flags côté admin. | `src/modules/admin/AdminFlagsPage.tsx` |
+| ValidationPage | `/validation` (dev only) | 🟠 | Boîte à outils QA (affichée uniquement en `NODE_ENV=development`). | `src/pages/ValidationPage.tsx` |
+| ComprehensiveSystemAudit | `/dev/system-audit` (dev only) | 🟠 | Audit routes/dépendances réservé aux devs. | `src/pages/ComprehensiveSystemAuditPage.tsx` |
+| AdminFlagsPage | `/admin/flags` | 🟠 | Gestion expérimentale des feature flags (protégée). | `src/modules/admin/AdminFlagsPage.tsx` |
 
-> _Ce document reflète la structure réelle du RouterV2 et les modules livrés. Utilisez `src/routerV2/registry.ts` pour retrouver la liste exhaustive des routes, y compris alias et redirections._
+> _Ce document reflète la structure actuelle de RouterV2 (`src/routerV2/registry.ts`). Utilisez `routes.ts` pour retrouver les helpers typés, y compris les alias et redirections legacy._

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -1,0 +1,67 @@
+# 🪴 Providers Racine
+
+Tous les providers React sont centralisés dans `src/providers/index.tsx` via le composant **`RootProvider`**.
+Ce guide résume l'empilement, les responsabilités et la marche à suivre pour ajouter/enlever un provider.
+
+## 🌳 Composition du RootProvider
+```
+<HelmetProvider>
+  <ErrorBoundary>
+    <QueryClientProvider>
+      <ErrorProvider>
+        <SimpleAuthProvider>
+          <AuthProvider>
+            <UserModeProvider>
+              <I18nBootstrap>
+                <ThemeProvider>
+                  <AccessibilityProvider>
+                    <NotificationProvider>
+                      <TooltipProvider>
+                        <UnifiedProvider>
+                          <MoodProvider>
+                            <MusicProvider>
+                              {children}
+                              <Toaster ... />
+```
+
+### Détails par bloc
+- **HelmetProvider** (`react-helmet-async`) : SEO côté client + meta dynamiques.
+- **ErrorBoundary** (`src/contexts/ErrorBoundary.tsx`) : catch global, fallback accessible.
+- **QueryClientProvider** : cache TanStack Query (staleTime 5 min, retry 1) – à utiliser pour toutes les requêtes HTTP.
+- **ErrorProvider** alias `useError` (`src/contexts/ErrorContext.tsx`) : expose `handleError`, `reportError` et l'alias re-exporté dans `src/contexts/index.ts`.
+- **SimpleAuthProvider** + **AuthProvider** : wrapper Supabase Auth (session, refresh) + compat legacy.
+- **UserModeProvider** : garde la distinction `consumer | employee | manager` (B2B/B2C switch).
+- **I18nBootstrap** : attend `i18n.isInitialized` avant de rendre quoi que ce soit → éviter les flashes de langue.
+- **ThemeProvider** (`src/providers/ThemeProvider.tsx`) : next-themes wrapper, stockage `localStorage` (`emotions-care-theme`).
+- **AccessibilityProvider** : gère focus ring, skip links, high-contrast (cf. `src/components/common/AccessibilityProvider.tsx`).
+- **NotificationProvider** + **Toaster** (Sonner) : notifications homogènes, toasts globaux.
+- **TooltipProvider** : delay & skip delay (200/100 ms).
+- **UnifiedProvider** (`src/core/UnifiedStateManager`) : connecte flags, health monitor, global interceptors.
+- **MoodProvider** / **MusicProvider** : contexte d'humeur (dashboard) + bus audio partagé.
+
+## 🧭 Règles d'initialisation
+1. **i18n avant render** : ne jamais consommer `useI18n` hors `I18nBootstrap`. Pour ajouter une nouvelle locale, mettre à jour `src/lib/i18n/index.ts`.
+2. **Providers UI** (Theme, Accessibility, Tooltip, Toaster) restent sous l'i18n pour bénéficier des traductions.
+3. **ErrorBoundary** doit rester tout en haut pour capturer les erreurs de providers descendants (sauf Helmet qui doit précéder pour SSR). `ErrorProvider` fournit l'API `useError` utilisée par les composants.
+4. **QueryClient** : si un provider a besoin de requêtes (ex : Feature Flags), le placer sous `QueryClientProvider`.
+
+## 🚦 Ajout / retrait d'un provider
+- Ajouter le provider dans `RootProvider` **et** documenter la dépendance dans ce fichier.
+- Vérifier les ordres suivants :
+  - Auth dépend de QueryClient (`useQuery`), donc doit être en-dessous.
+  - Providers UI (Theme, Tooltip, Toaster) n'ont pas besoin d'auth → garder proches de l'arbre UI.
+  - Tout provider qui lit la locale doit être après `I18nBootstrap`.
+- Penser à exposer l'API depuis `src/providers/index.tsx` ou un fichier dédié si nécessaire.
+- Mettre à jour les tests snapshot/renderer (`src/__tests__/AppProviders.test.tsx`) s'ils existent.
+
+## 🧯 ErrorBoundary global
+- `ErrorBoundary` enveloppe l'application et affiche une page accessible en cas de crash runtime.
+- Pour remonter une erreur contrôlée depuis un module, utiliser `const { reportError } = useError();` (alias exporté via `src/contexts/index.ts`).
+- Les erreurs envoyées à Sentry sont nettoyées par `src/lib/sentry-config.ts` (pas de PII).
+
+## 🔐 Feature flags & modes
+- `UserModeProvider` lit la session Supabase et expose `mode` (`consumer`, `employee`, `manager`).
+- `UnifiedProvider` charge `/me/feature_flags` et stocke les defaults (`src/core/flags.ts`).
+- Le RootProvider garantit que ces hooks sont disponibles dans toutes les pages (B2C/B2B) sans reconfigurer à la main.
+
+> _Modifier l'ordre des providers impacte l'onboarding (<15 min). Toute évolution doit être documentée ici et testée via `npm run lint` + QA rapide (auth, toasts, i18n)._ 

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -1,0 +1,58 @@
+# 🗺️ Routing – RouterV2
+
+La navigation de l'app s'appuie sur **RouterV2** (`src/routerV2`). Cette section détaille les sources d'autorité, les alias, les guards et la gestion B2C/B2B.
+
+## 📚 Source unique de vérité
+- `src/routerV2/registry.ts` contient la liste exhaustive des routes (`ROUTES_REGISTRY`).
+- Chaque entrée décrit : `name`, `path`, `segment` (`public`, `consumer`, `employee`, `manager`…), rôle, layout, composant chargé.
+- Les alias et redirections historiques sont attachés via `aliases` (ex. `/dashboard` → `/app/home`).
+
+### Helpers
+- `src/lib/routes.ts` expose des helpers typés (`routes.public.home()`, `routes.b2c.scan()`, etc.).
+- `src/routerV2/routes.ts` conserve la compatibilité avec l'ancien `Routes.xxx()` tout en déléguant à `lib/routes`.
+- Toujours importer ces helpers plutôt que des strings hardcodés → ESLint (`ec/no-legacy-routes-helpers`) l'impose.
+
+## 🔐 Guards & segments
+- Chaque route protégée définit `segment` & `role`. RouterV2 applique :
+  - **Auth guard** : vérifie la session via `AuthProvider`.
+  - **Role guard** : compare `UserModeProvider` (`consumer`, `employee`, `manager`).
+  - **Feature flags** : certains modules (VR, Community) vérifient `useFlags().has('FF_...')`.
+- Les pages `401`, `403`, `404`, `503` sont centralisées dans `src/pages/errors` et référencées dans la registry (même layout marketing).
+
+## 🔄 Alias & redirections
+- `src/routerV2/aliases.tsx` mappe les anciens chemins (`/emotions`, `/flash-glow`, `/social-cocon`, etc.) vers leurs équivalents RouterV2.
+- `LegacyRedirect` ajoute un breadcrumb Sentry (`route:alias`) et fusionne query/hash.
+- Toute nouvelle migration de route doit être déclarée dans `ROUTE_ALIASES` + `aliases` côté registry pour garder la trace.
+
+## 🔀 B2C / B2B switch
+- `UserModeProvider` sélectionne le mode selon `auth.user.user_metadata.role` (consumer, employee, manager).
+- RouterV2 lit ce mode pour diriger `/app` :
+  - consumer → `/app/home`
+  - employee → `/app/collab`
+  - manager → `/app/rh`
+- Les helpers `Routes.consumerHome()`, `Routes.managerHome()` encapsulent cette logique.
+
+## 🧭 Structure du router
+- `src/routerV2/router.tsx` instancie `createBrowserRouter` avec :
+  - Suspense/Lazy boundaries (lazy import des pages).
+  - `withErrorBoundary` (alias `ErrorContext`).
+  - `PerformanceGuard` (log Sentry, measure).
+- `RouterV2/index.tsx` connecte le router à React Router (`RouterProvider`).
+
+## 🧱 Layouts & providers
+- Layout marketing vs app sont définis dans la registry (`layout: 'marketing' | 'app' | 'simple'`).
+- `AppLayout` applique les providers UI (sidebar, topbar) selon le segment.
+- Les pages dev (`/validation`, `/dev/system-audit`) ne sont montées qu'en `import.meta.env.DEV` (voir registry).
+
+## 📄 Pages d'état uniformisées
+- `/401`, `/403`, `/404`, `/503` partagent la même charte (CTA retour, i18n, logs Sentry).
+- `*` (catch-all) est résolu vers `UnifiedErrorPage` – ne jamais créer un fallback custom hors registry.
+
+## ✅ Checklist lors de l'ajout d'une route
+1. Ajouter la route dans `ROUTES_REGISTRY` (avec alias éventuels, layout, guard, segment).
+2. Exporter le composant depuis `src/pages/index.ts` si besoin (lazy import auto).
+3. Mettre à jour `docs/PAGES_LISTING.md` + `docs/MODULES_LISTING.md`.
+4. Ajouter/adapter les tests (unitaires router + e2e Playwright si parcours critique).
+5. Vérifier `ROUTE_ALIASES` si migration.
+
+> _RouterV2 est la vérité absolue. Aucune route ne doit être définie directement dans les modules sans passer par la registry._

--- a/docs/SECURITY_PRIVACY.md
+++ b/docs/SECURITY_PRIVACY.md
@@ -1,0 +1,47 @@
+# 🔒 Sécurité & Privacy – Règles clés
+
+Ce référentiel regroupe les règles incontournables déjà implémentées dans le codebase. Toute nouvelle feature doit les respecter à la lettre.
+
+## 🚫 Interdiction des imports `node:*` côté client
+- ESLint (`eslint.config.js`) interdit `node:*` sur `src/**` (`no-restricted-imports`).
+- Utiliser les APIs Web :
+  - Hash → `src/lib/hash.ts` (Web Crypto `crypto.subtle`).
+  - Fichiers → `File`, `Blob`, `URL`.
+  - Streams → `ReadableStream`.
+- Exceptions : dossiers `services/**` & `supabase/functions/**` (server/edge uniquement).
+
+## 🔐 Hash & pseudonymisation
+- `src/lib/hash.ts` fournit `sha256(text)` basé uniquement sur Web Crypto.
+- Edge : `_shared/hash_user.ts` (Deno) applique le même algo → cohérence côté serveur.
+- Aucun UUID utilisateur brut n'est loggé ; toujours passer par `hash(user.id)`.
+
+## 🛡️ Sentry sans PII
+- `src/lib/sentry-config.ts` sanitize tout avant envoi :
+  - URLs tronquées (`sanitizeUrl`).
+  - Payloads JSON purgés (`sanitizeData`, `sensitiveKeyPattern`).
+  - `event.user` réduit à `{ id, ip_address }` si présent.
+  - Breadcrumbs limités à 50 items et `message` scrub.
+- Les modules sensibles (Coach, Journal, Community) ajoutent uniquement des longueurs/flags, jamais de texte brut.
+
+## 🗄️ RLS & accès données
+- Toutes les tables sensibles (`emotion_scans`, `sessions`, `journal_entries`, `clinical_feature_flags`, `org_assess_rollups`, etc.) sont sous **Row Level Security**.
+- Policies : owner-only pour les tables utilisateur, accès service-role restreint sur les Edge (clé `SUPABASE_SERVICE_ROLE_KEY`).
+- Scripts/Edge vérifient les variables d'environnement (`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`) avant d'exécuter.
+
+## 🤖 Robots & indexation
+- Les Edge Functions appliquent `X-Robots-Tag: noindex` via `applySecurityHeaders` (`supabase/functions/_shared/http.ts`).
+- Côté frontend, `PageSEO` accepte `noIndex` → toutes les pages `/app/` sensibles l'activent.
+- Les pages partage B2B (`/app/reports/:period?share=staff`) définissent `noindex` pour éviter toute indexation accidentelle.
+
+## 🙅 Respect du doNotTrack
+- `useClinicalConsent` (`src/hooks/useClinicalConsent.ts`) vérifie `navigator.doNotTrack`, `msDoNotTrack`, `window.doNotTrack`.
+- Si DNT est actif, les assessments & certains trackers (performance monitor) sont désactivés par défaut.
+
+## ✅ Checklist avant merge
+- [ ] Aucune dépendance `node:*` dans `src/**`.
+- [ ] Hash utilisateur via `sha256` (Web Crypto) pour tout log/ID client.
+- [ ] Nouveaux logs Sentry passent par `captureException`/`addBreadcrumb` sans PII.
+- [ ] Nouveaux endpoints Supabase : policies RLS + `noindex` si exposent des données.
+- [ ] DNT respecté pour toute nouvelle collecte (fallback opt-out explicite).
+
+> _Cette page complète `docs/PRIVACY.md`. En cas de doute, contacter legal/security avant de merger._

--- a/docs/SOCIAL_ROOMS.md
+++ b/docs/SOCIAL_ROOMS.md
@@ -1,0 +1,35 @@
+# 🏠 Social Rooms & Cocon
+
+Les espaces sociaux (B2C `/app/social-cocon`, B2B `/app/social`) offrent des lieux protégés. Voici les conventions UX/sécurité.
+
+## 🌈 Types d'espaces (B2C)
+| Type | Description | Règles |
+| --- | --- | --- |
+| `guided` | Animé par un hôte EmotionsCare (ex. « Cocon Sérénité »). | Modération en direct, messages pré-formatés, CTA ressources. |
+| `semi-private` | Groupe restreint auto-géré. | 25 personnes max, rotation hebdo des modérateurs. |
+| `private` | Cercle très fermé (amis, binômes). | Invitation obligatoire, historique effacé après 30 jours. |
+
+- Affichage : badges `Shield`, `Eye`, `Lock` (`lucide-react`) + compteur anonymisé (`XX membres`).
+- Animation d'entrée (framer-motion) doit respecter `prefers-reduced-motion`.
+- CTA principal « Rejoindre » → animation douce puis état `✓ Membre`.
+
+## 🏢 Social Cocon B2B
+- Page `src/pages/B2BSocialCoconPage.tsx` : vitrine programmes & activités.
+- Données utilisées : `teamActivities`, `wellnessPrograms`, `teamMetrics` (mock dev → à brancher sur Supabase).
+- Règles :
+  - Pas de données nominatives, uniquement équipes (`Dev`, `Marketing`, etc.).
+  - Tags (`wellness`, `workshop`, `challenge`) centralisés pour filtrage futur.
+  - Export CSV désactivé tant que min_n < 5.
+
+## 🔐 Privacy & analytics
+- `PageSEO` impose `noindex`.
+- Aucun historique individuel n'est exposé (seules agrégations anonymes).
+- Events Sentry : `social_cocon:join_space`, `social_cocon:guided_prompt`, `social_cocon:program_view` (pas de texte libre).
+
+## ✅ Checklist avant merge
+- [ ] Nouveau room → préciser type (`private`, `semi-private`, `guided`).
+- [ ] Pas de texte libre persisté côté client (sauf modération). Utiliser store sécurisé si besoin.
+- [ ] Boutons accessibles (`aria-label`, focus visible).
+- [ ] QA mobile : animation de join, toasts, fallback reduced motion.
+
+> _Coordonner toute évolution Social Rooms avec l'équipe Care + B2B pour valider la posture (ton, modération, analytics)._ 

--- a/docs/STATE_MANAGEMENT.md
+++ b/docs/STATE_MANAGEMENT.md
@@ -1,0 +1,107 @@
+# 🗄️ Gestion d'état – Conventions Zustand
+
+Objectif : un socle prévisible sans immer, compatible SSR et edge, tout en limitant les rerenders.
+Les stores existants (Glow, Breath, VR Safety, ScreenSilk, Flags, etc.) respectent les principes ci-dessous.
+
+## 1. Création des stores (sans immer)
+- Utiliser **Zustand vanilla** : `import { create } from 'zustand';`.
+- La fonction utilitaire `createImmutableStore` (`src/store/utils/createImmutableStore.ts`) fournit un `set` immuable :
+  - `set(partial)` fusionne via `Object.assign` (pas de mutation in-place).
+  - `set(fn)` reçoit l'état courant → retourner un partiel.
+- Exemple minimal :
+```ts
+import { create } from 'zustand';
+import { createImmutableStore } from '@/store/utils/createImmutableStore';
+
+type ExampleState = {
+  value: number;
+  increment: () => void;
+};
+
+const baseStore = create<ExampleState>()(
+  createImmutableStore((set) => ({
+    value: 0,
+    increment: () => set(state => ({ value: state.value + 1 })),
+  })),
+);
+```
+> 🚫 Pas d'immer, pas de `set(state => state.foo++)`.
+
+## 2. Sélecteurs & performances
+- Pour éviter les rerenders, exposer **des sélecteurs dédiés** via `createSelectors` (`src/store/utils/createSelectors.ts`).
+- Pattern :
+```ts
+const useGlowStoreBase = create<GlowState>()(createImmutableStore(...));
+export const useGlowStore = createSelectors(useGlowStoreBase);
+
+// Utilisation : composant = useGlowStore.use.phase();
+```
+- Avantages : les composants consomment un selector par clé (`useGlowStore.use.phase()`), ce qui garantit la comparaison par référence de Zustand.
+- Pour les sélecteurs composés, préférer `useStore(store, selector, shallow)` ou créer un hook dérivé (`useGlowProgress`).
+
+## 3. Persistance contrôlée
+- Utiliser `persist` exporté par `createImmutableStore` (wrapper maison) :
+```ts
+const useScreenSilkStore = create<ScreenSilkState>()(
+  persist((set, get) => ({ ... }), {
+    name: 'screen-silk-v1',
+    partialize: state => ({ completedSessions: state.completedSessions }),
+    version: 1,
+    migrate: (persisted, version) => ({ ...persisted }),
+  }),
+);
+```
+- Points de vigilance :
+  - **Aucune fonction** ne doit être sérialisée (la helper filtre automatiquement).
+  - Toujours versionner (`version`) et prévoir une migration simple.
+  - `storage` optionnel si besoin (`() => sessionStorage`).
+
+## 4. Pattern « selector lecture + mutation explicite »
+- Lecture : `const phase = useGlowStore.use.phase();` (read-only, pas d'actions attachées).
+- Mutation : récupérer les actions directement via `useGlowStore(state => state.actions.someAction)` **ou** exposer un hook métier.
+- Exemple complet (`src/store/glow.store.ts`) :
+```ts
+const useGlowStoreBase = create<GlowStore>()(
+  createImmutableStore((set, get) => ({
+    phase: 'idle',
+    actions: {
+      start() {
+        set({ phase: 'warmup', startedAt: Date.now() });
+      },
+      complete() {
+        const { startedAt } = get();
+        set({ phase: 'complete', durationMs: Date.now() - (startedAt ?? Date.now()) });
+      },
+    },
+  })),
+);
+
+export const useGlowStore = createSelectors(useGlowStoreBase);
+
+// Dans un composant :
+const phase = useGlowStore.use.phase();
+const startGlow = useGlowStore(state => state.actions.start);
+```
+- Ce découplage rend les composants faciles à tester et limite les rerenders à la clé ciblée.
+
+## 5. Souscriptions sans rerender
+- Pour side-effects (analytics, timers), utiliser `store.subscribe(selector, listener, options)` directement sur la base :
+```ts
+useEffect(() => {
+  const unsub = useGlowStoreBase.subscribe(
+    state => state.phase,
+    phase => phase === 'complete' && sendMetric(),
+  );
+  return () => unsub();
+}, []);
+```
+- `subscribeWithSelector` n'est pas nécessaire : Zustand natif suffit avec nos helpers.
+
+## 6. Tests & lint
+- Chaque store doit avoir des tests unitaires ciblant :
+  - transitions critiques (actions start/stop/reset),
+  - hydratation persist (si `persist` activé),
+  - selectors dérivés.
+- Le lint interdit `node:*` côté client → toute logique cryptographique doit passer par `src/lib/hash.ts` ou Edge.
+
+> _Réutilisez ce guide lors de la création de nouveaux stores (ex. nouveaux modules, flags). Gardez les actions pures, pas d'effets side dans les setters, et mettez à jour ce doc si un nouveau helper est introduit._

--- a/docs/UI_COMPONENTS_REGISTRY.md
+++ b/docs/UI_COMPONENTS_REGISTRY.md
@@ -1,34 +1,49 @@
 # Registre des composants UI
 
-> 📌 Généré automatiquement le 17 septembre 2025 à 20:41 à partir de `src/COMPONENTS.reg.ts`. Utilisez `npm run generate:ui-registry` pour rafraîchir cette liste.
+> 📌 Généré automatiquement le 20 septembre 2025 à 16:45 à partir de `src/COMPONENTS.reg.ts`. Utilisez `npm run generate:ui-registry` pour rafraîchir cette liste.
 
 
 ## Statistiques rapides
 
-- **42** entrées référencées
+- **65** entrées référencées
 - Animation : 2
 - Audio : 1
-- Composant UI : 14
+- Composant UI : 32
 - Consentement : 2
 - Feature flags : 5
 - Hook : 10
 - Internationalisation : 3
+- Provider : 4
 - SEO : 1
 - Thème : 3
-- Visualisation : 1
+- Visualisation : 2
 
 ## Détails des exports
 
 | Export | Type | Source |
 | --- | --- | --- |
+| AccessibilityProvider | Provider | `src/components/common/AccessibilityProvider` |
 | AudioPlayer | Audio | `src/ui/AudioPlayer` |
+| Avatar | Composant UI | `src/components/ui/avatar.tsx` |
+| AvatarFallback | Composant UI | `src/components/ui/avatar.tsx` |
+| AvatarImage | Composant UI | `src/components/ui/avatar.tsx` |
+| Badge | Composant UI | `src/components/ui/badge.tsx` |
 | BadgeLevel | Composant UI | `src/ui/BadgeLevel` |
 | Button | Composant UI | `src/components/ui/button.tsx` |
 | Card | Composant UI | `src/components/ui/card.tsx` |
+| CardContent | Composant UI | `src/components/ui/card.tsx` |
+| CardDescription | Composant UI | `src/components/ui/card.tsx` |
+| CardHeader | Composant UI | `src/components/ui/card.tsx` |
+| CardTitle | Composant UI | `src/components/ui/card.tsx` |
 | clearOverride | Feature flags | `src/lib/flags/rollout` |
 | CommandPalette | Composant UI | `src/ui/CommandPalette` |
 | ConstellationCanvas | Composant UI | `src/ui/ConstellationCanvas` |
 | CookieConsent | Consentement | `src/ui/CookieConsent` |
+| Dialog | Composant UI | `src/components/ui/dialog.tsx` |
+| DialogContent | Composant UI | `src/components/ui/dialog.tsx` |
+| DialogHeader | Composant UI | `src/components/ui/dialog.tsx` |
+| DialogTitle | Composant UI | `src/components/ui/dialog.tsx` |
+| DialogTrigger | Composant UI | `src/components/ui/dialog.tsx` |
 | FadeIn | Animation | `src/ui/motion/FadeIn` |
 | FeedbackForm | Composant UI | `src/ui/FeedbackForm` |
 | flagActive | Feature flags | `src/lib/flags/rollout` |
@@ -39,18 +54,27 @@
 | I18nProvider | Internationalisation | `src/lib/i18n/i18n` |
 | inCohort | Feature flags | `src/lib/flags/rollout` |
 | Input | Composant UI | `src/components/ui/input.tsx` |
+| Label | Composant UI | `src/components/ui/label.tsx` |
 | LoadingSpinner | Composant UI | `src/components/ui/LoadingSpinner.tsx` |
 | NavBar | Composant UI | `src/ui/NavBar` |
+| NotificationProvider | Provider | `src/components/ui/notification-system` |
 | PageHeader | Composant UI | `src/components/ui/PageHeader.tsx` |
+| Progress | Visualisation | `src/components/ui/progress.tsx` |
 | ProgressBar | Visualisation | `src/ui/ProgressBar` |
 | SeoHead | SEO | `src/lib/seo/SeoHead` |
 | setOverride | Feature flags | `src/lib/flags/rollout` |
 | SlideIn | Animation | `src/ui/motion/SlideIn` |
 | Sparkline | Composant UI | `src/ui/Sparkline` |
 | t | Internationalisation | `src/lib/i18n/i18n` |
+| Tabs | Composant UI | `src/components/ui/tabs.tsx` |
+| TabsContent | Composant UI | `src/components/ui/tabs.tsx` |
+| TabsList | Composant UI | `src/components/ui/tabs.tsx` |
+| TabsTrigger | Composant UI | `src/components/ui/tabs.tsx` |
 | Textarea | Composant UI | `src/components/ui/textarea.tsx` |
 | ThemeProvider | Thème | `src/theme/ThemeProvider` |
+| ThemeProvider | Provider | `src/providers/ThemeProvider` |
 | ThemeToggle | Thème | `src/theme/ThemeProvider` |
+| TooltipProvider | Provider | `src/components/ui/tooltip` |
 | useAudioBus | Hook | `src/ui/hooks/useAudioBus` |
 | useCommandPalette | Hook | `src/ui/CommandPalette` |
 | useCrossfade | Hook | `src/ui/hooks/useCrossfade` |

--- a/docs/VR_SAFETY.md
+++ b/docs/VR_SAFETY.md
@@ -1,0 +1,36 @@
+# 🥽 VR Safety Guidelines
+
+Ce document recense les garde-fous VR déjà implémentés et la checklist à respecter pour toute évolution VR (`/app/vr*`).
+
+## 🧱 Socle technique
+- Store : `src/store/vrSafety.store.ts`
+  - Persistance locale (`persist`), stockage des préférences (mode 2D/VR_soft/VR), SSQ & POMS récents.
+  - Sélecteurs `useVRSafetyStore.use.*` pour lecture (particleMode, lowPerformance, etc.).
+- Hooks :
+  - `useVRPerformanceGuard` → détecte `prefers-reduced-motion`, FPS faibles, GPU non supporté.
+  - `useClinicalConsent` (`FF_ASSESS_SSQ`) → déclenche SSQ (Simulator Sickness Questionnaire) lorsque nécessaire.
+- Composants :
+  - `VRSafetyCheck` (questionnaire rapide avant session, CTA fallback 2D).
+  - `VRModeControls` (switch VR ↔ 2D).
+
+## 🧠 Règles UX & produit
+1. **Opt-in systématique** : si l'utilisateur n'a jamais validé la safety checklist, afficher `VRSafetyCheck` avant d'activer le mode immersif.
+2. **Fallback 2D** : toujours proposer un mode 2D accessible (`modePreference = '2d'`). Ne jamais forcer le mode VR.
+3. **Temps max** : `useVRSafetyStore` limite la durée (`maxSessionDuration`) en fonction des réponses POMS/SSQ (ex. `tense` → 180 s max).
+4. **Motion** : respecter `prefers-reduced-motion` → bascule automatique `vr_soft` ou 2D (aucune animation agressive).
+5. **doNotTrack** : si DNT actif, ne pas enregistrer de métriques immersives.
+6. **Analytics** : breadcrumbs Sentry `vr:enter` / `vr:exit`, tags `motion_safe`, `ssq_hint_used`.
+
+## 🔐 Sécurité & données
+- Sessions persistées via `createSession({ type: 'vr_galaxy' | 'vr_breath' })`.
+- `meta` des sessions contient uniquement : mode (`2D`, `VR_soft`, `VR`), summary texte (poétique), hints SSQ/POMS.
+- Aucun flux vidéo/audio n'est enregistré.
+
+## ✅ Checklist avant merge
+- [ ] Feature flag `FF_VR` vérifié avant d'afficher le module.
+- [ ] `VRSafetyCheck` affiché pour toute nouvelle entrée immersive.
+- [ ] Fallback 2D opérationnel (testé avec `prefers-reduced-motion` + `force lowPerformance`).
+- [ ] Durées/clocks respectent `maxSessionDuration`.
+- [ ] Breadcrumbs Sentry (`vr:*`) visibles en QA.
+
+> _Mettre à jour ce guide si un nouveau module VR (ex: mini-jeux) est ajouté ou si la politique SSQ change._

--- a/src/COMPONENTS.reg.ts
+++ b/src/COMPONENTS.reg.ts
@@ -1,33 +1,64 @@
-export { default as PageHeader } from "./components/ui/PageHeader.tsx";
-export { LoadingSpinner } from "./components/ui/LoadingSpinner.tsx";
-export { Button } from "./components/ui/button.tsx";
-export { Card } from "./components/ui/card.tsx";
-export { useDebounce } from "@/ui/hooks/useDebounce";
-export { useThrottle } from "@/ui/hooks/useThrottle";
-export { CookieConsent, hasConsent } from "@/ui/CookieConsent";
-export { ThemeProvider, useTheme } from "@/theme/ThemeProvider";
-export { ThemeToggle } from "@/theme/ThemeProvider";
-export { FadeIn } from "@/ui/motion/FadeIn";
-export { SlideIn } from "@/ui/motion/SlideIn";
-export { I18nProvider, useI18n, t } from "@/lib/i18n/i18n";
-export { SeoHead } from "@/lib/seo/SeoHead";
-export { ProgressBar } from "@/ui/ProgressBar";
-export { Sparkline } from "@/ui/Sparkline";
-export { BadgeLevel } from "@/ui/BadgeLevel";
-export { useSound } from "@/ui/hooks/useSound";
-export { useAudioBus } from "@/ui/hooks/useAudioBus";
-export { useCrossfade } from "@/ui/hooks/useCrossfade";
-export { AudioPlayer } from "@/ui/AudioPlayer";
-export { NavBar } from "@/ui/NavBar";
-export { Footer } from "@/ui/Footer";
-export { CommandPalette, useCommandPalette } from "@/ui/CommandPalette";
-export { usePrefetchOnHover } from "@/hooks/usePrefetchOnHover";
-export { Input } from "./components/ui/input.tsx";
-export { Textarea } from "./components/ui/textarea.tsx";
-export { FeedbackForm } from "@/ui/FeedbackForm";
-export { GlowSurface } from "@/ui/GlowSurface";
-export { usePulseClock } from "@/ui/hooks/usePulseClock";
-export { useTimer } from "@/ui/hooks/useTimer";
-export { flagActive, inCohort, setOverride, clearOverride, getOverrides } from "@/lib/flags/rollout";
-export { useRaf } from "@/ui/hooks/useRaf";
-export { ConstellationCanvas } from "@/ui/ConstellationCanvas";
+// ============================================================================
+//  EmotionsCare – UI Component Registry (UI pur uniquement)
+//  Utilisez `npm run generate:ui-registry` après toute modification.
+// ============================================================================
+
+// --- Layout & marketing -----------------------------------------------------
+export { default as PageHeader } from './components/ui/PageHeader.tsx';
+export { LoadingSpinner } from './components/ui/LoadingSpinner.tsx';
+export { NavBar } from '@/ui/NavBar';
+export { Footer } from '@/ui/Footer';
+export { GlowSurface } from '@/ui/GlowSurface';
+export { CookieConsent, hasConsent } from '@/ui/CookieConsent';
+export { SeoHead } from '@/lib/seo/SeoHead';
+
+// --- shadcn / UI primitives -------------------------------------------------
+export { Button } from './components/ui/button.tsx';
+export { Card, CardContent, CardHeader, CardTitle, CardDescription } from './components/ui/card.tsx';
+export { Input } from './components/ui/input.tsx';
+export { Textarea } from './components/ui/textarea.tsx';
+export { Label } from './components/ui/label.tsx';
+export { Tabs, TabsContent, TabsList, TabsTrigger } from './components/ui/tabs.tsx';
+export { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from './components/ui/dialog.tsx';
+export { Badge } from './components/ui/badge.tsx';
+export { Avatar, AvatarImage, AvatarFallback } from './components/ui/avatar.tsx';
+export { Progress } from './components/ui/progress.tsx';
+
+// --- Animation & motion -----------------------------------------------------
+export { FadeIn } from '@/ui/motion/FadeIn';
+export { SlideIn } from '@/ui/motion/SlideIn';
+
+// --- Thème & i18n -----------------------------------------------------------
+export { ThemeProvider, useTheme, ThemeToggle } from '@/theme/ThemeProvider';
+export { I18nProvider, useI18n, t } from '@/lib/i18n/i18n';
+
+// --- Hooks UI ---------------------------------------------------------------
+export { usePrefetchOnHover } from '@/hooks/usePrefetchOnHover';
+export { usePulseClock } from '@/ui/hooks/usePulseClock';
+export { useTimer } from '@/ui/hooks/useTimer';
+export { useSound } from '@/ui/hooks/useSound';
+export { useAudioBus } from '@/ui/hooks/useAudioBus';
+export { useCrossfade } from '@/ui/hooks/useCrossfade';
+export { useRaf } from '@/ui/hooks/useRaf';
+export { useDebounce } from '@/ui/hooks/useDebounce';
+export { useThrottle } from '@/ui/hooks/useThrottle';
+
+// --- Components data viz & feedback ----------------------------------------
+export { ProgressBar } from '@/ui/ProgressBar';
+export { Sparkline } from '@/ui/Sparkline';
+export { BadgeLevel } from '@/ui/BadgeLevel';
+export { AudioPlayer } from '@/ui/AudioPlayer';
+export { FeedbackForm } from '@/ui/FeedbackForm';
+export { ConstellationCanvas } from '@/ui/ConstellationCanvas';
+export { CommandPalette, useCommandPalette } from '@/ui/CommandPalette';
+
+// --- Notifications & overlays ----------------------------------------------
+export { NotificationProvider } from '@/components/ui/notification-system';
+export { TooltipProvider } from '@/components/ui/tooltip';
+
+// --- Feature flags ---------------------------------------------------------
+export { flagActive, inCohort, setOverride, clearOverride, getOverrides } from '@/lib/flags/rollout';
+
+// --- Providers additionnels -------------------------------------------------
+export { AccessibilityProvider } from '@/components/common/AccessibilityProvider';
+export { ThemeProvider as LegacyThemeProvider } from '@/providers/ThemeProvider';

--- a/src/services/b2b/reportsApi.ts
+++ b/src/services/b2b/reportsApi.ts
@@ -135,6 +135,7 @@ async function fetchHeatmap(params: GetHeatmapParams): Promise<HeatmapCell[]> {
 
 export async function getAggregateSummaries(params: GetHeatmapParams): Promise<AggregateSummary[]> {
   return fetchAggregateSummaries(params);
+}
 interface HeatmapMatrixParams extends UseHeatmapParams {
   periods: string[];
 }


### PR DESCRIPTION
## Summary
- refresh .env.example with annotated Supabase, observability, notification and QA sections for a 15‑minute setup
- update page and module cartography plus add guides covering state management, providers, routing, assessments, security/privacy, VR and social rooms
- tidy the UI registry (COMPONENTS.reg.ts + generated catalog) and document contribution process updates for exports, terminology and pre-merge QA

## Testing
- npm run generate:ui-registry
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cebbcc3b1c832d9161ea1cac8d575d