### PR TITLE
feat(assess): expose localized catalogs via edge start

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,13 @@ SUPABASE_FUNCTIONS_URL=https://your-project.supabase.co/functions/v1
 SUPABASE_GRAPHQL_URL=https://your-project.supabase.co/graphql/v1
 SUPABASE_JWT_SECRET=
 
+# === ASSESSMENTS EDGE (clinical instruments) ===
+CORS_ORIGINS="https://app.prod.tld,https://staging.app.tld,http://localhost:5173"
+FF_ASSESS_WHO5=true
+FF_ASSESS_STAI6=true
+FF_ASSESS_SAM=true
+FF_ASSESS_SUDS=true
+
 # Identifiants seed pour `npm run db:seed`
 # DEMO_SUPABASE_UID=00000000-0000-0000-0000-000000000001
 # DEMO_SUPABASE_ORG=00000000-0000-0000-0000-0000000000ab

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -1,0 +1,13 @@
+# EmotionsCare – Variables d'environnement
+
+## Assessments cliniques
+
+| Variable | Description | Valeur recommandée (dev) |
+| --- | --- | --- |
+| `CORS_ORIGINS` | Liste des origines autorisées pour les Edge Functions cliniques (`/functions/v1/assess-start`). | `https://app.prod.tld,https://staging.app.tld,http://localhost:5173` |
+| `FF_ASSESS_WHO5` | Active la diffusion du WHO-5 via l'Edge. | `true` |
+| `FF_ASSESS_STAI6` | Active la diffusion du STAI-6 via l'Edge. | `true` |
+| `FF_ASSESS_SAM` | Active la diffusion du SAM via l'Edge. | `true` |
+| `FF_ASSESS_SUDS` | Active la diffusion du SUDS via l'Edge. | `true` |
+
+> ℹ️ Ces variables sont lues côté Edge. Toute désactivation (`false`) renvoie une erreur `instrument_disabled`.

--- a/src/features/assess/api.ts
+++ b/src/features/assess/api.ts
@@ -1,0 +1,23 @@
+import type { InstrumentCatalog, InstrumentCode, LocaleCode } from '@/lib/assess/types';
+
+export async function startAssessment(
+  instrument: InstrumentCode,
+  locale: LocaleCode = 'fr',
+  fetchImpl: typeof fetch = fetch,
+): Promise<InstrumentCatalog> {
+  const response = await fetchImpl('/functions/v1/assess-start', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ instrument, locale }),
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    const reason = typeof data?.error === 'string' ? data.error : 'assess_start_failed';
+    throw new Error(reason);
+  }
+
+  return response.json() as Promise<InstrumentCatalog>;
+}

