### PR TITLE
feat(home): orchestrate dashboard with WHO-5 signals

### DIFF
--- a/src/core/flags.ts
+++ b/src/core/flags.ts
@@ -36,6 +36,7 @@ interface FeatureFlags {
   FF_ASSESS_CBI: boolean;
   FF_ASSESS_CVSQ: boolean;
   FF_ASSESS_SAM: boolean;
+  FF_ZERO_NUMBERS?: boolean;
 
   [key: string]: boolean;
 }
@@ -77,6 +78,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   FF_ASSESS_CBI: true,
   FF_ASSESS_CVSQ: true,
   FF_ASSESS_SAM: true,
+  FF_ZERO_NUMBERS: true,
 };
 
 let flagsCache: FeatureFlags | null = null;

--- a/src/features/dashboard/DashboardCards.tsx
+++ b/src/features/dashboard/DashboardCards.tsx
@@ -1,0 +1,140 @@
+import React, { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { Footprints, MessageCircle, Music, PenTool, Scan, Wind } from 'lucide-react';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import type { Who5Tone } from '@/features/orchestration/useWho5Orchestration';
+import { getCardNudge, getToneCopy, type DashboardCardId } from '@/features/dashboard/nudges';
+import { cn } from '@/lib/utils';
+
+type DashboardCardsProps = {
+  order: string[];
+  tone: Who5Tone;
+};
+
+type CardConfig = {
+  title: string;
+  description: string;
+  to: string;
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  accent: string;
+};
+
+const CARD_CATALOG: Record<DashboardCardId, CardConfig> = {
+  'card-nyvee': {
+    title: 'Nyvée',
+    description: 'Un échange chaleureux avec l’IA compagnon.',
+    to: '/app/coach',
+    icon: MessageCircle,
+    accent: 'bg-purple-100/10 text-purple-200',
+  },
+  'card-breath': {
+    title: 'Respiration',
+    description: 'Séance guidée pour réguler le souffle et apaiser le corps.',
+    to: '/app/breath',
+    icon: Wind,
+    accent: 'bg-sky-100/10 text-sky-200',
+  },
+  'card-music': {
+    title: 'Musique adaptative',
+    description: 'Ambiances sur mesure pour soutenir le moment présent.',
+    to: '/app/music',
+    icon: Music,
+    accent: 'bg-blue-100/10 text-blue-200',
+  },
+  'card-journal': {
+    title: 'Journal léger',
+    description: 'Un espace pour déposer quelques phrases en toute simplicité.',
+    to: '/app/journal',
+    icon: PenTool,
+    accent: 'bg-emerald-100/10 text-emerald-200',
+  },
+  'card-scan': {
+    title: 'Scan émotionnel',
+    description: 'Observer le visage et repérer les nuances du moment.',
+    to: '/app/scan',
+    icon: Scan,
+    accent: 'bg-amber-100/10 text-amber-200',
+  },
+  'card-coach': {
+    title: 'Micro-action',
+    description: 'Un petit pas guidé pour faire circuler l’énergie.',
+    to: '/app/coach-micro',
+    icon: Footprints,
+    accent: 'bg-rose-100/10 text-rose-200',
+  },
+};
+
+const DEFAULT_ORDER: DashboardCardId[] = [
+  'card-nyvee',
+  'card-breath',
+  'card-music',
+  'card-journal',
+  'card-scan',
+  'card-coach',
+];
+
+const toneBadgeClasses: Record<Who5Tone, string> = {
+  very_low: 'bg-sky-950/40 text-sky-100',
+  low: 'bg-sky-900/40 text-sky-50',
+  neutral: 'bg-slate-900/40 text-slate-100',
+  high: 'bg-indigo-900/40 text-indigo-100',
+  very_high: 'bg-amber-900/40 text-amber-50',
+};
+
+export const DashboardCards: React.FC<DashboardCardsProps> = ({ order, tone }) => {
+  const toneCopy = getToneCopy(tone);
+
+  const resolvedOrder = useMemo<DashboardCardId[]>(() => {
+    const unique = new Set<DashboardCardId>();
+    order.forEach((id) => {
+      if ((CARD_CATALOG as Record<string, CardConfig>)[id]) {
+        unique.add(id as DashboardCardId);
+      }
+    });
+    DEFAULT_ORDER.forEach((id) => unique.add(id));
+    return Array.from(unique);
+  }, [order]);
+
+  return (
+    <section aria-label="Suggestions du jour" className="space-y-6">
+      <div className="flex flex-wrap items-center gap-3">
+        <span className={cn('rounded-full px-3 py-1 text-sm font-medium', toneBadgeClasses[tone])}>{toneCopy.headline}</span>
+        <p className="text-sm text-slate-300">{toneCopy.helper}</p>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        {resolvedOrder.map((cardId) => {
+          const config = CARD_CATALOG[cardId];
+          const CardIcon = config.icon;
+          const nudge = getCardNudge(cardId, tone);
+
+          return (
+            <Card key={cardId} role="article" className="border border-slate-800/60 bg-slate-950/60">
+              <CardHeader className="flex flex-row items-start gap-4">
+                <div className={cn('flex h-10 w-10 items-center justify-center rounded-full', config.accent)}>
+                  <CardIcon className="h-5 w-5" aria-hidden />
+                </div>
+                <div>
+                  <CardTitle className="text-base text-slate-100">{config.title}</CardTitle>
+                  <CardDescription className="text-slate-300">{nudge}</CardDescription>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <p className="text-sm text-slate-300">{config.description}</p>
+                <Button asChild variant="ghost" className="justify-start gap-2 px-0 text-slate-200 hover:text-slate-50">
+                  <Link to={config.to} aria-label={`${config.title} - ouvrir`} className="flex items-center gap-2">
+                    <span>Découvrir</span>
+                    <span aria-hidden className="font-semibold text-slate-100">→</span>
+                  </Link>
+                </Button>
+              </CardContent>
+            </Card>
+          );
+        })
+      </div>
+    </section>
+  );
+};
+
+export default DashboardCards;

--- a/src/features/dashboard/PrimaryCTA.tsx
+++ b/src/features/dashboard/PrimaryCTA.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { ArrowRight, Feather, MessageCircle, Music, PenTool, Scan, Sparkles, Wind } from 'lucide-react';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import type { Who5Tone, Who5Orchestration } from '@/features/orchestration/useWho5Orchestration';
+import { cn } from '@/lib/utils';
+
+type PrimaryCTAProps = {
+  kind: Who5Orchestration['primaryCta'];
+  tone: Who5Tone;
+};
+
+type CtaConfig = {
+  label: string;
+  description: string;
+  to: string;
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+};
+
+const CTA_COPY: Record<Who5Orchestration['primaryCta'], CtaConfig> = {
+  breath_soft: {
+    label: 'Respirer doucement',
+    description: 'Un instant guidé pour laisser retomber la tension.',
+    to: '/app/breath',
+    icon: Wind,
+  },
+  nyvee_calm: {
+    label: 'Parler à Nyvée',
+    description: 'Une écoute immédiate pour déposer ce qui pèse.',
+    to: '/app/coach',
+    icon: MessageCircle,
+  },
+  journal_light: {
+    label: 'Écrire quelques mots',
+    description: 'Un petit récit pour éclairer le moment présent.',
+    to: '/app/journal',
+    icon: PenTool,
+  },
+  music_soft: {
+    label: 'Lancer une ambiance douce',
+    description: 'Un cocon sonore sur mesure pour prolonger l’apaisement.',
+    to: '/app/music',
+    icon: Music,
+  },
+  scan: {
+    label: 'Observer mon état',
+    description: 'Un scan calme pour prendre le pouls intérieur.',
+    to: '/app/scan',
+    icon: Scan,
+  },
+  coach_micro: {
+    label: 'Bouger en douceur',
+    description: 'Une micro-action guidée pour canaliser l’énergie.',
+    to: '/app/coach-micro',
+    icon: Sparkles,
+  },
+};
+
+const TONE_ACCENTS: Record<Who5Tone, string> = {
+  very_low: 'from-sky-950/40 via-sky-900/20 to-slate-900/30',
+  low: 'from-sky-900/30 via-slate-900/20 to-purple-900/20',
+  neutral: 'from-slate-900/20 via-slate-800/20 to-slate-900/20',
+  high: 'from-purple-900/30 via-indigo-900/20 to-slate-900/20',
+  very_high: 'from-amber-900/30 via-purple-900/20 to-slate-900/20',
+};
+
+const ICON_BACKGROUNDS: Record<Who5Tone, string> = {
+  very_low: 'bg-sky-900/50 text-sky-100',
+  low: 'bg-sky-800/50 text-sky-100',
+  neutral: 'bg-slate-800/60 text-slate-100',
+  high: 'bg-indigo-800/60 text-indigo-100',
+  very_high: 'bg-amber-800/60 text-amber-100',
+};
+
+const SecondaryIcon: React.FC = () => (
+  <Feather className="h-5 w-5 text-slate-200/60" aria-hidden />
+);
+
+export const PrimaryCTA: React.FC<PrimaryCTAProps> = ({ kind, tone }) => {
+  const config = CTA_COPY[kind];
+  const AccentIcon = config.icon;
+
+  return (
+    <Card
+      className={cn(
+        'relative overflow-hidden border-none bg-gradient-to-r text-slate-100 shadow-lg shadow-slate-950/40',
+        TONE_ACCENTS[tone],
+      )}
+      aria-label="Suggestion principale du jour"
+    >
+      <CardHeader className="flex flex-row items-start justify-between gap-4">
+        <div className={cn('flex h-12 w-12 items-center justify-center rounded-full', ICON_BACKGROUNDS[tone])}>
+          <AccentIcon className="h-6 w-6" aria-hidden />
+        </div>
+        <SecondaryIcon />
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div>
+          <CardTitle className="text-xl font-semibold text-slate-50">{config.label}</CardTitle>
+          <CardDescription className="text-slate-200/80">{config.description}</CardDescription>
+        </div>
+        <Button asChild variant="secondary" className="bg-slate-100 text-slate-900 hover:bg-slate-50">
+          <Link to={config.to} className="flex items-center gap-2" aria-label={`${config.label} - ouvrir`}>
+            <span>{config.label}</span>
+            <ArrowRight className="h-4 w-4" aria-hidden />
+          </Link>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default PrimaryCTA;

--- a/src/features/dashboard/Who5InviteBanner.tsx
+++ b/src/features/dashboard/Who5InviteBanner.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
+import { HeartHandshake } from 'lucide-react';
+
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import type { Who5Tone } from '@/features/orchestration/useWho5Orchestration';
+import { cn } from '@/lib/utils';
+
+interface Who5InviteBannerProps {
+  summary: string;
+  tone: Who5Tone;
+  onStart: () => Promise<void>;
+  onSnooze?: () => void;
+}
+
+const toneBackground: Record<Who5Tone, string> = {
+  very_low: 'from-sky-950/60 via-slate-900/50 to-slate-900/40',
+  low: 'from-sky-900/60 via-slate-900/40 to-purple-900/40',
+  neutral: 'from-slate-900/50 via-slate-800/40 to-slate-900/40',
+  high: 'from-indigo-900/50 via-purple-900/40 to-slate-900/40',
+  very_high: 'from-amber-900/50 via-purple-900/40 to-slate-900/40',
+};
+
+export const Who5InviteBanner: React.FC<Who5InviteBannerProps> = ({ summary, tone, onStart, onSnooze }) => {
+  const prefersReducedMotion = useReducedMotion();
+
+  const content = (
+    <Card
+      role="region"
+      aria-label="Invitation à partager votre ressenti"
+      className={cn(
+        'overflow-hidden border-none bg-gradient-to-r text-slate-100 shadow-md shadow-slate-950/30',
+        toneBackground[tone],
+      )}
+    >
+      <CardContent className="flex flex-col gap-4 p-5 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-start gap-4">
+          <div className="mt-1 rounded-full bg-slate-900/60 p-2">
+            <HeartHandshake className="h-6 w-6 text-slate-100" aria-hidden />
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm font-semibold uppercase tracking-wide text-slate-200">Écoute hebdomadaire</p>
+            <p className="text-base text-slate-100">Partagez comment vous allez aujourd’hui.</p>
+            <p className="text-sm text-slate-200/80">{summary}</p>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            variant="secondary"
+            className="bg-slate-100 text-slate-900 hover:bg-slate-50"
+            onClick={() => {
+              void onStart();
+            }}
+          >
+            D’accord
+          </Button>
+          <Button
+            variant="ghost"
+            className="text-slate-100 hover:bg-slate-100/10"
+            onClick={() => onSnooze?.()}
+          >
+            Plus tard
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+
+  if (prefersReducedMotion) {
+    return content;
+  }
+
+  return (
+    <motion.div initial={{ opacity: 0, y: -12 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4, ease: 'easeOut' }}>
+      {content}
+    </motion.div>
+  );
+};
+
+export default Who5InviteBanner;

--- a/src/features/dashboard/ZeroNumberBoundary.tsx
+++ b/src/features/dashboard/ZeroNumberBoundary.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useRef } from 'react';
+
+interface ZeroNumberBoundaryProps {
+  children: React.ReactNode;
+}
+
+export const ZeroNumberBoundary: React.FC<ZeroNumberBoundaryProps> = ({ children }) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const textContent = container.textContent ?? '';
+    if (/\d/.test(textContent)) {
+      console.warn('[ZeroNumberBoundary] Numeric characters detected in rendered content.');
+    }
+  }, [children]);
+
+  return (
+    <div ref={containerRef} data-zero-number-boundary>
+      {children}
+    </div>
+  );
+};
+
+export default ZeroNumberBoundary;

--- a/src/features/dashboard/__tests__/nudges.test.ts
+++ b/src/features/dashboard/__tests__/nudges.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { cardNudges, listAllNudges, toneMessages } from '../nudges';
+
+describe('dashboard nudges copy', () => {
+  it('contains entries for every tone and locale', () => {
+    Object.values(toneMessages).forEach((localeMap) => {
+      expect(localeMap.fr.headline.length).toBeGreaterThan(0);
+      expect(localeMap.en.headline.length).toBeGreaterThan(0);
+    });
+
+    Object.values(cardNudges).forEach((toneMap) => {
+      Object.values(toneMap).forEach((localeMap) => {
+        expect(localeMap.fr.length).toBeGreaterThan(0);
+        expect(localeMap.en.length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  it('never exposes numerical characters', () => {
+    listAllNudges().forEach((entry) => {
+      expect(entry).not.toMatch(/\d/);
+    });
+  });
+});

--- a/src/features/dashboard/nudges.ts
+++ b/src/features/dashboard/nudges.ts
@@ -1,0 +1,229 @@
+import type { Who5Tone } from '@/features/orchestration/useWho5Orchestration';
+
+export type DashboardCardId =
+  | 'card-nyvee'
+  | 'card-breath'
+  | 'card-music'
+  | 'card-journal'
+  | 'card-scan'
+  | 'card-coach';
+
+type Locale = 'fr' | 'en';
+
+interface ToneCopy {
+  headline: string;
+  helper: string;
+}
+
+type ToneDictionary = Record<Who5Tone, Record<Locale, ToneCopy>>;
+
+type CardToneCopy = Record<DashboardCardId, Record<Who5Tone, Record<Locale, string>>>;
+
+export const toneMessages: ToneDictionary = {
+  very_low: {
+    fr: {
+      headline: 'On reste tout en douceur',
+      helper: 'Respirons ensemble et laissons venir les sensations.',
+    },
+    en: {
+      headline: 'We stay gentle',
+      helper: 'Let’s breathe together and welcome whatever shows up.',
+    },
+  },
+  low: {
+    fr: {
+      headline: 'Un tempo tranquille',
+      helper: 'De petits gestes tendres pour se réconforter.',
+    },
+    en: {
+      headline: 'A calm tempo',
+      helper: 'Small, kind gestures to feel supported.',
+    },
+  },
+  neutral: {
+    fr: {
+      headline: 'Équilibre maintenu',
+      helper: 'On observe et on ajuste si besoin.',
+    },
+    en: {
+      headline: 'Steady balance',
+      helper: 'We observe and adapt whenever it feels right.',
+    },
+  },
+  high: {
+    fr: {
+      headline: 'Bel élan repéré',
+      helper: 'Nourrissons cette énergie avec une action inspirante.',
+    },
+    en: {
+      headline: 'A bright spark',
+      helper: 'Nurture the momentum with an inspiring action.',
+    },
+  },
+  very_high: {
+    fr: {
+      headline: 'Énergie vive',
+      helper: 'Canalisons cet élan dans une micro-action tonique.',
+    },
+    en: {
+      headline: 'Vivid energy',
+      helper: 'Channel the momentum into a gentle micro action.',
+    },
+  },
+};
+
+export const cardNudges: CardToneCopy = {
+  'card-nyvee': {
+    very_low: {
+      fr: 'Nyvée écoute tout en douceur, sans pression.',
+      en: 'Nyvée listens softly, with zero pressure.',
+    },
+    low: {
+      fr: 'Un mot à Nyvée peut alléger le coeur.',
+      en: 'A note to Nyvée can lighten the heart.',
+    },
+    neutral: {
+      fr: 'Nyvée reste disponible pour un point d’étape.',
+      en: 'Nyvée is ready for a quick check-in.',
+    },
+    high: {
+      fr: 'Partagez cette énergie avec Nyvée pour la canaliser.',
+      en: 'Share the momentum with Nyvée to help channel it.',
+    },
+    very_high: {
+      fr: 'Nyvée transforme l’élan en inspiration concrète.',
+      en: 'Nyvée turns momentum into tangible inspiration.',
+    },
+  },
+  'card-breath': {
+    very_low: {
+      fr: 'Une respiration guidée pour déposer la tension.',
+      en: 'Guided breathing to soften any tension.',
+    },
+    low: {
+      fr: 'On suit le souffle et on laisse descendre les épaules.',
+      en: 'Follow the breath and let the shoulders fall.',
+    },
+    neutral: {
+      fr: 'Un souffle régulier pour rester présent.',
+      en: 'Steady breathing to stay grounded.',
+    },
+    high: {
+      fr: 'Respirer aide à garder l’élan en douceur.',
+      en: 'Breathing helps keep momentum gentle.',
+    },
+    very_high: {
+      fr: 'Un souffle ample pour accompagner l’énergie.',
+      en: 'Wide breathing to accompany the energy.',
+    },
+  },
+  'card-music': {
+    very_low: {
+      fr: 'Une ambiance feutrée pour se sentir enveloppé.',
+      en: 'A soft soundscape to feel held.',
+    },
+    low: {
+      fr: 'Laissez la musique bercer la journée.',
+      en: 'Let the music cradle your day.',
+    },
+    neutral: {
+      fr: 'Une atmosphère adaptée pour garder l’équilibre.',
+      en: 'A tailored atmosphere to sustain balance.',
+    },
+    high: {
+      fr: 'Un rythme vivant pour nourrir l’élan.',
+      en: 'A lively rhythm to feed the momentum.',
+    },
+    very_high: {
+      fr: 'Des textures sonores pour canaliser l’énergie.',
+      en: 'Sound textures to channel the energy.',
+    },
+  },
+  'card-journal': {
+    very_low: {
+      fr: 'Quelques mots pour déposer le ressenti.',
+      en: 'A few words to lay down the feeling.',
+    },
+    low: {
+      fr: 'Noter une sensation aide à clarifier l’instant.',
+      en: 'Writing a sensation can clarify the moment.',
+    },
+    neutral: {
+      fr: 'Un court récit pour garder le cap.',
+      en: 'A short note to stay on course.',
+    },
+    high: {
+      fr: 'Décrire l’énergie la rend plus concrète.',
+      en: 'Describing the energy makes it tangible.',
+    },
+    very_high: {
+      fr: 'Une micro-note pour orienter l’élan.',
+      en: 'A micro note to steer the momentum.',
+    },
+  },
+  'card-scan': {
+    very_low: {
+      fr: 'Un scan tout en douceur pour observer sans juger.',
+      en: 'A gentle scan to observe without judging.',
+    },
+    low: {
+      fr: 'Observer l’émotion aide à mieux la comprendre.',
+      en: 'Observing the emotion helps understand it.',
+    },
+    neutral: {
+      fr: 'Un point d’étape pour rester aligné.',
+      en: 'A quick check to stay aligned.',
+    },
+    high: {
+      fr: 'Un scan transforme l’énergie en données utiles.',
+      en: 'A scan turns energy into helpful insights.',
+    },
+    very_high: {
+      fr: 'Observer l’élan permet de le guider finement.',
+      en: 'Watching the momentum lets you guide it with care.',
+    },
+  },
+  'card-coach': {
+    very_low: {
+      fr: 'Un micro-mouvement pour relancer tout en douceur.',
+      en: 'A micro move to restart softly.',
+    },
+    low: {
+      fr: 'Un geste léger pour réveiller l’envie.',
+      en: 'A light move to awaken motivation.',
+    },
+    neutral: {
+      fr: 'Une petite action entretient l’équilibre.',
+      en: 'A small action maintains balance.',
+    },
+    high: {
+      fr: 'Le coach propose une action vive pour prolonger l’élan.',
+      en: 'The coach suggests a spirited action to sustain momentum.',
+    },
+    very_high: {
+      fr: 'Canalisez l’énergie dans une micro-action tonique.',
+      en: 'Channel the energy into a vibrant micro action.',
+    },
+  },
+};
+
+export const getToneCopy = (tone: Who5Tone, locale: Locale = 'fr'): ToneCopy => toneMessages[tone][locale];
+
+export const getCardNudge = (card: DashboardCardId, tone: Who5Tone, locale: Locale = 'fr'): string =>
+  cardNudges[card]?.[tone]?.[locale] ?? '';
+
+export const listAllNudges = (): string[] => {
+  const entries: string[] = [];
+  (Object.keys(toneMessages) as Who5Tone[]).forEach((tone) => {
+    const toneEntry = toneMessages[tone];
+    entries.push(toneEntry.fr.headline, toneEntry.fr.helper, toneEntry.en.headline, toneEntry.en.helper);
+  });
+  (Object.keys(cardNudges) as DashboardCardId[]).forEach((card) => {
+    const toneMap = cardNudges[card];
+    (Object.keys(toneMap) as Who5Tone[]).forEach((tone) => {
+      const localeMap = toneMap[tone];
+      entries.push(localeMap.fr, localeMap.en);
+    });
+  });
+  return entries;
+};

--- a/src/features/orchestration/__tests__/useWho5Orchestration.test.ts
+++ b/src/features/orchestration/__tests__/useWho5Orchestration.test.ts
@@ -1,0 +1,102 @@
+import dayjs from 'dayjs';
+import isoWeek from 'dayjs/plugin/isoWeek';
+import { describe, expect, it } from 'vitest';
+
+import {
+  getToneFromLevel,
+  getPrimaryCtaFromLevel,
+  getCardOrderFromLevel,
+  isWho5Due,
+} from '../useWho5Orchestration';
+
+dayjs.extend(isoWeek);
+
+describe('WHO-5 orchestration mapping', () => {
+  it('maps level to tone consistently', () => {
+    expect(getToneFromLevel(0)).toBe('very_low');
+    expect(getToneFromLevel(1)).toBe('low');
+    expect(getToneFromLevel(2)).toBe('neutral');
+    expect(getToneFromLevel(3)).toBe('high');
+    expect(getToneFromLevel(4)).toBe('very_high');
+    expect(getToneFromLevel(99)).toBe('very_high');
+  });
+
+  it('maps level to primary CTA', () => {
+    expect(getPrimaryCtaFromLevel(0)).toBe('breath_soft');
+    expect(getPrimaryCtaFromLevel(1)).toBe('nyvee_calm');
+    expect(getPrimaryCtaFromLevel(2)).toBe('scan');
+    expect(getPrimaryCtaFromLevel(3)).toBe('music_soft');
+    expect(getPrimaryCtaFromLevel(4)).toBe('coach_micro');
+  });
+
+  it('orders cards according to tone', () => {
+    expect(getCardOrderFromLevel(0)[0]).toBe('card-nyvee');
+    expect(getCardOrderFromLevel(2)[0]).toBe('card-scan');
+    expect(getCardOrderFromLevel(4)[0]).toBe('card-coach');
+  });
+});
+
+describe('WHO-5 due computation', () => {
+  const reference = dayjs('2024-05-15T10:00:00.000Z');
+
+  const baseInput = {
+    snoozedUntil: null as string | null,
+    hasConsent: true,
+    isFlagEnabled: true,
+    canDisplay: true,
+    zeroNumbersReady: true,
+    now: reference,
+  };
+
+  it('does not trigger when same ISO week already recorded', () => {
+    const lastCompletedAt = reference.toISOString();
+    expect(
+      isWho5Due({
+        ...baseInput,
+        lastCompletedAt,
+      }),
+    ).toBe(false);
+  });
+
+  it('triggers when previous week', () => {
+    const lastCompletedAt = reference.subtract(1, 'week').toISOString();
+    expect(
+      isWho5Due({
+        ...baseInput,
+        lastCompletedAt,
+      }),
+    ).toBe(true);
+  });
+
+  it('respects snooze period', () => {
+    const snoozedUntil = reference.add(2, 'hour').toISOString();
+    expect(
+      isWho5Due({
+        ...baseInput,
+        lastCompletedAt: undefined,
+        snoozedUntil,
+      }),
+    ).toBe(false);
+  });
+
+  it('requires consent and flags', () => {
+    expect(
+      isWho5Due({
+        ...baseInput,
+        hasConsent: false,
+      }),
+    ).toBe(false);
+    expect(
+      isWho5Due({
+        ...baseInput,
+        isFlagEnabled: false,
+      }),
+    ).toBe(false);
+    expect(
+      isWho5Due({
+        ...baseInput,
+        zeroNumbersReady: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/features/orchestration/useWho5Orchestration.ts
+++ b/src/features/orchestration/useWho5Orchestration.ts
@@ -1,0 +1,254 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import * as Sentry from '@sentry/react';
+import dayjs from 'dayjs';
+import isoWeek from 'dayjs/plugin/isoWeek';
+
+import { useAssessment } from '@/hooks/useAssessment';
+import { useAssessmentHistory } from '@/hooks/useAssessmentHistory';
+import { useConsent } from '@/features/clinical-optin/ConsentProvider';
+import { useFlags } from '@/core/flags';
+
+export type Who5Tone = 'very_low' | 'low' | 'neutral' | 'high' | 'very_high';
+
+export interface Who5Orchestration {
+  due: boolean;
+  start: () => Promise<void>;
+  apply: () => void;
+  tone: Who5Tone;
+  primaryCta: 'breath_soft' | 'nyvee_calm' | 'journal_light' | 'music_soft' | 'scan' | 'coach_micro';
+  cardOrder: string[];
+  summaryLabel: string;
+  snooze: (durationHours?: number) => void;
+}
+
+dayjs.extend(isoWeek);
+
+const SNOOZE_STORAGE_KEY = 'who5.invite.snooze_until';
+const DEFAULT_SUMMARY = 'équilibre stable';
+
+type CardOrderMapping = Record<Who5Tone, string[]>;
+
+type PrimaryCtaMapping = Record<Who5Tone, Who5Orchestration['primaryCta']>;
+
+const CARD_ORDER: CardOrderMapping = {
+  very_low: ['card-nyvee', 'card-breath', 'card-music', 'card-journal', 'card-scan', 'card-coach'],
+  low: ['card-nyvee', 'card-breath', 'card-journal', 'card-music', 'card-scan', 'card-coach'],
+  neutral: ['card-scan', 'card-journal', 'card-music', 'card-nyvee', 'card-breath', 'card-coach'],
+  high: ['card-music', 'card-journal', 'card-scan', 'card-nyvee', 'card-coach', 'card-breath'],
+  very_high: ['card-coach', 'card-music', 'card-scan', 'card-journal', 'card-nyvee', 'card-breath'],
+};
+
+const PRIMARY_CTA: PrimaryCtaMapping = {
+  very_low: 'breath_soft',
+  low: 'nyvee_calm',
+  neutral: 'scan',
+  high: 'music_soft',
+  very_high: 'coach_micro',
+};
+
+const clampLevel = (value: number): 0 | 1 | 2 | 3 | 4 => {
+  if (value <= 0) return 0;
+  if (value === 1) return 1;
+  if (value === 2) return 2;
+  if (value === 3) return 3;
+  return 4;
+};
+
+const resolveTone = (level: number): Who5Tone => {
+  const safeLevel = clampLevel(level);
+  if (safeLevel === 0) return 'very_low';
+  if (safeLevel === 1) return 'low';
+  if (safeLevel === 2) return 'neutral';
+  if (safeLevel === 3) return 'high';
+  return 'very_high';
+};
+
+const sanitizeSummary = (summary?: string | null): string => {
+  if (!summary) {
+    return DEFAULT_SUMMARY;
+  }
+  const cleaned = summary.replace(/\d/g, '').trim();
+  return cleaned.length ? cleaned : DEFAULT_SUMMARY;
+};
+
+const readStoredSnooze = (): string | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    const value = window.localStorage.getItem(SNOOZE_STORAGE_KEY);
+    return value ?? null;
+  } catch (error) {
+    console.warn('[who5] unable to read snooze value', error);
+    return null;
+  }
+};
+
+const persistSnooze = (value: string | null) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    if (!value) {
+      window.localStorage.removeItem(SNOOZE_STORAGE_KEY);
+      return;
+    }
+    window.localStorage.setItem(SNOOZE_STORAGE_KEY, value);
+  } catch (error) {
+    console.warn('[who5] unable to persist snooze value', error);
+  }
+};
+
+const isoWeekKey = (date: dayjs.Dayjs) => `${date.isoWeekYear()}-${date.isoWeek()}`;
+
+interface DueComputationInput {
+  lastCompletedAt?: string;
+  snoozedUntil?: string | null;
+  hasConsent: boolean;
+  isFlagEnabled: boolean;
+  canDisplay: boolean;
+  zeroNumbersReady: boolean;
+  now?: dayjs.Dayjs;
+}
+
+export const isWho5Due = ({
+  lastCompletedAt,
+  snoozedUntil,
+  hasConsent,
+  isFlagEnabled,
+  canDisplay,
+  zeroNumbersReady,
+  now = dayjs(),
+}: DueComputationInput): boolean => {
+  if (!hasConsent || !isFlagEnabled || !canDisplay || !zeroNumbersReady) {
+    return false;
+  }
+
+  if (snoozedUntil) {
+    const snoozeDate = dayjs(snoozedUntil);
+    if (snoozeDate.isValid() && snoozeDate.isAfter(now)) {
+      return false;
+    }
+  }
+
+  if (!lastCompletedAt) {
+    return true;
+  }
+
+  const lastDate = dayjs(lastCompletedAt);
+  if (!lastDate.isValid()) {
+    return true;
+  }
+
+  return isoWeekKey(lastDate) !== isoWeekKey(now);
+};
+
+export const getToneFromLevel = (level: number): Who5Tone => resolveTone(level);
+
+export const getPrimaryCtaFromLevel = (level: number): Who5Orchestration['primaryCta'] => {
+  const tone = resolveTone(level);
+  return PRIMARY_CTA[tone];
+};
+
+export const getCardOrderFromLevel = (level: number): string[] => {
+  const tone = resolveTone(level);
+  return CARD_ORDER[tone];
+};
+
+export function useWho5Orchestration(): Who5Orchestration {
+  const { clinicalAccepted } = useConsent();
+  const { flags } = useFlags();
+  const zeroNumbersReady = flags.FF_ZERO_NUMBERS ?? true;
+  const who5Assessment = useAssessment('WHO5');
+  const history = useAssessmentHistory('WHO5', {
+    limit: 1,
+    enabled: clinicalAccepted && who5Assessment.state.canDisplay,
+  });
+
+  const [snoozedUntil, setSnoozedUntil] = useState<string | null>(() => readStoredSnooze());
+
+  useEffect(() => {
+    persistSnooze(snoozedUntil);
+  }, [snoozedUntil]);
+
+  const lastHistoryEntry = history.data?.[0];
+  const lastComputation = who5Assessment.state.lastComputation;
+  const lastLevel = lastComputation?.level ?? lastHistoryEntry?.level ?? 2;
+  const tone = resolveTone(lastLevel);
+  const cardOrder = CARD_ORDER[tone];
+  const primaryCta = PRIMARY_CTA[tone];
+  const summaryLabel = sanitizeSummary(lastComputation?.summary ?? lastHistoryEntry?.summary ?? DEFAULT_SUMMARY);
+  const lastCompletedAt = who5Assessment.state.lastCompletedAt ?? lastHistoryEntry?.timestamp;
+
+  const due = useMemo(
+    () =>
+      isWho5Due({
+        lastCompletedAt,
+        snoozedUntil,
+        hasConsent: clinicalAccepted,
+        isFlagEnabled: who5Assessment.state.isFlagEnabled,
+        canDisplay: who5Assessment.state.canDisplay,
+        zeroNumbersReady,
+      }),
+    [clinicalAccepted, lastCompletedAt, snoozedUntil, who5Assessment.state.canDisplay, who5Assessment.state.isFlagEnabled, zeroNumbersReady],
+  );
+
+  const inviteLoggedRef = useRef<string | null>(null);
+  const submittedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!due) {
+      return;
+    }
+    const now = dayjs();
+    const key = isoWeekKey(now);
+    if (inviteLoggedRef.current === key) {
+      return;
+    }
+    inviteLoggedRef.current = key;
+    Sentry.addBreadcrumb({ category: 'who5', message: 'who5:invite_shown', level: 'info', data: { tone } });
+  }, [due, tone]);
+
+  useEffect(() => {
+    if (!lastCompletedAt) {
+      return;
+    }
+    if (submittedRef.current === lastCompletedAt) {
+      return;
+    }
+    submittedRef.current = lastCompletedAt;
+    setSnoozedUntil(null);
+    Sentry.addBreadcrumb({ category: 'who5', message: 'who5:submitted', level: 'info', data: { tone } });
+  }, [lastCompletedAt, tone]);
+
+  const start = useCallback(async () => {
+    Sentry.addBreadcrumb({ category: 'who5', message: 'who5:start_clicked', level: 'info', data: { tone } });
+    await who5Assessment.start();
+  }, [tone, who5Assessment]);
+
+  const apply = useCallback(() => {
+    Sentry.addBreadcrumb({ category: 'who5', message: 'who5:applied', level: 'info', data: { tone, level: clampLevel(lastLevel) } });
+  }, [lastLevel, tone]);
+
+  const snooze = useCallback(
+    (durationHours = 48) => {
+      const until = dayjs().add(durationHours, 'hour').toISOString();
+      setSnoozedUntil(until);
+      Sentry.addBreadcrumb({ category: 'who5', message: 'who5:skipped', level: 'info', data: { tone, durationHours } });
+    },
+    [tone],
+  );
+
+  return {
+    due,
+    start,
+    apply,
+    tone,
+    primaryCta,
+    cardOrder,
+    summaryLabel,
+    snooze,
+  };
+}
+
+export type { CardOrderMapping };

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect } from 'react';
+
+import PageSEO from '@/components/seo/PageSEO';
+import { PrimaryCTA } from '@/features/dashboard/PrimaryCTA';
+import { DashboardCards } from '@/features/dashboard/DashboardCards';
+import { Who5InviteBanner } from '@/features/dashboard/Who5InviteBanner';
+import { ZeroNumberBoundary } from '@/features/dashboard/ZeroNumberBoundary';
+import { useWho5Orchestration } from '@/features/orchestration/useWho5Orchestration';
+
+const HomePage: React.FC = () => {
+  const who5 = useWho5Orchestration();
+
+  useEffect(() => {
+    who5.apply();
+  }, [who5]);
+
+  return (
+    <ZeroNumberBoundary>
+      <div className="min-h-screen bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950 text-slate-100">
+        <PageSEO title="Plan du jour" description="Un plan du jour vivant, sans chiffres, guidé par votre ressenti." />
+        <main className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8 sm:px-6 lg:px-8" aria-label="Plan du jour">
+          <header className="space-y-2">
+            <p className="text-sm uppercase tracking-[0.3em] text-slate-400">Plan du jour</p>
+            <h1 className="text-3xl font-semibold text-slate-50">{who5.summaryLabel}</h1>
+            <p className="max-w-2xl text-sm text-slate-300">
+              Chaque proposition s’adapte à vos réponses récentes au mini questionnaire bien-être.
+            </p>
+          </header>
+
+          {who5.due && (
+            <Who5InviteBanner summary={who5.summaryLabel} tone={who5.tone} onStart={who5.start} onSnooze={() => who5.snooze()} />
+          )}
+
+          <PrimaryCTA kind={who5.primaryCta} tone={who5.tone} />
+
+          <DashboardCards order={who5.cardOrder} tone={who5.tone} />
+        </main>
+      </div>
+    </ZeroNumberBoundary>
+  );
+};
+
+export default HomePage;


### PR DESCRIPTION
## Summary
- introduce a WHO-5 orchestration hook that reads consent, history and feature flags to derive tone, CTA, card order and Sentry breadcrumbs
- build dashboard components (invite banner, primary CTA, card grid, zero-number boundary) driven by the orchestration profile with non-numeric nudges
- rework the /app/home page to surface the adaptive plan du jour and add unit coverage for mappings and nudge copy guards

## Testing
- npx vitest run src/features/orchestration/__tests__/useWho5Orchestration.test.ts src/features/dashboard/__tests__/nudges.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cee2aa5740832da8bded0d4739038b