### PR TITLE
SEC-02 tighten headers, Sentry scrubbing, and lint guard

### DIFF
--- a/_headers
+++ b/_headers
@@ -18,6 +18,10 @@
 
 /app/*
   X-Robots-Tag: noindex
+  Referrer-Policy: strict-origin-when-cross-origin
+  X-Content-Type-Options: nosniff
+  Cross-Origin-Resource-Policy: same-site
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob:; font-src 'self' https://rsms.me https://fonts.gstatic.com data:; style-src 'self' 'unsafe-inline' https://rsms.me https://fonts.googleapis.com; script-src 'self' https://cdn.gpteng.co; connect-src 'self' https://*.supabase.co https://*.supabase.in https://api.emotionscare.com https://api.openai.com https://cdn.gpteng.co https://api.hume.ai https://*.sentry.io https://*.ingest.sentry.io wss://*.supabase.co wss://*.supabase.in; media-src 'self' blob: https://*.supabase.co https://storage.googleapis.com; frame-src 'self'; worker-src 'self' blob:; manifest-src 'self'; object-src 'none'
 
 # Assets avec cache long terme
 /assets/*

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <meta name="description" content="Plateforme de bien-être émotionnel en entreprise" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' https://cdn.gpteng.co; style-src 'self' 'unsafe-inline' https://rsms.me https://fonts.googleapis.com; font-src 'self' https://rsms.me https://fonts.gstatic.com data:; img-src 'self' data: blob: https://images.unsplash.com https://cdn.gpteng.co https://rsms.me; connect-src 'self' https://*.supabase.co https://*.supabase.in https://api.openai.com https://cdn.gpteng.co https://api.hume.ai https://api.emotionscare.com wss://*.supabase.co wss://*.supabase.in; media-src 'self' https://*.supabase.co https://storage.googleapis.com data: blob:; frame-ancestors 'self'; form-action 'self'; base-uri 'self'; object-src 'none'; worker-src 'self' blob:; manifest-src 'self'; frame-src 'self'"
+      content="default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob:; font-src 'self' https://rsms.me https://fonts.gstatic.com data:; style-src 'self' 'unsafe-inline' https://rsms.me https://fonts.googleapis.com; script-src 'self' https://cdn.gpteng.co; connect-src 'self' https://*.supabase.co https://*.supabase.in https://api.emotionscare.com https://api.openai.com https://cdn.gpteng.co https://api.hume.ai https://*.sentry.io https://*.ingest.sentry.io wss://*.supabase.co wss://*.supabase.in; media-src 'self' blob: https://*.supabase.co https://storage.googleapis.com; frame-src 'self'; worker-src 'self' blob:; manifest-src 'self'; object-src 'none'"
     />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
 

--- a/src/__tests__/lint-node-imports.test.ts
+++ b/src/__tests__/lint-node-imports.test.ts
@@ -1,0 +1,29 @@
+import { ESLint } from 'eslint';
+import { afterAll, describe, expect, it } from 'vitest';
+
+const projectRoot = process.cwd();
+
+const eslint = new ESLint({
+  overrideConfigFile: `${projectRoot}/eslint.config.js`,
+  cwd: projectRoot,
+});
+
+afterAll(async () => {
+  if (typeof eslint.close === 'function') {
+    await eslint.close();
+  }
+});
+
+describe('client bundle import restrictions', () => {
+  it('flags node: protocol imports within the src tree', async () => {
+    const sample = "import fs from 'node:fs';\nexport const touch = () => fs.promises;\n";
+    const [result] = await eslint.lintText(sample, {
+      filePath: `${projectRoot}/src/components/fixtures/node-import.ts`,
+      warnIgnored: false,
+    });
+
+    expect(result.errorCount).toBeGreaterThan(0);
+    const messages = result.messages.map(message => message.message);
+    expect(messages.some(message => message.includes('Interdit dans le bundle client'))).toBe(true);
+  });
+});

--- a/src/lib/__tests__/sentry-config.test.ts
+++ b/src/lib/__tests__/sentry-config.test.ts
@@ -1,0 +1,194 @@
+import type { Event as SentryEvent } from '@sentry/types';
+import { describe, expect, it, vi } from 'vitest';
+
+const setNavigatorDnt = (value?: string) => {
+  Object.defineProperty(window.navigator, 'doNotTrack', {
+    configurable: true,
+    get: () => value,
+  });
+};
+
+const mockSentry = (overrides: Partial<Record<string, unknown>> = {}) => {
+  const scope = {
+    setTag: vi.fn(),
+    setContext: vi.fn(),
+    setExtra: vi.fn(),
+    getTransaction: vi.fn(),
+  };
+
+  const hubScope = {
+    getTransaction: vi.fn(),
+    setExtra: vi.fn(),
+    setTag: vi.fn(),
+  };
+
+  const init = vi.fn();
+  const configureScope = vi.fn((callback: (scope: typeof scope) => void) => {
+    callback(scope);
+  });
+  const addGlobalEventProcessor = vi.fn();
+  const withScope = vi.fn((callback: (scope: typeof scope) => void) => {
+    callback(scope);
+  });
+
+  vi.doMock('@sentry/react', () => ({
+    init,
+    configureScope,
+    addGlobalEventProcessor,
+    withScope,
+    getCurrentHub: () => ({
+      getClient: () => ({}),
+      getScope: () => hubScope,
+    }),
+    BrowserTracing: class {},
+    Replay: class {},
+  }));
+
+  vi.doMock('@/lib/env', () => ({
+    BUILD_INFO: { version: '1.0.0', commitSha: 'commit', release: 'rel' },
+    SENTRY_CONFIG: {
+      dsn: 'https://example.ingest.sentry.io/123',
+      environment: 'production',
+      tracesSampleRate: 0.5,
+      replaysSessionSampleRate: 0.25,
+      replaysOnErrorSampleRate: 0.5,
+      ...overrides,
+    },
+  }));
+
+  return { init, configureScope, addGlobalEventProcessor, withScope, scope, hubScope };
+};
+
+describe('sentry-config privacy guardrails', () => {
+  it('scrubs personally identifiable data before sending events', async () => {
+    vi.resetModules();
+    const mocks = mockSentry();
+    const { SENTRY_PRIVACY_GUARDS } = await import('@/lib/sentry-config');
+
+    const event = {
+      event_id: 'abc123',
+      type: 'error',
+      request: {
+        url: 'https://app.emotionscare.com/app/profile?token=secret-token&email=user@example.com',
+        headers: {
+          authorization: 'Bearer super-secret-token',
+          referer: 'https://app.emotionscare.com/app/dashboard?tab=focus',
+          'user-agent': 'Mozilla/5.0 (Macintosh)',
+          'accept-language': 'fr-FR,fr;q=0.9',
+        },
+        data: {
+          email: 'user@example.com',
+          supabase_service_role_key: 'should-never-leak',
+        },
+      },
+      user: {
+        id: 'user-123',
+        email: 'user@example.com',
+      },
+      breadcrumbs: [
+        {
+          category: 'http',
+          data: {
+            url: 'https://api.emotionscare.com/private?token=12345',
+            request_body: new URLSearchParams('token=12345&session=abcd'),
+          },
+          message: 'fetch private data with token=12345',
+        },
+        {
+          category: 'console',
+          message: 'interface ready',
+        },
+      ],
+      extra: {
+        raw: 'user@example.com sent a message',
+        nested: {
+          supabase_service_role_key: 'super-secret',
+          comments: ['First entry with token abc123', 'Another with email admin@example.com'],
+        },
+        params: new URLSearchParams('token=secret&safe=value'),
+      },
+      contexts: {
+        session: {
+          token: 'jwt-token',
+          phone: '+33123456789',
+        },
+      },
+      tags: {
+        release: 'test-build',
+      },
+    } as unknown as SentryEvent;
+
+    const sanitized = SENTRY_PRIVACY_GUARDS.sanitizeEvent(structuredClone(event));
+    expect(sanitized).not.toBeNull();
+    const sanitizedEvent = sanitized as SentryEvent;
+
+    expect(sanitizedEvent.user).toBeUndefined();
+    expect(sanitizedEvent.request?.url).toBe('https://app.emotionscare.com/app/profile');
+    expect(sanitizedEvent.request?.headers).toEqual({
+      referer: 'https://app.emotionscare.com/app/dashboard?tab=focus',
+      'user-agent': 'Mozilla/5.0 (Macintosh)',
+      'accept-language': 'fr-FR,fr;q=0.9',
+    });
+    expect(sanitizedEvent.request?.data).toBe('[scrubbed]');
+
+    expect(sanitizedEvent.breadcrumbs).toHaveLength(1);
+    expect(sanitizedEvent.breadcrumbs?.[0]?.category).toBe('console');
+
+    const extra = sanitizedEvent.extra as Record<string, unknown> | undefined;
+    expect(extra).toBeDefined();
+    expect(extra?.raw).toBe('[scrubbed]');
+    expect(extra?.nested).toEqual({
+      supabase_service_role_key: '[redacted]',
+      comments: '[scrubbed]',
+    });
+    expect(extra?.params).toEqual({});
+
+    const contexts = sanitizedEvent.contexts as Record<string, unknown> | undefined;
+    expect(contexts?.session).toEqual({
+      token: '[redacted]',
+      phone: '[redacted]',
+    });
+
+    expect(sanitizedEvent.tags).toMatchObject({
+      release: 'test-build',
+      pii_scrubbed: 'true',
+      dnt: 'false',
+      telemetry_disabled: 'false',
+    });
+
+    // ensure original event was not mutated
+    expect(event.request?.headers?.authorization).toBe('Bearer super-secret-token');
+    expect(event.extra?.params instanceof URLSearchParams).toBe(true);
+
+    // ensure mocks not triggered by sanitize-only test
+    expect(mocks.init).not.toHaveBeenCalled();
+  });
+
+  it('disables telemetry and tags scope when doNotTrack is enabled', async () => {
+    vi.resetModules();
+    const mocks = mockSentry();
+    const { initializeSentry } = await import('@/lib/sentry-config');
+
+    setNavigatorDnt('1');
+    initializeSentry();
+
+    expect(mocks.init).toHaveBeenCalledTimes(1);
+    const config = mocks.init.mock.calls[0][0];
+    expect(config.tracesSampleRate).toBe(0);
+    expect(config.replaysSessionSampleRate).toBe(0);
+    expect(config.replaysOnErrorSampleRate).toBe(0);
+    expect(config.autoSessionTracking).toBe(false);
+    expect(config.sendDefaultPii).toBe(false);
+    expect(config.enableTracing).toBe(false);
+
+    expect(mocks.scope.setTag).toHaveBeenCalledWith('dnt', 'true');
+    expect(mocks.scope.setTag).toHaveBeenCalledWith('telemetry_disabled', 'true');
+
+    expect(document.documentElement.getAttribute('data-dnt')).toBe('true');
+    expect((window as Record<string, unknown>).__EMOTIONSCARE_DNT__).toBe(true);
+
+    // reset DNT flag for other tests
+    setNavigatorDnt(undefined);
+    delete (window as Record<string, unknown>).__EMOTIONSCARE_DNT__;
+  });
+});

--- a/src/lib/security/headers.ts
+++ b/src/lib/security/headers.ts
@@ -3,6 +3,23 @@
  * Security headers management
  */
 