--- a/src/lib/assess/catalogs.ts
+++ b/src/lib/assess/catalogs.ts
@@ -1,0 +1,264 @@
+import type { InstrumentCatalog, InstrumentCode, LocaleCode } from './types';
+
+const CATALOGS: Record<InstrumentCode, Record<LocaleCode, InstrumentCatalog>> = {
+  WHO5: {
+    fr: {
+      code: 'WHO5',
+      name: 'Indice de bien-être OMS',
+      version: '1.0',
+      expiry_minutes: 30,
+      items: [
+        { id: '1', prompt: 'Je me suis senti(e) gai(e) et de bonne humeur', type: 'scale', min: 0, max: 5 },
+        { id: '2', prompt: 'Je me suis senti(e) calme et détendu(e)', type: 'scale', min: 0, max: 5 },
+        { id: '3', prompt: 'Je me suis senti(e) actif/ve et énergique', type: 'scale', min: 0, max: 5 },
+        { id: '4', prompt: "Je me suis réveillé(e) frais/fraîche et reposé(e)", type: 'scale', min: 0, max: 5 },
+        { id: '5', prompt: "Ma vie quotidienne a été remplie de choses qui m'intéressent", type: 'scale', min: 0, max: 5 },
+      ],
+    },
+    en: {
+      code: 'WHO5',
+      name: 'WHO Well-Being Index',
+      version: '1.0',
+      expiry_minutes: 30,
+      items: [
+        { id: '1', prompt: 'I have felt cheerful and in good spirits', type: 'scale', min: 0, max: 5 },
+        { id: '2', prompt: 'I have felt calm and relaxed', type: 'scale', min: 0, max: 5 },
+        { id: '3', prompt: 'I have felt active and vigorous', type: 'scale', min: 0, max: 5 },
+        { id: '4', prompt: 'I woke up feeling fresh and rested', type: 'scale', min: 0, max: 5 },
+        { id: '5', prompt: 'My daily life has been filled with things that interest me', type: 'scale', min: 0, max: 5 },
+      ],
+    },
+    es: {
+      code: 'WHO5',
+      name: 'Índice de Bienestar OMS',
+      version: '1.0',
+      expiry_minutes: 30,
+      items: [
+        { id: '1', prompt: 'Me he sentido alegre y de buen ánimo', type: 'scale', min: 0, max: 5 },
+        { id: '2', prompt: 'Me he sentido calmado/a y relajado/a', type: 'scale', min: 0, max: 5 },
+        { id: '3', prompt: 'Me he sentido activo/a y enérgico/a', type: 'scale', min: 0, max: 5 },
+        { id: '4', prompt: 'Me he despertado sintiéndome fresco/a y descansado/a', type: 'scale', min: 0, max: 5 },
+        { id: '5', prompt: 'Mi vida diaria ha estado llena de cosas que me interesan', type: 'scale', min: 0, max: 5 },
+      ],
+    },
+    de: {
+      code: 'WHO5',
+      name: 'WHO Wohlbefinden Index',
+      version: '1.0',
+      expiry_minutes: 30,
+      items: [
+        { id: '1', prompt: 'Ich war fröhlich und guter Laune', type: 'scale', min: 0, max: 5 },
+        { id: '2', prompt: 'Ich habe mich ruhig und entspannt gefühlt', type: 'scale', min: 0, max: 5 },
+        { id: '3', prompt: 'Ich habe mich energisch und aktiv gefühlt', type: 'scale', min: 0, max: 5 },
+        { id: '4', prompt: 'Ich bin frisch und ausgeruht aufgewacht', type: 'scale', min: 0, max: 5 },
+        { id: '5', prompt: 'Mein Alltag war voller Dinge, die mich interessieren', type: 'scale', min: 0, max: 5 },
+      ],
+    },
+    it: {
+      code: 'WHO5',
+      name: 'Indice di Benessere OMS',
+      version: '1.0',
+      expiry_minutes: 30,
+      items: [
+        { id: '1', prompt: 'Mi sono sentito/a allegro/a e di buon umore', type: 'scale', min: 0, max: 5 },
+        { id: '2', prompt: 'Mi sono sentito/a calmo/a e rilassato/a', type: 'scale', min: 0, max: 5 },
+        { id: '3', prompt: 'Mi sono sentito/a attivo/a ed energico/a', type: 'scale', min: 0, max: 5 },
+        { id: '4', prompt: 'Mi sono svegliato/a sentendomi fresco/a e riposato/a', type: 'scale', min: 0, max: 5 },
+        { id: '5', prompt: 'La mia vita quotidiana è stata piena di cose che mi interessano', type: 'scale', min: 0, max: 5 },
+      ],
+    },
+  },
+  STAI6: {
+    fr: {
+      code: 'STAI6',
+      name: "Inventaire d’anxiété état (court)",
+      version: '1.0',
+      expiry_minutes: 15,
+      items: [
+        { id: '1', prompt: 'Je me sens calme', type: 'scale', min: 1, max: 4, reversed: true },
+        { id: '2', prompt: 'Je me sens tendu(e)', type: 'scale', min: 1, max: 4 },
+        { id: '3', prompt: 'Je me sens contrarié(e)', type: 'scale', min: 1, max: 4 },
+        { id: '4', prompt: 'Je me sens détendu(e)', type: 'scale', min: 1, max: 4, reversed: true },
+        { id: '5', prompt: 'Je me sens inquiet/ète', type: 'scale', min: 1, max: 4 },
+        { id: '6', prompt: 'Je me sens confus(e)', type: 'scale', min: 1, max: 4 },
+      ],
+    },
+    en: {
+      code: 'STAI6',
+      name: 'State Anxiety Inventory (Short)',
+      version: '1.0',
+      expiry_minutes: 15,
+      items: [
+        { id: '1', prompt: 'I feel calm', type: 'scale', min: 1, max: 4, reversed: true },
+        { id: '2', prompt: 'I feel tense', type: 'scale', min: 1, max: 4 },
+        { id: '3', prompt: 'I feel upset', type: 'scale', min: 1, max: 4 },
+        { id: '4', prompt: 'I feel relaxed', type: 'scale', min: 1, max: 4, reversed: true },
+        { id: '5', prompt: 'I feel worried', type: 'scale', min: 1, max: 4 },
+        { id: '6', prompt: 'I feel confused', type: 'scale', min: 1, max: 4 },
+      ],
+    },
+    es: {
+      code: 'STAI6',
+      name: 'Inventario de Ansiedad Estado (Corto)',
+      version: '1.0',
+      expiry_minutes: 15,
+      items: [
+        { id: '1', prompt: 'Me siento calmado/a', type: 'scale', min: 1, max: 4, reversed: true },
+        { id: '2', prompt: 'Me siento tenso/a', type: 'scale', min: 1, max: 4 },
+        { id: '3', prompt: 'Me siento molesto/a', type: 'scale', min: 1, max: 4 },
+        { id: '4', prompt: 'Me siento relajado/a', type: 'scale', min: 1, max: 4, reversed: true },
+        { id: '5', prompt: 'Me siento preocupado/a', type: 'scale', min: 1, max: 4 },
+        { id: '6', prompt: 'Me siento confundido/a', type: 'scale', min: 1, max: 4 },
+      ],
+    },
+    de: {
+      code: 'STAI6',
+      name: 'Zustandsangst Inventar (Kurz)',
+      version: '1.0',
+      expiry_minutes: 15,
+      items: [
+        { id: '1', prompt: 'Ich fühle mich ruhig', type: 'scale', min: 1, max: 4, reversed: true },
+        { id: '2', prompt: 'Ich fühle mich angespannt', type: 'scale', min: 1, max: 4 },
+        { id: '3', prompt: 'Ich fühle mich verärgert', type: 'scale', min: 1, max: 4 },
+        { id: '4', prompt: 'Ich fühle mich entspannt', type: 'scale', min: 1, max: 4, reversed: true },
+        { id: '5', prompt: 'Ich fühle mich besorgt', type: 'scale', min: 1, max: 4 },
+        { id: '6', prompt: 'Ich fühle mich verwirrt', type: 'scale', min: 1, max: 4 },
+      ],
+    },
+    it: {
+      code: 'STAI6',
+      name: 'Inventario Ansia di Stato (Breve)',
+      version: '1.0',
+      expiry_minutes: 15,
+      items: [
+        { id: '1', prompt: 'Mi sento calmo/a', type: 'scale', min: 1, max: 4, reversed: true },
+        { id: '2', prompt: 'Mi sento teso/a', type: 'scale', min: 1, max: 4 },
+        { id: '3', prompt: 'Mi sento contrariato/a', type: 'scale', min: 1, max: 4 },
+        { id: '4', prompt: 'Mi sento rilassato/a', type: 'scale', min: 1, max: 4, reversed: true },
+        { id: '5', prompt: 'Mi sento preoccupato/a', type: 'scale', min: 1, max: 4 },
+        { id: '6', prompt: 'Mi sento confuso/a', type: 'scale', min: 1, max: 4 },
+      ],
+    },
+  },
+  SAM: {
+    fr: {
+      code: 'SAM',
+      name: 'Auto-évaluation émotionnelle',
+      version: '1.0',
+      expiry_minutes: 5,
+      items: [
+        { id: '1', prompt: 'Plaisir/Déplaisir', type: 'slider', min: 1, max: 9 },
+        { id: '2', prompt: 'Activation/Calme', type: 'slider', min: 1, max: 9 },
+      ],
+    },
+    en: {
+      code: 'SAM',
+      name: 'Self-Assessment Manikin',
+      version: '1.0',
+      expiry_minutes: 5,
+      items: [
+        { id: '1', prompt: 'Pleasure/Displeasure', type: 'slider', min: 1, max: 9 },
+        { id: '2', prompt: 'Arousal/Calm', type: 'slider', min: 1, max: 9 },
+      ],
+    },
+    es: {
+      code: 'SAM',
+      name: 'Muñeco de Autoevaluación',
+      version: '1.0',
+      expiry_minutes: 5,
+      items: [
+        { id: '1', prompt: 'Placer/Displacer', type: 'slider', min: 1, max: 9 },
+        { id: '2', prompt: 'Activación/Calma', type: 'slider', min: 1, max: 9 },
+      ],
+    },
+    de: {
+      code: 'SAM',
+      name: 'Selbstbewertungs-Manikin',
+      version: '1.0',
+      expiry_minutes: 5,
+      items: [
+        { id: '1', prompt: 'Freude/Unfreude', type: 'slider', min: 1, max: 9 },
+        { id: '2', prompt: 'Erregung/Ruhe', type: 'slider', min: 1, max: 9 },
+      ],
+    },
+    it: {
+      code: 'SAM',
+      name: 'Omino di Autovalutazione',
+      version: '1.0',
+      expiry_minutes: 5,
+      items: [
+        { id: '1', prompt: 'Piacere/Dispiacere', type: 'slider', min: 1, max: 9 },
+        { id: '2', prompt: 'Attivazione/Calma', type: 'slider', min: 1, max: 9 },
+      ],
+    },
+  },
+  SUDS: {
+    fr: {
+      code: 'SUDS',
+      name: 'Unités subjectives de détresse',
+      version: '1.0',
+      expiry_minutes: 5,
+      items: [
+        { id: '1', prompt: 'Niveau de détresse actuel (0 = aucune, 10 = extrême)', type: 'slider', min: 0, max: 10 },
+      ],
+    },
+    en: {
+      code: 'SUDS',
+      name: 'Subjective Units of Distress',
+      version: '1.0',
+      expiry_minutes: 5,
+      items: [
+        { id: '1', prompt: 'Current distress level (0 = none, 10 = extreme)', type: 'slider', min: 0, max: 10 },
+      ],
+    },
+    es: {
+      code: 'SUDS',
+      name: 'Unidades Subjetivas de Angustia',
+      version: '1.0',
+      expiry_minutes: 5,
+      items: [
+        { id: '1', prompt: 'Nivel de angustia actual (0 = ninguna, 10 = extrema)', type: 'slider', min: 0, max: 10 },
+      ],
+    },
+    de: {
+      code: 'SUDS',
+      name: 'Subjektive Belastungseinheiten',
+      version: '1.0',
+      expiry_minutes: 5,
+      items: [
+        { id: '1', prompt: 'Aktueller Belastungsgrad (0 = keiner, 10 = extrem)', type: 'slider', min: 0, max: 10 },
+      ],
+    },
+    it: {
+      code: 'SUDS',
+      name: 'Unità Soggettive di Distress',
+      version: '1.0',
+      expiry_minutes: 5,
+      items: [
+        { id: '1', prompt: 'Livello di distress attuale (0 = nessuno, 10 = estremo)', type: 'slider', min: 0, max: 10 },
+      ],
+    },
+  },
+};
+
+export function getCatalog(instrument: InstrumentCode, locale: LocaleCode = 'fr'): InstrumentCatalog {
+  const catalogByLocale = CATALOGS[instrument];
+  if (!catalogByLocale) {
+    throw new Error(`Unknown instrument: ${instrument}`);
+  }
+
+  const localized = catalogByLocale[locale] || catalogByLocale.fr || catalogByLocale.en;
+  if (!localized) {
+    throw new Error(`No catalog available for instrument ${instrument}`);
+  }
+
+  return localized;
+}
+
+export function listAvailableLocales(instrument: InstrumentCode): LocaleCode[] {
+  return Object.keys(CATALOGS[instrument] ?? {}) as LocaleCode[];
+}
+
+export function getAllCatalogs(): Record<InstrumentCode, Record<LocaleCode, InstrumentCatalog>> {
+  return CATALOGS;
+}

