### PR TITLE
feat: add flash glow orchestrator and SUDS integration

### DIFF
--- a/src/features/assess/api.ts
+++ b/src/features/assess/api.ts
@@ -1,3 +1,48 @@
+export interface AssessmentStartOptions {
+  locale?: string;
+  stage?: 'pre' | 'post';
+}
+
+export interface AssessmentItem {
+  id: string;
+  prompt: string;
+  type: 'scale' | 'choice' | 'slider' | 'text';
+  options?: string[];
+  min?: number;
+  max?: number;
+}
+
+export interface AssessmentStartResponse {
+  instrument: string;
+  locale: string;
+  name: string;
+  version: string;
+  items: AssessmentItem[];
+}
+
+export async function startAssessment(
+  instrument: string,
+  options: AssessmentStartOptions = {},
+): Promise<AssessmentStartResponse> {
+  const res = await fetch('/functions/v1/assess-start', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      instrument,
+      locale: options.locale,
+      stage: options.stage,
+    }),
+  });
+
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const errorMessage = typeof (data as { error?: string })?.error === 'string' ? (data as { error?: string }).error : 'assess_start_failed';
+    throw new Error(errorMessage);
+  }
+
+  return data as AssessmentStartResponse;
+}
+
 export async function submitAssessment(
   instrument: string,
   answers: Record<string, number>,
@@ -11,7 +56,7 @@ export async function submitAssessment(
 
   const data = await res.json().catch(() => ({}));
   if (!res.ok) {
-    const errorMessage = typeof data?.error === 'string' ? data.error : 'assess_submit_failed';
+    const errorMessage = typeof (data as { error?: string })?.error === 'string' ? (data as { error?: string }).error : 'assess_submit_failed';
     throw new Error(errorMessage);
   }
 

--- a/src/features/assess/useAssessment.ts
+++ b/src/features/assess/useAssessment.ts
@@ -1,0 +1,153 @@
+import { useCallback, useMemo, useState } from 'react';
+import * as Sentry from '@sentry/react';
+
+import { startAssessment, submitAssessment, type AssessmentStartResponse } from './api';
+
+export type AssessmentStage = 'pre' | 'post';
+
+interface AssessmentState {
+  stage: AssessmentStage | null;
+  isStarting: boolean;
+  isSubmitting: boolean;
+  prompt: string | null;
+  summary: string | null;
+  error: string | null;
+  lastStartedAt: string | null;
+  catalog?: AssessmentStartResponse;
+}
+
+interface StartResult {
+  stage: AssessmentStage;
+  startedAt: string;
+  response: AssessmentStartResponse;
+}
+
+interface SubmitResult {
+  stage: AssessmentStage;
+  submittedAt: string;
+  summary: string;
+}
+
+export interface UseAssessmentResult {
+  instrument: string;
+  state: AssessmentState;
+  start: (stage: AssessmentStage) => Promise<StartResult | null>;
+  submit: (stage: AssessmentStage, answers: Record<string, number>, options?: { ts?: string }) => Promise<SubmitResult | null>;
+  reset: () => void;
+}
+
+const initialState: AssessmentState = {
+  stage: null,
+  isStarting: false,
+  isSubmitting: false,
+  prompt: null,
+  summary: null,
+  error: null,
+  lastStartedAt: null,
+  catalog: undefined,
+};
+
+export function useAssessment(instrument: string): UseAssessmentResult {
+  const [state, setState] = useState<AssessmentState>(initialState);
+
+  const start = useCallback<UseAssessmentResult['start']>(
+    async (stage) => {
+      setState((prev) => ({
+        ...prev,
+        stage,
+        isStarting: true,
+        error: null,
+      }));
+
+      try {
+        const response = await startAssessment(instrument, { locale: 'fr', stage });
+        const startedAt = new Date().toISOString();
+
+        Sentry.addBreadcrumb({
+          category: 'assess',
+          level: 'info',
+          message: 'assessment:start',
+          data: { instrument, stage },
+        });
+
+        setState((prev) => ({
+          ...prev,
+          stage,
+          isStarting: false,
+          prompt: response.items[0]?.prompt ?? null,
+          catalog: response,
+          lastStartedAt: startedAt,
+          error: null,
+        }));
+
+        return { stage, startedAt, response };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'assessment_start_failed';
+        Sentry.captureException(error, {
+          tags: { scope: 'useAssessment', instrument },
+          extra: { stage },
+        });
+        setState((prev) => ({
+          ...prev,
+          isStarting: false,
+          error: message,
+        }));
+        return null;
+      }
+    },
+    [instrument],
+  );
+
+  const submit = useCallback<UseAssessmentResult['submit']>(
+    async (stage, answers, options) => {
+      setState((prev) => ({
+        ...prev,
+        stage,
+        isSubmitting: true,
+        error: null,
+      }));
+
+      try {
+        const response = await submitAssessment(instrument, answers, options?.ts);
+        const submittedAt = new Date().toISOString();
+
+        Sentry.addBreadcrumb({
+          category: 'assess',
+          level: 'info',
+          message: 'assessment:submit',
+          data: { instrument, stage },
+        });
+
+        setState((prev) => ({
+          ...prev,
+          isSubmitting: false,
+          summary: response.summary,
+          error: null,
+        }));
+
+        return { stage, submittedAt, summary: response.summary };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'assessment_submit_failed';
+        Sentry.captureException(error, {
+          tags: { scope: 'useAssessment', instrument },
+          extra: { stage },
+        });
+        setState((prev) => ({
+          ...prev,
+          isSubmitting: false,
+          error: message,
+        }));
+        return null;
+      }
+    },
+    [instrument],
+  );
+
+  const reset = useCallback(() => {
+    setState(initialState);
+  }, []);
+
+  const value = useMemo<UseAssessmentResult>(() => ({ instrument, state, start, submit, reset }), [instrument, state, start, submit, reset]);
+
+  return value;
+}

--- a/src/features/orchestration/__tests__/flashGlow.orchestrator.spec.ts
+++ b/src/features/orchestration/__tests__/flashGlow.orchestrator.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeFlashGlowActions } from '../flashGlow.orchestrator';
+
+describe('computeFlashGlowActions', () => {
+  it('returns extension instructions when post level stays high', () => {
+    const result = computeFlashGlowActions({
+      preLevel: 3,
+      postLevel: 4,
+      optedIn: true,
+      prefersReducedMotion: false,
+    });
+
+    expect(result).toMatchObject({
+      extend_session: 60_000,
+      set_visuals_intensity: 'lowered',
+      set_breath_pattern: 'exhale_longer',
+      set_audio_fade: 'slow',
+      set_haptics: 'calm',
+    });
+    expect(result.soft_exit).toBeUndefined();
+    expect(result.post_cta).toBeUndefined();
+  });
+
+  it('prepares a soft exit flow when the post level calms down', () => {
+    const result = computeFlashGlowActions({
+      preLevel: 3,
+      postLevel: 1,
+      optedIn: true,
+      prefersReducedMotion: false,
+    });
+
+    expect(result).toMatchObject({
+      soft_exit: true,
+      toast_text: 'gratitude',
+      post_cta: 'screen_silk',
+      set_visuals_intensity: 'lowered',
+      set_breath_pattern: 'exhale_longer',
+      set_audio_fade: 'slow',
+      set_haptics: 'calm',
+    });
+    expect(result.extend_session).toBeUndefined();
+  });
+
+  it('prioritises motion reduction hints when prefers reduced motion', () => {
+    const result = computeFlashGlowActions({
+      preLevel: 2,
+      postLevel: 2,
+      optedIn: true,
+      prefersReducedMotion: true,
+    });
+
+    expect(result.set_haptics).toBe('off');
+    expect(result.set_visuals_intensity).toBe('lowered');
+    expect(result.post_cta).toBe('screen_silk');
+  });
+
+  it('handles the no consent path gracefully', () => {
+    const result = computeFlashGlowActions({
+      optedIn: false,
+      prefersReducedMotion: false,
+    });
+
+    expect(result).toEqual({});
+  });
+});

--- a/src/features/orchestration/flashGlow.orchestrator.ts
+++ b/src/features/orchestration/flashGlow.orchestrator.ts
@@ -1,0 +1,63 @@
+export type FlashGlowVisualIntensity = 'baseline' | 'lowered';
+export type FlashGlowBreathPattern = 'steady' | 'exhale_longer';
+export type FlashGlowAudioFade = 'gentle' | 'slow';
+export type FlashGlowHapticsSetting = 'default' | 'calm' | 'off';
+export type FlashGlowPostCta = 'screen_silk';
+export type FlashGlowToastText = 'gratitude';
+
+export interface FlashGlowActions {
+  extend_session?: number;
+  soft_exit?: boolean;
+  set_visuals_intensity?: FlashGlowVisualIntensity;
+  set_breath_pattern?: FlashGlowBreathPattern;
+  set_audio_fade?: FlashGlowAudioFade;
+  set_haptics?: FlashGlowHapticsSetting;
+  post_cta?: FlashGlowPostCta;
+  toast_text?: FlashGlowToastText;
+}
+
+export interface ComputeFlashGlowActionsInput {
+  preLevel?: number | null;
+  postLevel?: number | null;
+  prefersReducedMotion?: boolean;
+  optedIn?: boolean;
+}
+
+const HIGH_THRESHOLD = 3;
+const LOW_THRESHOLD = 1;
+const EXTEND_DURATION_MS = 60_000;
+
+export function computeFlashGlowActions(input: ComputeFlashGlowActionsInput): FlashGlowActions {
+  const { preLevel, postLevel, prefersReducedMotion, optedIn = true } = input;
+  const actions: FlashGlowActions = {};
+
+  if (prefersReducedMotion) {
+    actions.set_haptics = 'off';
+    actions.set_visuals_intensity = 'lowered';
+  }
+
+  const canUseSudsSignals = optedIn !== false;
+
+  if (canUseSudsSignals && typeof preLevel === 'number' && preLevel >= HIGH_THRESHOLD) {
+    actions.set_visuals_intensity = 'lowered';
+    actions.set_breath_pattern = 'exhale_longer';
+    actions.set_audio_fade = 'slow';
+    if (actions.set_haptics !== 'off') {
+      actions.set_haptics = 'calm';
+    }
+  }
+
+  if (canUseSudsSignals && typeof postLevel === 'number') {
+    if (postLevel >= HIGH_THRESHOLD) {
+      actions.extend_session = EXTEND_DURATION_MS;
+    } else if (postLevel <= LOW_THRESHOLD) {
+      actions.soft_exit = true;
+      actions.toast_text = 'gratitude';
+      actions.post_cta = 'screen_silk';
+    } else {
+      actions.post_cta = 'screen_silk';
+    }
+  }
+
+  return actions;
+}


### PR DESCRIPTION
## Summary
- introduce a reusable assessment hook that starts and submits SUDS stages through the existing API surface
- add the Flash Glow orchestration logic with unit coverage for the main mapping scenarios
- refactor the Flash Glow page to honour consent, trigger assessments, compute clinical intents, and surface reduced-motion friendly messaging

## Testing
- npx vitest run src/features/orchestration/__tests__/flashGlow.orchestrator.spec.ts
- npm run typecheck
- npm run lint (fails: parser errors in legacy assess catalog files)


------
https://chatgpt.com/codex/tasks/task_e_68cee8498f2c832da082d8f037115903