+export const APP_BASE_CSP = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+  "img-src 'self' data: blob:",
+  "font-src 'self' https://rsms.me https://fonts.gstatic.com data:",
+  "style-src 'self' 'unsafe-inline' https://rsms.me https://fonts.googleapis.com",
+  "script-src 'self' https://cdn.gpteng.co",
+  "connect-src 'self' https://*.supabase.co https://*.supabase.in https://api.emotionscare.com https://api.openai.com https://cdn.gpteng.co https://api.hume.ai https://*.sentry.io https://*.ingest.sentry.io wss://*.supabase.co wss://*.supabase.in",
+  "media-src 'self' blob: https://*.supabase.co https://storage.googleapis.com",
+  "frame-src 'self'",
+  "worker-src 'self' blob:",
+  "manifest-src 'self'",
+  "object-src 'none'",
+].join('; ');
+
 export const SECURITY_HEADERS = {
   'X-Content-Type-Options': 'nosniff',
   'X-Frame-Options': 'DENY',
@@ -17,7 +34,8 @@ export const SECURITY_HEADERS = {
   'Cross-Origin-Embedder-Policy': 'credentialless',
   'Cross-Origin-Opener-Policy': 'same-origin',
   'Cross-Origin-Resource-Policy': 'same-site',
-  'X-Robots-Tag': 'noindex'
+  'X-Robots-Tag': 'noindex',
+  'Content-Security-Policy': APP_BASE_CSP,
 };
 
 /**
@@ -52,11 +70,14 @@ export const applySecurityMeta = (): void => {
   if (typeof document === 'undefined') return;
 
   // Remove existing security meta tags
-  const existingMetas = document.querySelectorAll('meta[name^="security-"], meta[http-equiv^="X-"]');
+  const existingMetas = document.querySelectorAll(
+    'meta[name^="security-"], meta[http-equiv^="X-"], meta[http-equiv="Content-Security-Policy"]',
+  );
   existingMetas.forEach(meta => meta.remove());
 
   // Add security meta tags
   const metas = [
+    { httpEquiv: 'Content-Security-Policy', content: APP_BASE_CSP },
     { httpEquiv: 'X-Content-Type-Options', content: 'nosniff' },
     { httpEquiv: 'X-Frame-Options', content: 'DENY' },
     { httpEquiv: 'X-XSS-Protection', content: '1; mode=block' },

--- a/src/lib/security/productionSecurity.ts
+++ b/src/lib/security/productionSecurity.ts
@@ -1,4 +1,6 @@
 
+import { APP_BASE_CSP } from './headers';
+
 /**
  * Sécurité renforcée pour la production
  */
@@ -45,22 +47,20 @@ const disableDevTools = (): void => {
 };
 
 const applySecurityHeaders = (): void => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
   // Content Security Policy
-  const cspMeta = document.createElement('meta');
-  cspMeta.httpEquiv = 'Content-Security-Policy';
-  cspMeta.content = [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline' https://cdn.gpteng.co",
-    "style-src 'self' 'unsafe-inline' https://rsms.me",
-    "font-src 'self' https://rsms.me",
-    "img-src 'self' data: https: blob:",
-    "connect-src 'self' https://yaincoxihiqdksxgrsrk.supabase.co wss://yaincoxihiqdksxgrsrk.supabase.co",
-    "media-src 'self' blob:",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'"
-  ].join('; ');
-  document.head.appendChild(cspMeta);
+  const existingCsp = document.querySelector('meta[http-equiv="Content-Security-Policy"]');
+  if (existingCsp) {
+    existingCsp.setAttribute('content', APP_BASE_CSP);
+  } else {
+    const cspMeta = document.createElement('meta');
+    cspMeta.httpEquiv = 'Content-Security-Policy';
+    cspMeta.content = APP_BASE_CSP;
+    document.head.appendChild(cspMeta);
+  }
 
   // Autres en-têtes de sécurité
   const securityHeaders = [
@@ -74,6 +74,13 @@ const applySecurityHeaders = (): void => {
   ];
 
   securityHeaders.forEach(({ httpEquiv, content }) => {
+    const selector = `meta[http-equiv="${httpEquiv}"]`;
+    const existing = document.querySelector(selector);
+    if (existing) {
+      existing.setAttribute('content', content);
+      return;
+    }
+
     const meta = document.createElement('meta');
     meta.httpEquiv = httpEquiv;
     meta.content = content;


### PR DESCRIPTION
## Summary
- align the app CSP and security headers across static assets, production bootstrapping, and the Netlify `_headers` file
- harden the Sentry client pipeline with stricter sanitisation, DNT tagging, and targeted unit coverage
- add an automated lint regression test to ensure `node:` imports cannot slip into the browser bundle

## Testing
- npm run lint
- npx vitest run src/lib/__tests__/sentry-config.test.ts src/__tests__/lint-node-imports.test.ts --silent

------
https://chatgpt.com/codex/tasks/task_e_68cecc8833e8832d8a1908a3e5c82ef3