--- a/src/lib/assess/types.ts
+++ b/src/lib/assess/types.ts
@@ -1,0 +1,29 @@
+export type LocaleCode = 'fr' | 'en' | 'es' | 'de' | 'it';
+
+export type InstrumentCode = 'WHO5' | 'STAI6' | 'SAM' | 'SUDS';
+
+export type ItemType = 'scale' | 'choice' | 'slider';
+
+export interface InstrumentItem {
+  id: string;
+  prompt: string;
+  type: ItemType;
+  options?: string[];
+  min?: number;
+  max?: number;
+  reversed?: boolean;
+  subscale?: string;
+}
+
+export interface InstrumentCatalog {
+  code: InstrumentCode;
+  name: string;
+  version: string;
+  items: InstrumentItem[];
+  expiry_minutes: number;
+}
+
+export interface StartRequest {
+  instrument: InstrumentCode;
+  locale?: LocaleCode;
+}

--- a/supabase/functions/assess-start/index.ts
+++ b/supabase/functions/assess-start/index.ts
@@ -2,7 +2,6 @@ import { serve } from '../_shared/serve.ts';
 import { z } from '../_shared/zod.ts';
 
 import { authenticateRequest, logUnauthorizedAccess } from '../_shared/auth-middleware.ts';
-import { getCatalog, instrumentSchema, localeSchema } from '../_shared/assess.ts';
 import { appendCorsHeaders, preflightResponse, rejectCors, resolveCors } from '../_shared/cors.ts';
 import { applySecurityHeaders, json } from '../_shared/http.ts';
 import { hash } from '../_shared/hash_user.ts';
@@ -10,11 +9,88 @@ import { logAccess } from '../_shared/logging.ts';
 import { addSentryBreadcrumb, captureSentryException } from '../_shared/sentry.ts';
 import { buildRateLimitResponse, enforceEdgeRateLimit } from '../_shared/rate-limit.ts';
 import { recordEdgeLatencyMetric } from '../_shared/metrics.ts';
+import { createClient } from '../_shared/supabase.ts';
+
+import { getCatalog } from '../../../src/lib/assess/catalogs.ts';
+import type { InstrumentCatalog, InstrumentCode, LocaleCode } from '../../../src/lib/assess/types.ts';
+
+const instrumentSchema = z.enum(['WHO5', 'STAI6', 'SAM', 'SUDS']);
+const localeSchema = z.enum(['fr', 'en', 'es', 'de', 'it']);
 
 const requestSchema = z.object({
   instrument: instrumentSchema,
   locale: localeSchema.optional(),
 });
