### PR TITLE
refactor(app-store): slice-based Zustand store without immer

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,10 +7,19 @@ const createNoNodeImportsRule = (extraPatterns = []) => [
   "error",
   {
     patterns: [
-      {
+  {
         group: ["node:*"],
         message:
           "Interdit dans le bundle client. Utilise les APIs Web (crypto.subtle via '@/lib/hash', fetch, File API, etc.)."
+      },
+      {
+        group: ["zustand/middleware/immer"],
+        message: "Interdit: Zustand doit fonctionner sans immer."
+      },
+      {
+        group: ["immer"],
+        message:
+          "Interdit côté client: utilisez des mises à jour immutables (spread)!"
       },
       ...extraPatterns.map((pattern) =>
         typeof pattern === "string" ? { group: [pattern] } : pattern

--- a/src/components/pages/DataSettingsPage.tsx
+++ b/src/components/pages/DataSettingsPage.tsx
@@ -9,7 +9,6 @@ import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
-import { useAppStore } from '@/store/unified.store';
 import { toast } from '@/hooks/use-toast';
 import { 
   Download, 
@@ -37,7 +36,6 @@ interface DataExport {
 }
 
 export const DataSettingsPage: React.FC<DataSettingsPageProps> = ({ 'data-testid': testId }) => {
-  const { user } = useAppStore();
   const [isExporting, setIsExporting] = React.useState(false);
   const [isDeleting, setIsDeleting] = React.useState(false);
   const [exports, setExports] = React.useState<DataExport[]>([

--- a/src/components/pages/ProfileSettingsPage.tsx
+++ b/src/components/pages/ProfileSettingsPage.tsx
@@ -20,7 +20,8 @@ interface ProfileSettingsPageProps {
 }
 
 export const ProfileSettingsPage: React.FC<ProfileSettingsPageProps> = ({ 'data-testid': testId }) => {
-  const { user, setUser } = useAppStore();
+  const user = useAppStore.use.user();
+  const setUser = useAppStore.use.setUser();
   const [isLoading, setIsLoading] = React.useState(false);
   
   const [formData, setFormData] = React.useState({

--- a/src/hooks/useGlobalState.ts
+++ b/src/hooks/useGlobalState.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useAppStore, shallow } from '@/store/appStore';
+import { useStoreActions, useGlobalStateSlice } from '@/store/hooks';
 import { useErrorHandler } from '@/contexts/ErrorContext';
 import { useCache } from '@/contexts/CacheContext';
 
@@ -8,43 +8,9 @@ import { useCache } from '@/contexts/CacheContext';
  * Combine Zustand store, gestion d'erreurs et cache
  */
 export const useGlobalState = () => {
-  const stateSlice = useAppStore(
-    (state) => ({
-      user: state.user,
-      isAuthenticated: state.isAuthenticated,
-      isLoading: state.isLoading,
-      theme: state.theme,
-      sidebarCollapsed: state.sidebarCollapsed,
-      activeModule: state.activeModule,
-      cache: state.cache,
-      cacheTimestamps: state.cacheTimestamps,
-      preferences: state.preferences,
-      modules: state.modules,
-    }),
-    shallow
-  );
+  const stateSlice = useGlobalStateSlice();
 
-  const actions = useAppStore(
-    (state) => ({
-      setUser: state.setUser,
-      setTheme: state.setTheme,
-      setAuthenticated: state.setAuthenticated,
-      setLoading: state.setLoading,
-      toggleSidebar: state.toggleSidebar,
-      setActiveModule: state.setActiveModule,
-      updatePreferences: state.updatePreferences,
-      updateMusicState: state.updateMusicState,
-      updateEmotionState: state.updateEmotionState,
-      updateJournalState: state.updateJournalState,
-      updateCoachState: state.updateCoachState,
-      setCache: state.setCache,
-      getCache: state.getCache,
-      clearCache: state.clearCache,
-      isCacheValid: state.isCacheValid,
-      reset: state.reset,
-    }),
-    shallow
-  );
+  const actions = useStoreActions();
   const errorHandler = useErrorHandler();
   const cache = useCache();
 

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -1,0 +1,31 @@
+'use client';
+
+import { useShallow } from 'zustand/react/shallow';
+
+import { useAppStore } from './appStore';
+import {
+  selectAuthSlice,
+  selectCacheValue,
+  selectGlobalState,
+  selectMusicModule,
+  selectPreferences,
+  selectSetUser,
+  selectStoreActions,
+  selectTheme,
+  selectUIState,
+  selectUser,
+} from './selectors';
+
+export const useUser = () => useAppStore(selectUser);
+export const useThemeValue = () => useAppStore(selectTheme);
+
+export const useAuthState = () => useAppStore(useShallow(selectAuthSlice));
+export const useUIState = () => useAppStore(useShallow(selectUIState));
+export const useMusicState = () => useAppStore(useShallow(selectMusicModule));
+export const usePreferences = () => useAppStore(selectPreferences);
+export const useGlobalStateSlice = () => useAppStore(useShallow(selectGlobalState));
+export const useStoreActions = () => useAppStore(useShallow(selectStoreActions));
+export const useSetUser = () => useAppStore(selectSetUser);
+
+export const useCachedValue = <T = unknown>(key: string) =>
+  useAppStore((state) => selectCacheValue(key)(state) as T);

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -1,0 +1,80 @@
+import type { AppState } from './appStore';
+
+export const selectUser = (state: AppState) => state.user;
+export const selectIsAuthenticated = (state: AppState) => state.isAuthenticated;
+export const selectIsLoading = (state: AppState) => state.isLoading;
+
+export const selectAuthSlice = (state: AppState) => ({
+  user: state.user,
+  isAuthenticated: state.isAuthenticated,
+  isLoading: state.isLoading,
+});
+
+export const selectTheme = (state: AppState) => state.theme;
+export const selectSidebarCollapsed = (state: AppState) => state.sidebarCollapsed;
+export const selectActiveModule = (state: AppState) => state.activeModule;
+
+export const selectUIState = (state: AppState) => ({
+  theme: state.theme,
+  sidebarCollapsed: state.sidebarCollapsed,
+  activeModule: state.activeModule,
+});
+
+export const selectPreferences = (state: AppState) => state.preferences;
+
+export const selectModules = (state: AppState) => state.modules;
+export const selectMusicModule = (state: AppState) => state.modules.music;
+export const selectEmotionModule = (state: AppState) => state.modules.emotion;
+export const selectJournalModule = (state: AppState) => state.modules.journal;
+export const selectCoachModule = (state: AppState) => state.modules.coach;
+
+export const selectCache = (state: AppState) => state.cache;
+export const selectCacheTimestamps = (state: AppState) => state.cacheTimestamps;
+export const selectCacheValue = (key: string) => (state: AppState) => state.cache[key];
+
+export const selectSetUser = (state: AppState) => state.setUser;
+export const selectSetTheme = (state: AppState) => state.setTheme;
+export const selectToggleSidebar = (state: AppState) => state.toggleSidebar;
+export const selectSetActiveModule = (state: AppState) => state.setActiveModule;
+export const selectUpdatePreferences = (state: AppState) => state.updatePreferences;
+export const selectUpdateMusicState = (state: AppState) => state.updateMusicState;
+export const selectUpdateEmotionState = (state: AppState) => state.updateEmotionState;
+export const selectUpdateJournalState = (state: AppState) => state.updateJournalState;
+export const selectUpdateCoachState = (state: AppState) => state.updateCoachState;
+export const selectSetCache = (state: AppState) => state.setCache;
+export const selectGetCache = (state: AppState) => state.getCache;
+export const selectClearCache = (state: AppState) => state.clearCache;
+export const selectIsCacheValid = (state: AppState) => state.isCacheValid;
+export const selectReset = (state: AppState) => state.reset;
+
+export const selectGlobalState = (state: AppState) => ({
+  user: state.user,
+  isAuthenticated: state.isAuthenticated,
+  isLoading: state.isLoading,
+  theme: state.theme,
+  sidebarCollapsed: state.sidebarCollapsed,
+  activeModule: state.activeModule,
+  cache: state.cache,
+  cacheTimestamps: state.cacheTimestamps,
+  preferences: state.preferences,
+  modules: state.modules,
+});
+
+export const selectStoreActions = (state: AppState) => ({
+  setUser: state.setUser,
+  setTheme: state.setTheme,
+  setAuthenticated: state.setAuthenticated,
+  setLoading: state.setLoading,
+  toggleSidebar: state.toggleSidebar,
+  setActiveModule: state.setActiveModule,
+  updatePreferences: state.updatePreferences,
+  updateMusicState: state.updateMusicState,
+  updateEmotionState: state.updateEmotionState,
+  updateJournalState: state.updateJournalState,
+  updateCoachState: state.updateCoachState,
+  setCache: state.setCache,
+  getCache: state.getCache,
+  clearCache: state.clearCache,
+  isCacheValid: state.isCacheValid,
+  reset: state.reset,
+});

--- a/src/store/slices/auth.ts
+++ b/src/store/slices/auth.ts
@@ -1,0 +1,41 @@
+import type { StateCreator } from 'zustand';
+import type { AppState } from '../appStore';
+
+export interface UserProfile {
+  display_name?: string;
+  avatar_url?: string;
+}
+
+export interface User {
+  id: string;
+  email: string;
+  role: 'b2c' | 'b2b_user' | 'b2b_admin';
+  profile?: UserProfile;
+}
+
+export interface AuthState {
+  user: User | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+}
+
+export interface AuthActions {
+  setUser: (user: User | null) => void;
+  setAuthenticated: (isAuthenticated: boolean) => void;
+  setLoading: (isLoading: boolean) => void;
+}
+
+export type AuthSlice = AuthState & AuthActions;
+
+export const createAuthInitialState = (): AuthState => ({
+  user: null,
+  isAuthenticated: false,
+  isLoading: true,
+});
+
+export const createAuthSlice: StateCreator<AppState, [], [], AuthSlice> = (set) => ({
+  ...createAuthInitialState(),
+  setUser: (user) => set({ user }),
+  setAuthenticated: (isAuthenticated) => set({ isAuthenticated }),
+  setLoading: (isLoading) => set({ isLoading }),
+});

--- a/src/store/slices/cache.ts
+++ b/src/store/slices/cache.ts
@@ -1,0 +1,51 @@
+import type { StateCreator } from 'zustand';
+import type { AppState } from '../appStore';
+
+export interface CacheState {
+  cache: Record<string, unknown>;
+  cacheTimestamps: Record<string, number>;
+}
+
+export interface CacheActions {
+  setCache: (key: string, value: unknown) => void;
+  getCache: (key: string) => unknown | undefined;
+  clearCache: (key?: string) => void;
+  isCacheValid: (key: string, maxAge?: number) => boolean;
+}
+
+export type CacheSlice = CacheState & CacheActions;
+
+export const createCacheInitialState = (): CacheState => ({
+  cache: {},
+  cacheTimestamps: {},
+});
+
+export const createCacheSlice: StateCreator<AppState, [], [], CacheSlice> = (set, get) => ({
+  ...createCacheInitialState(),
+  setCache: (key, value) =>
+    set((state) => ({
+      cache: { ...state.cache, [key]: value },
+      cacheTimestamps: { ...state.cacheTimestamps, [key]: Date.now() },
+    })),
+  getCache: (key) => get().cache[key],
+  clearCache: (key) => {
+    if (!key) {
+      set(() => createCacheInitialState());
+      return;
+    }
+
+    set((state) => {
+      const { [key]: _removedValue, ...restCache } = state.cache;
+      const { [key]: _removedTimestamp, ...restTimestamps } = state.cacheTimestamps;
+
+      return {
+        cache: restCache,
+        cacheTimestamps: restTimestamps,
+      };
+    });
+  },
+  isCacheValid: (key, maxAge = 5 * 60 * 1000) => {
+    const timestamp = get().cacheTimestamps[key];
+    return typeof timestamp === 'number' && Date.now() - timestamp < maxAge;
+  },
+});

--- a/src/store/slices/modules.ts
+++ b/src/store/slices/modules.ts
@@ -1,0 +1,107 @@
+import type { StateCreator } from 'zustand';
+import type { AppState } from '../appStore';
+
+export interface MusicModuleState {
+  currentTrack: unknown | null;
+  isPlaying: boolean;
+  volume: number;
+  playlist: unknown[];
+  [key: string]: unknown;
+}
+
+export interface EmotionModuleState {
+  currentMood: string | null;
+  lastScan: unknown | null;
+  history: unknown[];
+  [key: string]: unknown;
+}
+
+export interface JournalModuleState {
+  entries: unknown[];
+  currentEntry: unknown | null;
+  unsavedChanges: boolean;
+  [key: string]: unknown;
+}
+
+export interface CoachModuleState {
+  conversations: unknown[];
+  activeConversation: string | null;
+  suggestions: unknown[];
+  [key: string]: unknown;
+}
+
+export interface ModulesState {
+  modules: {
+    music: MusicModuleState;
+    emotion: EmotionModuleState;
+    journal: JournalModuleState;
+    coach: CoachModuleState;
+  };
+}
+
+export interface ModulesActions {
+  updateMusicState: (state: Partial<MusicModuleState>) => void;
+  updateEmotionState: (state: Partial<EmotionModuleState>) => void;
+  updateJournalState: (state: Partial<JournalModuleState>) => void;
+  updateCoachState: (state: Partial<CoachModuleState>) => void;
+}
+
+export type ModulesSlice = ModulesState & ModulesActions;
+
+export const createModulesInitialState = (): ModulesState => ({
+  modules: {
+    music: {
+      currentTrack: null,
+      isPlaying: false,
+      volume: 0.7,
+      playlist: [],
+    },
+    emotion: {
+      currentMood: null,
+      lastScan: null,
+      history: [],
+    },
+    journal: {
+      entries: [],
+      currentEntry: null,
+      unsavedChanges: false,
+    },
+    coach: {
+      conversations: [],
+      activeConversation: null,
+      suggestions: [],
+    },
+  },
+});
+
+export const createModulesSlice: StateCreator<AppState, [], [], ModulesSlice> = (set) => ({
+  ...createModulesInitialState(),
+  updateMusicState: (musicState) =>
+    set((state) => ({
+      modules: {
+        ...state.modules,
+        music: { ...state.modules.music, ...musicState },
+      },
+    })),
+  updateEmotionState: (emotionState) =>
+    set((state) => ({
+      modules: {
+        ...state.modules,
+        emotion: { ...state.modules.emotion, ...emotionState },
+      },
+    })),
+  updateJournalState: (journalState) =>
+    set((state) => ({
+      modules: {
+        ...state.modules,
+        journal: { ...state.modules.journal, ...journalState },
+      },
+    })),
+  updateCoachState: (coachState) =>
+    set((state) => ({
+      modules: {
+        ...state.modules,
+        coach: { ...state.modules.coach, ...coachState },
+      },
+    })),
+});

--- a/src/store/slices/preferences.ts
+++ b/src/store/slices/preferences.ts
@@ -1,0 +1,35 @@
+import type { StateCreator } from 'zustand';
+import type { AppState } from '../appStore';
+
+export interface PreferencesState {
+  preferences: {
+    language: 'fr' | 'en';
+    notifications: boolean;
+    autoSave: boolean;
+    analyticsEnabled: boolean;
+    [key: string]: unknown;
+  };
+}
+
+export interface PreferencesActions {
+  updatePreferences: (preferences: Record<string, unknown>) => void;
+}
+
+export type PreferencesSlice = PreferencesState & PreferencesActions;
+
+export const createPreferencesInitialState = (): PreferencesState => ({
+  preferences: {
+    language: 'fr',
+    notifications: true,
+    autoSave: true,
+    analyticsEnabled: true,
+  },
+});
+
+export const createPreferencesSlice: StateCreator<AppState, [], [], PreferencesSlice> = (set, get) => ({
+  ...createPreferencesInitialState(),
+  updatePreferences: (preferences) =>
+    set({
+      preferences: { ...get().preferences, ...preferences },
+    }),
+});

--- a/src/store/slices/ui.ts
+++ b/src/store/slices/ui.ts
@@ -1,0 +1,32 @@
+import type { StateCreator } from 'zustand';
+import type { AppState } from '../appStore';
+
+export type Theme = 'light' | 'dark' | 'system';
+export type ModuleKey = 'music' | 'emotion' | 'journal' | 'coach';
+
+export interface UIState {
+  theme: Theme;
+  sidebarCollapsed: boolean;
+  activeModule: ModuleKey | null;
+}
+
+export interface UIActions {
+  setTheme: (theme: Theme) => void;
+  toggleSidebar: () => void;
+  setActiveModule: (module: ModuleKey | null) => void;
+}
+
+export type UISlice = UIState & UIActions;
+
+export const createUIInitialState = (): UIState => ({
+  theme: 'system',
+  sidebarCollapsed: false,
+  activeModule: null,
+});
+
+export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get) => ({
+  ...createUIInitialState(),
+  setTheme: (theme) => set({ theme }),
+  toggleSidebar: () => set({ sidebarCollapsed: !get().sidebarCollapsed }),
+  setActiveModule: (module) => set({ activeModule: module }),
+});


### PR DESCRIPTION
## Summary
- replace the legacy immer-based app store with immutable Zustand slices, devtools and selective persistence
- add dedicated selectors and hooks to subscribe with useShallow and update consumers to rely on fine-grained selectors
- harden persistence with versioned migration, eslint guardrails against immer, and new tests covering structural sharing and render stability

## Testing
- npx eslint src/store src/hooks src/components/pages
- npx vitest run src/store/__tests__
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cedc5e4f50832da42ec20f5866e44f