+
+const CACHE_CONTROL = 'public, max-age=300, stale-while-revalidate=60';
+
+type ConsentResult =
+  | { status: 200 }
+  | { status: 403; error: 'optin_required' }
+  | { status: 500; error: 'internal_error'; detail: 'configuration_error' | 'optin_lookup_failed' };
+
+function readFlag(value: string | undefined): boolean {
+  if (!value) {
+    return true;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized !== 'false' && normalized !== '0' && normalized !== 'off';
+}
+
+function isInstrumentEnabled(instrument: InstrumentCode): boolean {
+  const envKey = `FF_ASSESS_${instrument}`;
+  return readFlag(Deno.env.get(envKey));
+}
+
+async function ensureClinicalOptIn(userId: string, instrument: InstrumentCode): Promise<ConsentResult> {
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    console.error('[assess-start] missing Supabase service configuration');
+    return { status: 500, error: 'internal_error', detail: 'configuration_error' };
+  }
+
+  const client = createClient(supabaseUrl, serviceRoleKey);
+  const { data, error } = await client
+    .from('clinical_consents')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('instrument_code', instrument)
+    .eq('is_active', true)
+    .maybeSingle();
+
+  if (error) {
+    console.error('[assess-start] clinical consent lookup failed', { message: error.message });
+    return { status: 500, error: 'internal_error', detail: 'optin_lookup_failed' };
+  }
+
+  if (!data) {
+    return { status: 403, error: 'optin_required' };
+  }
+
+  return { status: 200 };
+}
+
+async function computeEtag(payload: InstrumentCatalog): Promise<string> {
+  const encoder = new TextEncoder();
+  const raw = JSON.stringify(payload);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', encoder.encode(raw));
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function etagMatches(request: Request, etag: string): boolean {
+  const header = request.headers.get('if-none-match');
+  if (!header) {
+    return false;
+  }
+  return header
+    .split(',')
+    .map((candidate) => candidate.trim().replace(/^W\//, '').replace(/^"|"$/g, ''))
+    .includes(etag);
+}
 
 serve(async (req) => {
   const startedAt = Date.now();
@@ -45,15 +121,17 @@ serve(async (req) => {
     return finalize(applySecurityHeaders(rejectCors(cors), { cacheControl: 'no-store' }), {
       outcome: 'denied',
       error: 'origin_not_allowed',
+      stage: 'cors',
     });
   }
 
   if (req.method !== 'POST') {
-    const response = appendCorsHeaders(new Response('Method Not Allowed', { status: 405 }), cors);
-    return finalize(
-      applySecurityHeaders(response, { cacheControl: 'no-store' }),
-      { outcome: 'denied', error: 'method_not_allowed' },
-    );
+    const response = appendCorsHeaders(json(405, { error: 'method_not_allowed' }), cors);
+    return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+      outcome: 'denied',
+      error: 'method_not_allowed',
+      stage: 'method',
+    });
   }
 
   try {
@@ -63,10 +141,11 @@ serve(async (req) => {
         await logUnauthorizedAccess(req, auth.error ?? 'unauthorized');
       }
       const response = appendCorsHeaders(json(auth.status, { error: 'unauthorized' }), cors);
-      return finalize(
-        applySecurityHeaders(response, { cacheControl: 'no-store' }),
-        { outcome: 'denied', error: 'unauthorized' },
-      );
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'denied',
+        error: 'unauthorized',
+        stage: 'auth',
+      });
     }
 
     hashedUserId = hash(auth.user.id);
@@ -78,6 +157,7 @@ serve(async (req) => {
       limit: 10,
       windowMs: 60_000,
     });
+
     if (!rateDecision.allowed) {
       addSentryBreadcrumb({
         category: 'assess',
@@ -85,50 +165,89 @@ serve(async (req) => {
         data: { identifier: rateDecision.identifier, retry_after: rateDecision.retryAfterSeconds },
       });
       const response = buildRateLimitResponse(rateDecision, cors.headers);
-      return finalize(
-        applySecurityHeaders(response, { cacheControl: 'no-store' }),
-        { outcome: 'denied', error: 'rate_limited', stage: 'rate_limit' },
-      );
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'denied',
+        error: 'rate_limited',
+        stage: 'rate_limit',
+      });
     }
 
     const body = await req.json().catch(() => null);
     if (!body) {
       const response = appendCorsHeaders(json(422, { error: 'invalid_body' }), cors);
-      return finalize(
-        applySecurityHeaders(response, { cacheControl: 'no-store' }),
-        { outcome: 'denied', error: 'invalid_body' },
-      );
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'denied',
+        error: 'invalid_body',
+        stage: 'body_parse',
+      });
     }
 
     const parsed = requestSchema.safeParse(body);
     if (!parsed.success) {
-      const response = appendCorsHeaders(json(422, { error: 'invalid_body', details: 'validation_failed' }), cors);
-      return finalize(
-        applySecurityHeaders(response, { cacheControl: 'no-store' }),
-        { outcome: 'denied', error: 'validation_failed' },
-      );
+      const response = appendCorsHeaders(json(422, { error: 'invalid_body' }), cors);
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'denied',
+        error: 'validation_failed',
+        stage: 'validation',
+      });
     }
 
-    const { instrument, locale } = parsed.data;
-    const resolvedLocale = locale ?? 'fr';
+    const instrument = parsed.data.instrument as InstrumentCode;
+    const locale = (parsed.data.locale ?? 'fr') as LocaleCode;
 
-    let catalog: ReturnType<typeof getCatalog>;
+    addSentryBreadcrumb({
+      category: 'assess',
+      message: 'assess:start.request',
+      data: { instrument, locale },
+    });
+
+    if (!isInstrumentEnabled(instrument)) {
+      const response = appendCorsHeaders(json(404, { error: 'instrument_disabled' }), cors);
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'denied',
+        error: 'instrument_disabled',
+        stage: 'feature_flag',
+      });
+    }
+
+    const consent = await ensureClinicalOptIn(auth.user.id, instrument);
+    if (consent.status !== 200) {
+      const response = appendCorsHeaders(json(consent.status, { error: consent.error }), cors);
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'denied',
+        error: consent.status === 500 ? consent.detail : consent.error,
+        stage: 'optin',
+      });
+    }
+
+    let catalog: InstrumentCatalog;
     try {
-      catalog = getCatalog(instrument, resolvedLocale);
-    } catch (_error) {
-      return finalize(
-        applySecurityHeaders(
-          appendCorsHeaders(json(422, { error: 'invalid_body', details: 'catalog_unavailable' }), cors),
-          { cacheControl: 'no-store' },
-        ),
-        { outcome: 'denied', error: 'catalog_unavailable' },
-      );
+      catalog = getCatalog(instrument, locale);
+    } catch (error) {
+      console.error('[assess-start] failed to resolve catalog', { instrument, locale, error });
+      const response = appendCorsHeaders(json(500, { error: 'internal_error' }), cors);
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'error',
+        error: 'catalog_error',
+        stage: 'catalog',
+      });
+    }
+
+    const etag = await computeEtag(catalog);
+
+    if (etagMatches(req, etag)) {
+      const response = appendCorsHeaders(new Response(null, { status: 304 }), cors);
+      const secured = applySecurityHeaders(response, {
+        cacheControl: CACHE_CONTROL,
+        extra: { ETag: `"${etag}"` },
+      });
+      return finalize(secured, { outcome: 'success', stage: 'not_modified' });
     }
 
     addSentryBreadcrumb({
       category: 'assess',
-      message: 'assess:start:catalog_served',
-      data: { instrument, latency_ms: Date.now() - startedAt },
+      message: 'assess:start.success',
+      data: { instrument, locale },
     });
 
     await logAccess({
@@ -138,21 +257,29 @@ serve(async (req) => {
       action: 'assess:start',
       result: 'success',
       user_agent: 'redacted',
-      details: `instrument=${instrument} locale=${resolvedLocale}`,
+      details: `instrument=${instrument} locale=${locale}`,
     });
 
-    const ttlSeconds = Math.max(30, Math.min(catalog.expiry_minutes * 60, 600));
-    const responsePayload = { instrument, locale: locale ?? 'fr', ...catalog };
-    const response = appendCorsHeaders(json(200, responsePayload), cors);
-    applySecurityHeaders(response, { cacheControl: `private, max-age=${ttlSeconds}, must-revalidate` });
-    return finalize(response, { outcome: 'success', stage: 'catalog_served' });
+    const response = appendCorsHeaders(json(200, catalog), cors);
+    const secured = applySecurityHeaders(response, {
+      cacheControl: CACHE_CONTROL,
+      extra: { ETag: `"${etag}"` },
+    });
+    return finalize(secured, { outcome: 'success', stage: 'catalog_served' });
   } catch (error) {
     captureSentryException(error, { route: 'assess-start' });
     console.error('[assess-start] unexpected error', { message: error instanceof Error ? error.message : 'unknown' });
     const response = appendCorsHeaders(json(500, { error: 'internal_error' }), cors);
-    return finalize(
-      applySecurityHeaders(response, { cacheControl: 'no-store' }),
-      { outcome: 'error', error: 'internal_error' },
-    );
+    return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+      outcome: 'error',
+      error: 'internal_error',
+      stage: 'unhandled',
+    });
   }
 });
+
+export const __test__ = {
+  readFlag,
+  isInstrumentEnabled,
+  computeEtag,
+};

--- a/tests/assess/catalogs.spec.ts
+++ b/tests/assess/catalogs.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { getAllCatalogs, getCatalog } from '../../src/lib/assess/catalogs.ts';
+import type { InstrumentCode, LocaleCode } from '../../src/lib/assess/types.ts';
+
+describe('assessment catalogs', () => {
+  it('returns the WHO-5 catalog in French with five items', () => {
+    const catalog = getCatalog('WHO5', 'fr');
+    expect(catalog.code).toBe('WHO5');
+    expect(catalog.expiry_minutes).toBe(30);
+    expect(catalog.items).toHaveLength(5);
+  });
+
+  it('falls back to French when locale is unsupported and then to English when French is missing', () => {
+    const fallbackToFrench = getCatalog('WHO5', 'pt' as LocaleCode);
+    expect(fallbackToFrench.name).toContain('Indice');
+
+    const catalogs = getAllCatalogs();
+    const originalFrench = catalogs.SAM.fr;
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete catalogs.SAM.fr;
+    try {
+      const fallbackToEnglish = getCatalog('SAM', 'fr');
+      expect(fallbackToEnglish.name).toContain('Self-Assessment Manikin');
+    } finally {
+      catalogs.SAM.fr = originalFrench;
+    }
+  });
+
+  it('ensures item metadata stays within expected bounds', () => {
+    const catalogs = getAllCatalogs();
+    const allowedTypes = new Set(['scale', 'choice', 'slider']);
+
+    (Object.keys(catalogs) as InstrumentCode[]).forEach((instrument) => {
+      const locales = catalogs[instrument];
+      Object.values(locales).forEach((catalog) => {
+        catalog.items.forEach((item) => {
+          expect(allowedTypes.has(item.type)).toBe(true);
+          if (typeof item.min === 'number' && typeof item.max === 'number') {
+            expect(item.min).toBeLessThanOrEqual(item.max);
+          }
+        });
+      });
+    });
+  });
+});

--- a/tests/assess/flags.spec.ts
+++ b/tests/assess/flags.spec.ts
@@ -1,0 +1,57 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const envStore = new Map<string, string | undefined>();
+const getEnv = vi.fn((key: string) => envStore.get(key));
+
+vi.mock('../../supabase/functions/_shared/serve.ts', () => ({
+  serve: vi.fn(),
+}));
+
+let testExports: typeof import('../../supabase/functions/assess-start/index.ts').__test__;
+
+beforeAll(async () => {
+  vi.stubGlobal('Deno', { env: { get: getEnv } });
+  envStore.set('SUPABASE_URL', 'https://edge.supabase.local');
+  envStore.set('SUPABASE_SERVICE_ROLE_KEY', 'service-role');
+  envStore.set('SUPABASE_ANON_KEY', 'anon-key');
+  const module = await import('../../supabase/functions/assess-start/index.ts');
+  testExports = module.__test__;
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  envStore.clear();
+  envStore.set('SUPABASE_URL', 'https://edge.supabase.local');
+  envStore.set('SUPABASE_SERVICE_ROLE_KEY', 'service-role');
+  envStore.set('SUPABASE_ANON_KEY', 'anon-key');
+  getEnv.mockClear();
+});
+
+describe('assessment feature flags', () => {
+  it('enables instruments by default when flag is missing', () => {
+    const enabled = testExports.isInstrumentEnabled('WHO5');
+    expect(enabled).toBe(true);
+  });
+
+  it('disables instrument when environment flag is set to false-ish values', () => {
+    envStore.set('FF_ASSESS_WHO5', 'false');
+    expect(testExports.isInstrumentEnabled('WHO5')).toBe(false);
+
+    envStore.set('FF_ASSESS_STAI6', '0');
+    expect(testExports.isInstrumentEnabled('STAI6')).toBe(false);
+
+    envStore.set('FF_ASSESS_SAM', 'OFF');
+    expect(testExports.isInstrumentEnabled('SAM')).toBe(false);
+  });
+
+  it('treats any other value as enabled', () => {
+    envStore.set('FF_ASSESS_SUDS', 'true');
+    expect(testExports.isInstrumentEnabled('SUDS')).toBe(true);
+
+    envStore.set('FF_ASSESS_WHO5', '1');
+    expect(testExports.isInstrumentEnabled('WHO5')).toBe(true);
+  });
+});

--- a/tests/e2e/assess-start.e2e.ts
+++ b/tests/e2e/assess-start.e2e.ts
@@ -1,0 +1,252 @@
+import { expect, test } from '@playwright/test';
+import { vi } from 'vitest';
+
+type Handler = (req: Request) => Promise<Response>;
+
+const envStore = new Map<string, string | undefined>();
+const getEnv = vi.fn((key: string) => envStore.get(key));
+
+let handlerRef: { current: Handler | null };
+let corsAllowed: boolean;
+const corsHeaders = {
+  'Access-Control-Allow-Origin': 'https://app.local',
+  'Vary': 'Origin',
+};
+
+const authenticateRequest = vi.fn();
+const logUnauthorizedAccess = vi.fn();
+const appendCorsHeaders = vi.fn((response: Response) => {
+  Object.entries(corsHeaders).forEach(([key, value]) => response.headers.set(key, value));
+  return response;
+});
+const resolveCors = vi.fn(() => ({ allowed: corsAllowed, headers: corsHeaders }));
+const preflightResponse = vi.fn(() => new Response(null, { status: 204, headers: corsHeaders }));
+const rejectCors = vi.fn(() =>
+  new Response(JSON.stringify({ error: 'origin_not_allowed' }), {
+    status: 403,
+    headers: { ...corsHeaders, 'content-type': 'application/json' },
+  }),
+);
+const applySecurityHeaders = vi.fn((response: Response, options?: { cacheControl?: string; extra?: Record<string, string> }) => {
+  if (options?.cacheControl) {
+    response.headers.set('Cache-Control', options.cacheControl);
+  }
+  if (options?.extra) {
+    for (const [key, value] of Object.entries(options.extra)) {
+      response.headers.set(key, value);
+    }
+  }
+  return response;
+});
+const json = vi.fn((status: number, data: unknown) =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  }),
+);
+const hash = vi.fn(() => 'hashed-user');
+const logAccess = vi.fn(async () => {});
+const addSentryBreadcrumb = vi.fn();
+const captureSentryException = vi.fn();
+const enforceEdgeRateLimit = vi.fn(async () => ({ allowed: true, identifier: 'rate', retryAfterSeconds: 0 }));
+const buildRateLimitResponse = vi.fn(() => new Response('rate', { status: 429 }));
+const recordEdgeLatencyMetric = vi.fn(async () => {});
+
+const maybeSingleMock = vi.fn();
+const eqIsActiveMock = vi.fn(() => ({ maybeSingle: maybeSingleMock }));
+const eqInstrumentMock = vi.fn(() => ({ eq: eqIsActiveMock }));
+const eqUserMock = vi.fn(() => ({ eq: eqInstrumentMock }));
+const selectMock = vi.fn(() => ({ eq: eqUserMock }));
+const fromMock = vi.fn(() => ({ select: selectMock }));
+const createClient = vi.fn(() => ({ from: fromMock }));
+
+vi.mock('../../supabase/functions/_shared/serve.ts', () => ({
+  serve: (handler: Handler) => {
+    handlerRef.current = handler;
+  },
+}));
+
+vi.mock('../../supabase/functions/_shared/auth-middleware.ts', () => ({
+  authenticateRequest,
+  logUnauthorizedAccess,
+}));
+
+vi.mock('../../supabase/functions/_shared/cors.ts', () => ({
+  appendCorsHeaders,
+  resolveCors,
+  preflightResponse,
+  rejectCors,
+}));
+
+vi.mock('../../supabase/functions/_shared/http.ts', () => ({
+  applySecurityHeaders,
+  json,
+}));
+
+vi.mock('../../supabase/functions/_shared/hash_user.ts', () => ({
+  hash,
+}));
+
+vi.mock('../../supabase/functions/_shared/logging.ts', () => ({
+  logAccess,
+}));
+
+vi.mock('../../supabase/functions/_shared/sentry.ts', () => ({
+  addSentryBreadcrumb,
+  captureSentryException,
+}));
+
+vi.mock('../../supabase/functions/_shared/rate-limit.ts', () => ({
+  enforceEdgeRateLimit,
+  buildRateLimitResponse,
+}));
+
+vi.mock('../../supabase/functions/_shared/metrics.ts', () => ({
+  recordEdgeLatencyMetric,
+}));
+
+vi.mock('../../supabase/functions/_shared/supabase.ts', () => ({
+  createClient,
+}));
+
+test.beforeAll(() => {
+  handlerRef = { current: null };
+  (globalThis as { Deno?: { env: { get: typeof getEnv } } }).Deno = { env: { get: getEnv } };
+});
+
+test.afterAll(() => {
+  vi.unstubAllGlobals();
+  // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+  delete (globalThis as { Deno?: unknown }).Deno;
+});
+
+test.beforeEach(async ({ page }) => {
+  envStore.clear();
+  envStore.set('SUPABASE_URL', 'https://edge.supabase.local');
+  envStore.set('SUPABASE_SERVICE_ROLE_KEY', 'service-role');
+  envStore.set('FF_ASSESS_WHO5', 'true');
+  envStore.set('FF_ASSESS_STAI6', 'true');
+  envStore.set('FF_ASSESS_SAM', 'true');
+  envStore.set('FF_ASSESS_SUDS', 'true');
+
+  corsAllowed = true;
+
+  authenticateRequest.mockResolvedValue({ status: 200, user: { id: 'user-1', user_metadata: { role: 'member' } } });
+  maybeSingleMock.mockReset();
+  maybeSingleMock.mockResolvedValue({ data: { id: 'consent-1' }, error: null });
+
+  await page.route('https://app.local/', (route) =>
+    route.fulfill({ status: 200, contentType: 'text/html', body: '<html><body></body></html>' }),
+  );
+});
+
+test.afterEach(async ({ page }) => {
+  await page.unroute('https://app.local/');
+  vi.resetModules();
+});
+
+const getHandler = async (): Promise<Handler> => {
+  handlerRef.current = null;
+  await import('../../supabase/functions/assess-start/index.ts');
+  if (!handlerRef.current) {
+    throw new Error('handler not registered');
+  }
+  return handlerRef.current;
+};
+
+async function setupEdgeRoute(page: import('@playwright/test').Page, handler: Handler) {
+  await page.route('**/functions/v1/assess-start', async (route) => {
+    const request = route.request();
+    const headers = new Headers();
+    const rawHeaders = request.headers();
+    for (const [key, value] of Object.entries(rawHeaders)) {
+      headers.set(key, value);
+    }
+    const bodyBuffer = request.postDataBuffer();
+    const edgeRequest = new Request(request.url(), {
+      method: request.method(),
+      headers,
+      body: bodyBuffer ?? undefined,
+    });
+    const edgeResponse = await handler(edgeRequest);
+    const responseBody = await edgeResponse.text();
+    const responseHeaders = Object.fromEntries(edgeResponse.headers.entries());
+    await route.fulfill({
+      status: edgeResponse.status,
+      headers: responseHeaders,
+      body: responseBody,
+    });
+  });
+}
+
+test('blocks assessment start when opt-in is missing', async ({ page }) => {
+  const handler = await getHandler();
+  maybeSingleMock.mockResolvedValueOnce({ data: null, error: null });
+  await setupEdgeRoute(page, handler);
+
+  await page.goto('https://app.local/');
+
+  const result = await page.evaluate(async () => {
+    const res = await fetch('/functions/v1/assess-start', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        Authorization: 'Bearer access-token',
+      },
+      body: JSON.stringify({ instrument: 'WHO5', locale: 'fr' }),
+    });
+    return { status: res.status, body: await res.json() };
+  });
+
+  expect(result.status).toBe(403);
+  expect(result.body).toEqual({ error: 'optin_required' });
+});
+
+test('returns 404 when the feature flag is disabled', async ({ page }) => {
+  envStore.set('FF_ASSESS_WHO5', 'false');
+  const handler = await getHandler();
+  await setupEdgeRoute(page, handler);
+
+  await page.goto('https://app.local/');
+
+  const result = await page.evaluate(async () => {
+    const res = await fetch('/functions/v1/assess-start', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        Authorization: 'Bearer access-token',
+      },
+      body: JSON.stringify({ instrument: 'WHO5', locale: 'fr' }),
+    });
+    return { status: res.status, body: await res.json() };
+  });
+
+  expect(result.status).toBe(404);
+  expect(result.body).toEqual({ error: 'instrument_disabled' });
+});
+
+test('delivers catalog items without scores when conditions are met', async ({ page }) => {
+  const handler = await getHandler();
+  await setupEdgeRoute(page, handler);
+
+  await page.goto('https://app.local/');
+
+  const result = await page.evaluate(async () => {
+    const res = await fetch('/functions/v1/assess-start', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        Authorization: 'Bearer access-token',
+      },
+      body: JSON.stringify({ instrument: 'WHO5', locale: 'fr' }),
+    });
+    const payload = await res.json();
+    return { status: res.status, body: payload, cacheControl: res.headers.get('cache-control') };
+  });
+
+  expect(result.status).toBe(200);
+  expect(result.cacheControl).toBe('public, max-age=300, stale-while-revalidate=60');
+  expect(result.body).toMatchObject({ code: 'WHO5', version: '1.0', expiry_minutes: 30 });
+  expect(result.body).not.toHaveProperty('scores');
+  expect(Array.isArray(result.body.items)).toBe(true);
+});

--- a/tests/edge/assess-start.spec.ts
+++ b/tests/edge/assess-start.spec.ts
@@ -1,0 +1,283 @@
+/* @vitest-environment node */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Handler = (req: Request) => Promise<Response>;
+
+const envStore = new Map<string, string | undefined>();
+const getEnv = vi.fn((key: string) => envStore.get(key));
+
+let handlerRef: { current: Handler | null };
+let corsAllowed: boolean;
+const corsHeaders = {
+  'Access-Control-Allow-Origin': 'https://app.local',
+  'Vary': 'Origin',
+};
+
+const authenticateRequest = vi.fn();
+const logUnauthorizedAccess = vi.fn();
+const appendCorsHeaders = vi.fn((response: Response) => {
+  Object.entries(corsHeaders).forEach(([key, value]) => response.headers.set(key, value));
+  return response;
+});
+const resolveCors = vi.fn(() => ({ allowed: corsAllowed, headers: corsHeaders }));
+const preflightResponse = vi.fn(() => new Response(null, { status: 204, headers: corsHeaders }));
+const rejectCors = vi.fn(() =>
+  new Response(JSON.stringify({ error: 'origin_not_allowed' }), {
+    status: 403,
+    headers: { ...corsHeaders, 'content-type': 'application/json' },
+  }),
+);
+const applySecurityHeaders = vi.fn((response: Response, options?: { cacheControl?: string; extra?: Record<string, string> }) => {
+  if (options?.cacheControl) {
+    response.headers.set('Cache-Control', options.cacheControl);
+  }
+  if (options?.extra) {
+    for (const [key, value] of Object.entries(options.extra)) {
+      response.headers.set(key, value);
+    }
+  }
+  return response;
+});
+const json = vi.fn((status: number, data: unknown) =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  }),
+);
+const hash = vi.fn(() => 'hashed-user');
+const logAccess = vi.fn(async () => {});
+const addSentryBreadcrumb = vi.fn();
+const captureSentryException = vi.fn();
+const enforceEdgeRateLimit = vi.fn(async () => ({ allowed: true, identifier: 'rate', retryAfterSeconds: 0 }));
+const buildRateLimitResponse = vi.fn(() => new Response('rate', { status: 429 }));
+const recordEdgeLatencyMetric = vi.fn(async () => {});
+
+const maybeSingleMock = vi.fn();
+const eqIsActiveMock = vi.fn(() => ({ maybeSingle: maybeSingleMock }));
+const eqInstrumentMock = vi.fn(() => ({ eq: eqIsActiveMock }));
+const eqUserMock = vi.fn(() => ({ eq: eqInstrumentMock }));
+const selectMock = vi.fn(() => ({ eq: eqUserMock }));
+const fromMock = vi.fn(() => ({ select: selectMock }));
+const createClient = vi.fn(() => ({ from: fromMock }));
+
+vi.mock('../../supabase/functions/_shared/serve.ts', () => ({
+  serve: (handler: Handler) => {
+    handlerRef.current = handler;
+  },
+}));
+
+vi.mock('../../supabase/functions/_shared/auth-middleware.ts', () => ({
+  authenticateRequest,
+  logUnauthorizedAccess,
+}));
+
+vi.mock('../../supabase/functions/_shared/cors.ts', () => ({
+  appendCorsHeaders,
+  resolveCors,
+  preflightResponse,
+  rejectCors,
+}));
+
+vi.mock('../../supabase/functions/_shared/http.ts', () => ({
+  applySecurityHeaders,
+  json,
+}));
+
+vi.mock('../../supabase/functions/_shared/hash_user.ts', () => ({
+  hash,
+}));
+
+vi.mock('../../supabase/functions/_shared/logging.ts', () => ({
+  logAccess,
+}));
+
+vi.mock('../../supabase/functions/_shared/sentry.ts', () => ({
+  addSentryBreadcrumb,
+  captureSentryException,
+}));
+
+vi.mock('../../supabase/functions/_shared/rate-limit.ts', () => ({
+  enforceEdgeRateLimit,
+  buildRateLimitResponse,
+}));
+
+vi.mock('../../supabase/functions/_shared/metrics.ts', () => ({
+  recordEdgeLatencyMetric,
+}));
+
+vi.mock('../../supabase/functions/_shared/supabase.ts', () => ({
+  createClient,
+}));
+
+beforeAll(() => {
+  handlerRef = { current: null };
+  (globalThis as { Deno?: { env: { get: typeof getEnv } } }).Deno = { env: { get: getEnv } };
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+  // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+  delete (globalThis as { Deno?: unknown }).Deno;
+});
+
+beforeEach(() => {
+  envStore.clear();
+  envStore.set('SUPABASE_URL', 'https://edge.supabase.local');
+  envStore.set('SUPABASE_SERVICE_ROLE_KEY', 'service-role');
+  envStore.set('FF_ASSESS_WHO5', 'true');
+  envStore.set('FF_ASSESS_STAI6', 'true');
+  envStore.set('FF_ASSESS_SAM', 'true');
+  envStore.set('FF_ASSESS_SUDS', 'true');
+
+  corsAllowed = true;
+
+  authenticateRequest.mockResolvedValue({ status: 200, user: { id: 'user-1', user_metadata: { role: 'member' } } });
+  logUnauthorizedAccess.mockReset();
+  appendCorsHeaders.mockClear();
+  resolveCors.mockClear();
+  preflightResponse.mockClear();
+  rejectCors.mockClear();
+  applySecurityHeaders.mockClear();
+  json.mockClear();
+  hash.mockClear();
+  logAccess.mockClear();
+  addSentryBreadcrumb.mockClear();
+  captureSentryException.mockClear();
+  enforceEdgeRateLimit.mockClear();
+  buildRateLimitResponse.mockClear();
+  recordEdgeLatencyMetric.mockClear();
+  createClient.mockClear();
+  fromMock.mockClear();
+  selectMock.mockClear();
+  eqUserMock.mockClear();
+  eqInstrumentMock.mockClear();
+  eqIsActiveMock.mockClear();
+  maybeSingleMock.mockReset();
+  maybeSingleMock.mockResolvedValue({ data: { id: 'consent-1' }, error: null });
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+const getHandler = async (): Promise<Handler> => {
+  handlerRef.current = null;
+  await import('../../supabase/functions/assess-start/index.ts');
+  if (!handlerRef.current) {
+    throw new Error('handler not registered');
+  }
+  return handlerRef.current;
+};
+
+describe('assess-start edge contract', () => {
+  it('rejects origins not in the allow-list', async () => {
+    corsAllowed = false;
+    const handler = await getHandler();
+    const response = await handler(
+      new Request('https://edge.dev/assess/start', {
+        method: 'POST',
+        headers: { Origin: 'https://evil.test' },
+        body: JSON.stringify({ instrument: 'WHO5' }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body).toEqual({ error: 'origin_not_allowed' });
+  });
+
+  it('returns unauthorized when bearer token is missing', async () => {
+    authenticateRequest.mockResolvedValueOnce({ status: 401, user: null, error: 'missing' });
+    const handler = await getHandler();
+
+    const response = await handler(
+      new Request('https://edge.dev/assess/start', {
+        method: 'POST',
+        headers: { Origin: 'https://app.local' },
+        body: JSON.stringify({ instrument: 'WHO5' }),
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    const payload = await response.json();
+    expect(payload).toEqual({ error: 'unauthorized' });
+    expect(logUnauthorizedAccess).toHaveBeenCalled();
+  });
+
+  it('validates request body and returns 422 on invalid payload', async () => {
+    const handler = await getHandler();
+
+    const response = await handler(
+      new Request('https://edge.dev/assess/start', {
+        method: 'POST',
+        headers: { Origin: 'https://app.local', 'content-type': 'application/json' },
+        body: JSON.stringify({}),
+      }),
+    );
+
+    expect(response.status).toBe(422);
+    const payload = await response.json();
+    expect(payload).toEqual({ error: 'invalid_body' });
+  });
+
+  it('returns 404 when the feature flag disables the instrument', async () => {
+    envStore.set('FF_ASSESS_WHO5', 'false');
+    const handler = await getHandler();
+
+    const response = await handler(
+      new Request('https://edge.dev/assess/start', {
+        method: 'POST',
+        headers: { Origin: 'https://app.local', 'content-type': 'application/json' },
+        body: JSON.stringify({ instrument: 'WHO5', locale: 'fr' }),
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    const payload = await response.json();
+    expect(payload).toEqual({ error: 'instrument_disabled' });
+  });
+
+  it('returns 403 when the user has not opted in', async () => {
+    maybeSingleMock.mockResolvedValueOnce({ data: null, error: null });
+    const handler = await getHandler();
+
+    const response = await handler(
+      new Request('https://edge.dev/assess/start', {
+        method: 'POST',
+        headers: { Origin: 'https://app.local', 'content-type': 'application/json' },
+        body: JSON.stringify({ instrument: 'WHO5', locale: 'fr' }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    const payload = await response.json();
+    expect(payload).toEqual({ error: 'optin_required' });
+  });
+
+  it('delivers the catalog with caching hints and without scoring data', async () => {
+    const handler = await getHandler();
+
+    const response = await handler(
+      new Request('https://edge.dev/assess/start', {
+        method: 'POST',
+        headers: { Origin: 'https://app.local', 'content-type': 'application/json' },
+        body: JSON.stringify({ instrument: 'WHO5', locale: 'fr' }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=300, stale-while-revalidate=60');
+    expect(response.headers.get('ETag')).toMatch(/^"[a-f0-9]{64}"$/);
+
+    const payload = await response.json();
+    expect(payload).toMatchObject({ code: 'WHO5', version: '1.0', expiry_minutes: 30 });
+    expect(payload).not.toHaveProperty('scores');
+    expect(Array.isArray(payload.items)).toBe(true);
+
+    expect(logAccess).toHaveBeenCalledWith(
+      expect.objectContaining({ route: 'assess-start', action: 'assess:start', result: 'success' }),
+    );
+    expect(createClient).toHaveBeenCalledWith('https://edge.supabase.local', 'service-role');
+  });
+});


### PR DESCRIPTION
## Summary
- add shared clinical assessment types and localized catalog definitions for WHO-5, STAI-6, SAM, and SUDS
- harden the /functions/v1/assess-start edge handler with opt-in enforcement, feature flags, strict CORS, and cache hints while returning only catalog data
- provide a front-end startAssessment helper, document new environment variables, and add unit, contract, and e2e coverage for the delivery service

## Testing
- npx vitest run tests/assess/catalogs.spec.ts tests/assess/flags.spec.ts tests/edge/assess-start.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cedfe476f0832d9bbace2f8e367849