### PR TITLE
feat(vr): add adaptive orchestration and fallback flows

### DIFF
--- a/src/app/vr-breath-2d/page.tsx
+++ b/src/app/vr-breath-2d/page.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { ZeroNumberBoundary } from '@/components/a11y/ZeroNumberBoundary';
+
+const copy = {
+  title: 'Respiration sans mouvement',
+  intro: 'Un cocon immobile pour respirer en toute sécurité. Aucune caméra ne bouge, seul ton souffle guide le tempo.',
+  instruction: 'Allonge chaque sortie d’air et laisse la lumière rester stable autour de toi.',
+  ctaVr: 'Revenir vers la version immersive',
+  back: 'Explorer d’autres modules apaisants',
+};
+
+export default function VrBreath2DPage() {
+  return (
+    <ZeroNumberBoundary className="mx-auto flex min-h-screen max-w-3xl flex-col gap-6 px-6 py-12">
+      <section className="rounded-3xl bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-8 text-slate-100 shadow-lg transition-all duration-150 ease-out">
+        <h1 className="text-3xl font-semibold">{copy.title}</h1>
+        <p className="mt-4 text-sm leading-relaxed text-slate-200/80">{copy.intro}</p>
+        <div className="mt-6 rounded-2xl bg-slate-900/60 p-4 text-sm text-slate-100/80">
+          {copy.instruction}
+        </div>
+        <div className="mt-6 flex flex-wrap gap-3 text-sm">
+          <a
+            className="rounded-full bg-slate-100 px-5 py-2 font-semibold text-slate-900 transition-colors duration-150 ease-out hover:bg-slate-200"
+            href="/app/vr-breath"
+          >
+            {copy.ctaVr}
+          </a>
+          <a
+            className="rounded-full border border-slate-100/30 px-5 py-2 font-semibold text-slate-100 transition-colors duration-150 ease-out hover:bg-slate-100/10"
+            href="/app/music"
+          >
+            {copy.back}
+          </a>
+        </div>
+      </section>
+    </ZeroNumberBoundary>
+  );
+}

--- a/src/app/vr-breath/page.tsx
+++ b/src/app/vr-breath/page.tsx
@@ -1,0 +1,395 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import * as Sentry from '@sentry/react';
+
+import { ZeroNumberBoundary } from '@/components/a11y/ZeroNumberBoundary';
+import { useFlags } from '@/core/flags';
+import { useAssessment } from '@/hooks/useAssessment';
+import { createSession } from '@/services/sessions/sessionsApi';
+
+import { deriveBreathProfile } from '@/features/vr/deriveProfile';
+import useVRTier from '@/features/vr/useVRTier';
+import { computeBreathActions } from '@/features/vr/vrBreath.orchestrator';
+
+const COMFORT_LABELS: Record<'very_low' | 'low' | 'medium', string> = {
+  very_low: 'confort très doux',
+  low: 'confort doux',
+  medium: 'confort fluide',
+};
+
+const DURATION_LABELS: Record<'short' | 'normal', string> = {
+  short: 'scène courte',
+  normal: 'scène ample',
+};
+
+const LOCOMOTION_LABELS: Record<'teleport' | 'smooth', string> = {
+  teleport: 'déplacements par pauses',
+  smooth: 'glisse feutrée',
+};
+
+const FOV_LABELS: Record<'narrow' | 'default', string> = {
+  narrow: 'vision resserrée',
+  default: 'vision ouverte',
+};
+
+const AUDIO_LABELS: Record<'calm' | 'soft', string> = {
+  calm: 'paysage sonore calme',
+  soft: 'paysage sonore doux',
+};
+
+const GUIDANCE_LABELS: Record<'long_exhale' | 'none', string> = {
+  long_exhale: 'guidance longues expirations',
+  none: 'guidance légère',
+};
+
+const VIGNETTE_LABELS: Record<'none' | 'soft' | 'comfort', string> = {
+  none: 'halo neutre',
+  soft: 'halo délicat',
+  comfort: 'halo confort',
+};
+
+const PARTICLE_LABELS: Record<'low' | 'medium' | 'high', string> = {
+  low: 'particules très légères',
+  medium: 'particules douces',
+  high: 'particules riches',
+};
+
+const fallbackCopy = {
+  headline: 'Version sans mouvement conseillée',
+  body: "Ton confort passe avant tout. Tu peux savourer la version immobile aussi longtemps que tu le souhaites.",
+};
+
+const normalizeLevel = (value: number | undefined | null): 0 | 1 | 2 | 3 | 4 | undefined => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return undefined;
+  }
+  const clamped = Math.max(0, Math.min(4, Math.round(value)));
+  return clamped as 0 | 1 | 2 | 3 | 4;
+};
+
+const metaFromProfile = (profile: ReturnType<typeof deriveBreathProfile>) => ({
+  module: 'vr_breath',
+  comfort: COMFORT_LABELS[profile.comfort],
+  duration: DURATION_LABELS[profile.duration],
+  locomotion: LOCOMOTION_LABELS[profile.locomotion],
+  fov: FOV_LABELS[profile.fov],
+  audio: AUDIO_LABELS[profile.audio],
+  guidance: GUIDANCE_LABELS[profile.guidance],
+  vignette: VIGNETTE_LABELS[profile.vignette],
+  particules: PARTICLE_LABELS[profile.particles],
+  fallback_next: profile.fallback2dNext ? 'prévu' : 'non prévu',
+});
+
+export default function VrBreathPage() {
+  const { flags } = useFlags();
+  const tier = useVRTier();
+  const ssqAssessment = useAssessment('SSQ');
+  const tensionAssessment = useAssessment('POMS_TENSION');
+
+  const [sessionStartedAt, setSessionStartedAt] = useState<number | null>(null);
+  const [sessionActive, setSessionActive] = useState(false);
+  const [persisting, setPersisting] = useState(false);
+  const [sessionSaved, setSessionSaved] = useState(false);
+  const fallbackLoggedRef = useRef(false);
+  const ssqOfferLoggedRef = useRef(false);
+  const tensionOfferLoggedRef = useRef(false);
+
+  useEffect(() => {
+    Sentry.addBreadcrumb({ category: 'vr', level: 'info', message: 'vr:enter', data: { module: 'vr_breath' } });
+    return () => {
+      Sentry.addBreadcrumb({ category: 'vr', level: 'info', message: 'vr:exit', data: { module: 'vr_breath' } });
+    };
+  }, []);
+
+  const ssqLevel = normalizeLevel(ssqAssessment.state.lastComputation?.level ?? undefined);
+  const tensionLevel = normalizeLevel(tensionAssessment.state.lastComputation?.level ?? undefined);
+
+  const actions = useMemo(
+    () =>
+      computeBreathActions({
+        vrTier: tier.vrTier,
+        prm: tier.prm,
+        ssqLevel: ssqLevel,
+        tensionLevel: tensionLevel,
+      }),
+    [ssqLevel, tensionLevel, tier.prm, tier.vrTier],
+  );
+
+  const profile = useMemo(() => deriveBreathProfile(actions), [actions]);
+
+  useEffect(() => {
+    Sentry.addBreadcrumb({
+      category: 'vr',
+      level: 'info',
+      message: 'vr:actions:applied',
+      data: {
+        module: 'vr_breath',
+        comfort: profile.comfort,
+        duration: profile.duration,
+        locomotion: profile.locomotion,
+        fallback2d: profile.fallback2dNext,
+      },
+    });
+    Sentry.configureScope((scope) => {
+      scope.setTag('vr_module', 'vr_breath');
+      scope.setTag('vr_comfort', profile.comfort);
+      scope.setTag('vr_duration', profile.duration);
+      scope.setTag('vr_locomotion', profile.locomotion);
+      scope.setTag('vr_audio', profile.audio);
+    });
+  }, [profile]);
+
+  useEffect(() => {
+    const fallbackCondition = profile.fallback2dNext || !tier.supported || tier.prm || tier.fallbackReason === 'no_xr';
+    if (fallbackCondition && !fallbackLoggedRef.current) {
+      Sentry.addBreadcrumb({
+        category: 'vr',
+        level: 'warning',
+        message: 'fallback2d:set',
+        data: { module: 'vr_breath', reason: tier.fallbackReason ?? 'comfort' },
+      });
+      fallbackLoggedRef.current = true;
+    }
+  }, [profile.fallback2dNext, tier.fallbackReason, tier.prm, tier.supported]);
+
+  const ssqDue = ssqAssessment.isDue('post');
+  const tensionDue = tensionAssessment.isDue('post');
+
+  useEffect(() => {
+    if (ssqDue && !ssqOfferLoggedRef.current) {
+      Sentry.addBreadcrumb({ category: 'vr', level: 'info', message: 'ssq:post:offered', data: { module: 'vr_breath' } });
+      ssqOfferLoggedRef.current = true;
+    }
+  }, [ssqDue]);
+
+  useEffect(() => {
+    if (tensionDue && !tensionOfferLoggedRef.current) {
+      Sentry.addBreadcrumb({
+        category: 'vr',
+        level: 'info',
+        message: 'poms_tension:post:offered',
+        data: { module: 'vr_breath' },
+      });
+      tensionOfferLoggedRef.current = true;
+    }
+  }, [tensionDue]);
+
+  const zeroNumberEnabled = flags.FF_ZERO_NUMBERS !== false;
+  const vrEnabled = flags.FF_VR !== false;
+  const forceFallback = !vrEnabled || !tier.supported || tier.prm || profile.fallback2dNext;
+
+  const handleConsent = useCallback(async () => {
+    await ssqAssessment.grantConsent();
+  }, [ssqAssessment]);
+
+  const handleDecline = useCallback(async () => {
+    await ssqAssessment.declineConsent();
+  }, [ssqAssessment]);
+
+  const startSession = useCallback(() => {
+    setSessionActive(true);
+    setSessionSaved(false);
+    setSessionStartedAt(Date.now());
+  }, []);
+
+  const stopSession = useCallback(async () => {
+    if (!sessionActive) {
+      return;
+    }
+    setSessionActive(false);
+    const startedAt = sessionStartedAt;
+    setSessionStartedAt(null);
+    setPersisting(true);
+    try {
+      const durationSec = startedAt ? Math.max(1, Math.round((Date.now() - startedAt) / 1000)) : 0;
+      await createSession({ type: 'vr_breath', duration_sec: durationSec, meta: metaFromProfile(profile) });
+      setSessionSaved(true);
+    } catch (error) {
+      Sentry.captureException(error, { tags: { module: 'vr_breath' } });
+    } finally {
+      setPersisting(false);
+    }
+  }, [profile, sessionActive, sessionStartedAt]);
+
+  const openFallback = useCallback(() => {
+    window.location.href = '/app/vr-breath-2d';
+  }, []);
+
+  const handleStartAssessments = useCallback(
+    async (instrument: 'SSQ' | 'POMS_TENSION') => {
+      const target = instrument === 'SSQ' ? ssqAssessment : tensionAssessment;
+      await target.triggerAssessment();
+    },
+    [ssqAssessment, tensionAssessment],
+  );
+
+  if (ssqAssessment.state.isConsentLoading) {
+    return (
+      <ZeroNumberBoundary className="mx-auto flex min-h-screen max-w-3xl items-center justify-center px-6 py-10">
+        <div className="rounded-3xl bg-muted/40 p-8 text-center text-sm text-muted-foreground">Préparation de la bulle immersive.</div>
+      </ZeroNumberBoundary>
+    );
+  }
+
+  if (!ssqAssessment.state.hasConsent) {
+    return (
+      <ZeroNumberBoundary className="mx-auto flex min-h-screen max-w-3xl flex-col gap-6 px-6 py-12">
+        <section className="rounded-3xl bg-gradient-to-br from-muted/30 via-background to-background/70 p-8 shadow-sm">
+          <h1 className="text-2xl font-semibold text-foreground">Accord nécessaire pour la bulle immersive</h1>
+          <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
+            Pour activer la respiration immersive, nous avons besoin de ton accord explicite. Tu peux choisir la version sans
+            mouvement si tu préfères rester au calme.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={handleConsent}
+              className="rounded-full bg-foreground px-5 py-2 text-sm font-semibold text-background transition hover:bg-foreground/90"
+            >
+              J’autorise la bulle immersive douce
+            </button>
+            <button
+              type="button"
+              onClick={handleDecline}
+              className="rounded-full border border-foreground/20 px-5 py-2 text-sm font-semibold text-foreground transition hover:bg-foreground/5"
+            >
+              Je reste sur la version sans mouvement
+            </button>
+            <button
+              type="button"
+              onClick={openFallback}
+              className="rounded-full border border-foreground/30 px-4 py-2 text-sm font-medium text-foreground/80 transition hover:bg-foreground/5"
+            >
+              Ouvrir la version sans mouvement
+            </button>
+          </div>
+        </section>
+      </ZeroNumberBoundary>
+    );
+  }
+
+  if (forceFallback) {
+    return (
+      <ZeroNumberBoundary className="mx-auto flex min-h-screen max-w-3xl flex-col gap-6 px-6 py-12">
+        <section className="rounded-3xl bg-muted/20 p-8 shadow-sm">
+          <h1 className="text-2xl font-semibold text-foreground">{fallbackCopy.headline}</h1>
+          <p className="mt-4 max-w-xl text-sm leading-relaxed text-muted-foreground">{fallbackCopy.body}</p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={openFallback}
+              className="rounded-full bg-foreground px-5 py-2 text-sm font-semibold text-background transition hover:bg-foreground/90"
+            >
+              Explorer la version sans mouvement
+            </button>
+            {tier.supported && !tier.prm && !profile.fallback2dNext && (
+              <button
+                type="button"
+                onClick={startSession}
+                className="rounded-full border border-foreground/30 px-5 py-2 text-sm font-semibold text-foreground transition hover:bg-foreground/5"
+              >
+                Lancer la bulle immersive malgré tout
+              </button>
+            )}
+          </div>
+        </section>
+      </ZeroNumberBoundary>
+    );
+  }
+
+  const content = (
+    <div className="mx-auto flex min-h-screen max-w-4xl flex-col gap-8 px-6 py-12">
+      <section className="rounded-3xl bg-gradient-to-br from-slate-950 via-indigo-950 to-slate-900 p-10 text-slate-50 shadow-lg">
+        <div className="flex flex-col gap-6">
+          <header>
+            <h1 className="text-3xl font-semibold">Respiration immersive sécurisée</h1>
+            <p className="mt-3 max-w-2xl text-sm leading-relaxed text-slate-200/80">
+              Les mouvements sont ajustés selon ton confort partagé. Aucun chiffre n’est affiché, seulement des repères doux.
+            </p>
+          </header>
+
+          <div className="flex flex-wrap gap-3 text-xs font-semibold uppercase tracking-wide text-slate-100/80">
+            <span className="rounded-full bg-slate-800/70 px-3 py-1">{COMFORT_LABELS[profile.comfort]}</span>
+            <span className="rounded-full bg-slate-800/70 px-3 py-1">{DURATION_LABELS[profile.duration]}</span>
+            <span className="rounded-full bg-slate-800/70 px-3 py-1">{LOCOMOTION_LABELS[profile.locomotion]}</span>
+            <span className="rounded-full bg-slate-800/70 px-3 py-1">{FOV_LABELS[profile.fov]}</span>
+            <span className="rounded-full bg-slate-800/70 px-3 py-1">{AUDIO_LABELS[profile.audio]}</span>
+            <span className="rounded-full bg-slate-800/70 px-3 py-1">{GUIDANCE_LABELS[profile.guidance]}</span>
+            <span className="rounded-full bg-slate-800/70 px-3 py-1">{VIGNETTE_LABELS[profile.vignette]}</span>
+            <span className="rounded-full bg-slate-800/70 px-3 py-1">{PARTICLE_LABELS[profile.particles]}</span>
+          </div>
+
+          {profile.fallback2dNext && (
+            <div className="rounded-2xl bg-slate-800/60 p-4 text-sm text-slate-100/80">
+              On te proposera la version douce par défaut la prochaine fois.
+            </div>
+          )}
+
+          <div className="flex flex-wrap gap-3">
+            {!sessionActive ? (
+              <button
+                type="button"
+                onClick={startSession}
+                className="rounded-full bg-slate-100 px-5 py-2 text-sm font-semibold text-slate-900 transition hover:bg-slate-200"
+              >
+                Entrer dans la bulle immersive
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={stopSession}
+                disabled={persisting}
+                className="rounded-full bg-slate-100 px-5 py-2 text-sm font-semibold text-slate-900 transition hover:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {persisting ? 'Enregistrement en cours' : 'Terminer en douceur'}
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={openFallback}
+              className="rounded-full border border-slate-100/30 px-5 py-2 text-sm font-semibold text-slate-100 transition hover:bg-slate-100/10"
+            >
+              Basculer vers la version sans mouvement
+            </button>
+          </div>
+
+          {sessionSaved && (
+            <p className="text-sm text-slate-200/80">Ta session a été enregistrée avec les paramètres apaisés.</p>
+          )}
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-muted-foreground/20 bg-background/80 p-8 shadow-sm">
+        <h2 className="text-lg font-semibold text-foreground">Partager ton ressenti après la bulle</h2>
+        <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+          Ces mini-questionnaires sont facultatifs. Ils nous aident à maintenir un niveau de confort très doux.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <button
+            type="button"
+            disabled={!ssqDue || ssqAssessment.state.isStarting}
+            onClick={() => handleStartAssessments('SSQ')}
+            className="rounded-full bg-foreground px-5 py-2 text-sm font-semibold text-background transition hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Partager mon confort corporel
+          </button>
+          <button
+            type="button"
+            disabled={!tensionDue || tensionAssessment.state.isStarting}
+            onClick={() => handleStartAssessments('POMS_TENSION')}
+            className="rounded-full border border-foreground/20 px-5 py-2 text-sm font-semibold text-foreground transition hover:bg-foreground/5 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Partager ma tension émotionnelle
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+
+  if (!zeroNumberEnabled) {
+    return content;
+  }
+
+  return <ZeroNumberBoundary className="mx-auto flex min-h-screen max-w-4xl flex-col gap-8 px-6 py-12">{content.props.children}</ZeroNumberBoundary>;
+}

--- a/src/app/vr-galaxy-2d/page.tsx
+++ b/src/app/vr-galaxy-2d/page.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { ZeroNumberBoundary } from '@/components/a11y/ZeroNumberBoundary';
+
+const copy = {
+  title: 'Constellations sans mouvement',
+  intro: 'Une carte céleste immobile te permet de contempler les étoiles sans aucun déplacement.',
+  instruction: 'Suis les lignes lumineuses avec douceur et ralentis ta respiration à ton rythme.',
+  ctaVr: 'Retrouver la version immersive',
+  back: 'Revenir vers l’espace principal',
+};
+
+export default function VrGalaxy2DPage() {
+  return (
+    <ZeroNumberBoundary className="mx-auto flex min-h-screen max-w-3xl flex-col gap-6 px-6 py-12">
+      <section className="rounded-3xl bg-gradient-to-br from-slate-950 via-indigo-950 to-slate-950 p-8 text-slate-100 shadow-lg transition-all duration-150 ease-out">
+        <h1 className="text-3xl font-semibold">{copy.title}</h1>
+        <p className="mt-4 text-sm leading-relaxed text-slate-200/80">{copy.intro}</p>
+        <div className="mt-6 rounded-2xl bg-slate-900/60 p-4 text-sm text-slate-100/80">
+          {copy.instruction}
+        </div>
+        <div className="mt-6 flex flex-wrap gap-3 text-sm">
+          <a
+            className="rounded-full bg-slate-100 px-5 py-2 font-semibold text-slate-900 transition-colors duration-150 ease-out hover:bg-slate-200"
+            href="/app/vr-galaxy"
+          >
+            {copy.ctaVr}
+          </a>
+          <a
+            className="rounded-full border border-slate-100/30 px-5 py-2 font-semibold text-slate-100 transition-colors duration-150 ease-out hover:bg-slate-100/10"
+            href="/app/music"
+          >
+            {copy.back}
+          </a>
+        </div>
+      </section>
+    </ZeroNumberBoundary>
+  );
+}

--- a/src/app/vr-galaxy/page.tsx
+++ b/src/app/vr-galaxy/page.tsx
@@ -1,0 +1,401 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import * as Sentry from '@sentry/react';
+
+import { ZeroNumberBoundary } from '@/components/a11y/ZeroNumberBoundary';
+import { useFlags } from '@/core/flags';
+import { useAssessment } from '@/hooks/useAssessment';
+import { createSession } from '@/services/sessions/sessionsApi';
+
+import { deriveGalaxyProfile } from '@/features/vr/deriveProfile';
+import useVRTier from '@/features/vr/useVRTier';
+import { computeGalaxyActions } from '@/features/vr/vrGalaxy.orchestrator';
+
+const COMFORT_LABELS: Record<'very_low' | 'low' | 'medium', string> = {
+  very_low: 'confort cosmique très doux',
+  low: 'confort cosmique doux',
+  medium: 'confort cosmique fluide',
+};
+
+const DURATION_LABELS: Record<'short' | 'normal', string> = {
+  short: 'voyage court',
+  normal: 'voyage ample',
+};
+
+const LOCOMOTION_LABELS: Record<'teleport' | 'smooth', string> = {
+  teleport: 'sauts d’étoiles apaisés',
+  smooth: 'glisse orbitale douce',
+};
+
+const FOV_LABELS: Record<'narrow' | 'default', string> = {
+  narrow: 'hublot resserré',
+  default: 'hublot ouvert',
+};
+
+const AUDIO_LABELS: Record<'calm' | 'soft', string> = {
+  calm: 'ondes sonores calmes',
+  soft: 'ondes sonores douces',
+};
+
+const NAVIGATION_LABELS: Record<'drift' | 'gentle' | 'cruise', string> = {
+  drift: 'navigation en dérive',
+  gentle: 'navigation feutrée',
+  cruise: 'navigation fluide',
+};
+
+const STELLAR_LABELS: Record<'thin' | 'balanced' | 'lush', string> = {
+  thin: 'voile stellaire léger',
+  balanced: 'voile stellaire équilibré',
+  lush: 'voile stellaire généreux',
+};
+
+const VIGNETTE_LABELS: Record<'none' | 'soft' | 'comfort', string> = {
+  none: 'halo neutre',
+  soft: 'halo délicat',
+  comfort: 'halo confort',
+};
+
+const PARTICLE_LABELS: Record<'low' | 'medium' | 'high', string> = {
+  low: 'poussière d’étoiles légère',
+  medium: 'poussière d’étoiles douce',
+  high: 'poussière d’étoiles généreuse',
+};
+
+const fallbackCopy = {
+  headline: 'Exploration statique recommandée',
+  body: 'Ton équilibre prime. Les constellations restent accessibles en version immobile.',
+};
+
+const normalizeLevel = (value: number | undefined | null): 0 | 1 | 2 | 3 | 4 | undefined => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return undefined;
+  }
+  const clamped = Math.max(0, Math.min(4, Math.round(value)));
+  return clamped as 0 | 1 | 2 | 3 | 4;
+};
+
+const metaFromProfile = (profile: ReturnType<typeof deriveGalaxyProfile>) => ({
+  module: 'vr_galaxy',
+  comfort: COMFORT_LABELS[profile.comfort],
+  duration: DURATION_LABELS[profile.duration],
+  locomotion: LOCOMOTION_LABELS[profile.locomotion],
+  fov: FOV_LABELS[profile.fov],
+  audio: AUDIO_LABELS[profile.audio],
+  navigation: NAVIGATION_LABELS[profile.navigation],
+  voile_stellaire: STELLAR_LABELS[profile.stellarDensity],
+  vignette: VIGNETTE_LABELS[profile.vignette],
+  particules: PARTICLE_LABELS[profile.particles],
+  fallback_next: profile.fallback2dNext ? 'prévu' : 'non prévu',
+});
+
+export default function VrGalaxyPage() {
+  const { flags } = useFlags();
+  const tier = useVRTier();
+  const ssqAssessment = useAssessment('SSQ');
+  const tensionAssessment = useAssessment('POMS_TENSION');
+
+  const [sessionStartedAt, setSessionStartedAt] = useState<number | null>(null);
+  const [sessionActive, setSessionActive] = useState(false);
+  const [persisting, setPersisting] = useState(false);
+  const [sessionSaved, setSessionSaved] = useState(false);
+  const fallbackLoggedRef = useRef(false);
+  const ssqOfferLoggedRef = useRef(false);
+  const tensionOfferLoggedRef = useRef(false);
+
+  useEffect(() => {
+    Sentry.addBreadcrumb({ category: 'vr', level: 'info', message: 'vr:enter', data: { module: 'vr_galaxy' } });
+    return () => {
+      Sentry.addBreadcrumb({ category: 'vr', level: 'info', message: 'vr:exit', data: { module: 'vr_galaxy' } });
+    };
+  }, []);
+
+  const ssqLevel = normalizeLevel(ssqAssessment.state.lastComputation?.level ?? undefined);
+  const tensionLevel = normalizeLevel(tensionAssessment.state.lastComputation?.level ?? undefined);
+
+  const actions = useMemo(
+    () =>
+      computeGalaxyActions({
+        vrTier: tier.vrTier,
+        prm: tier.prm,
+        ssqLevel: ssqLevel,
+        tensionLevel: tensionLevel,
+      }),
+    [ssqLevel, tensionLevel, tier.prm, tier.vrTier],
+  );
+
+  const profile = useMemo(() => deriveGalaxyProfile(actions), [actions]);
+
+  useEffect(() => {
+    Sentry.addBreadcrumb({
+      category: 'vr',
+      level: 'info',
+      message: 'vr:actions:applied',
+      data: {
+        module: 'vr_galaxy',
+        comfort: profile.comfort,
+        navigation: profile.navigation,
+        fallback2d: profile.fallback2dNext,
+      },
+    });
+    Sentry.configureScope((scope) => {
+      scope.setTag('vr_module', 'vr_galaxy');
+      scope.setTag('vr_comfort', profile.comfort);
+      scope.setTag('vr_navigation', profile.navigation);
+      scope.setTag('vr_voile', profile.stellarDensity);
+    });
+  }, [profile]);
+
+  useEffect(() => {
+    const fallbackCondition = profile.fallback2dNext || !tier.supported || tier.prm || tier.fallbackReason === 'no_xr';
+    if (fallbackCondition && !fallbackLoggedRef.current) {
+      Sentry.addBreadcrumb({
+        category: 'vr',
+        level: 'warning',
+        message: 'fallback2d:set',
+        data: { module: 'vr_galaxy', reason: tier.fallbackReason ?? 'comfort' },
+      });
+      fallbackLoggedRef.current = true;
+    }
+  }, [profile.fallback2dNext, tier.fallbackReason, tier.prm, tier.supported]);
+
+  const ssqDue = ssqAssessment.isDue('post');
+  const tensionDue = tensionAssessment.isDue('post');
+
+  useEffect(() => {
+    if (ssqDue && !ssqOfferLoggedRef.current) {
+      Sentry.addBreadcrumb({ category: 'vr', level: 'info', message: 'ssq:post:offered', data: { module: 'vr_galaxy' } });
+      ssqOfferLoggedRef.current = true;
+    }
+  }, [ssqDue]);
+
+  useEffect(() => {
+    if (tensionDue && !tensionOfferLoggedRef.current) {
+      Sentry.addBreadcrumb({
+        category: 'vr',
+        level: 'info',
+        message: 'poms_tension:post:offered',
+        data: { module: 'vr_galaxy' },
+      });
+      tensionOfferLoggedRef.current = true;
+    }
+  }, [tensionDue]);
+
+  const zeroNumberEnabled = flags.FF_ZERO_NUMBERS !== false;
+  const vrEnabled = flags.FF_VR !== false;
+  const forceFallback = !vrEnabled || !tier.supported || tier.prm || profile.fallback2dNext;
+
+  const handleConsent = useCallback(async () => {
+    await ssqAssessment.grantConsent();
+  }, [ssqAssessment]);
+
+  const handleDecline = useCallback(async () => {
+    await ssqAssessment.declineConsent();
+  }, [ssqAssessment]);
+
+  const startSession = useCallback(() => {
+    setSessionActive(true);
+    setSessionSaved(false);
+    setSessionStartedAt(Date.now());
+  }, []);
+
+  const stopSession = useCallback(async () => {
+    if (!sessionActive) {
+      return;
+    }
+    setSessionActive(false);
+    const startedAt = sessionStartedAt;
+    setSessionStartedAt(null);
+    setPersisting(true);
+    try {
+      const durationSec = startedAt ? Math.max(1, Math.round((Date.now() - startedAt) / 1000)) : 0;
+      await createSession({ type: 'vr_galaxy', duration_sec: durationSec, meta: metaFromProfile(profile) });
+      setSessionSaved(true);
+    } catch (error) {
+      Sentry.captureException(error, { tags: { module: 'vr_galaxy' } });
+    } finally {
+      setPersisting(false);
+    }
+  }, [profile, sessionActive, sessionStartedAt]);
+
+  const openFallback = useCallback(() => {
+    window.location.href = '/app/vr-galaxy-2d';
+  }, []);
+
+  const handleStartAssessments = useCallback(
+    async (instrument: 'SSQ' | 'POMS_TENSION') => {
+      const target = instrument === 'SSQ' ? ssqAssessment : tensionAssessment;
+      await target.triggerAssessment();
+    },
+    [ssqAssessment, tensionAssessment],
+  );
+
+  if (ssqAssessment.state.isConsentLoading) {
+    return (
+      <ZeroNumberBoundary className="mx-auto flex min-h-screen max-w-3xl items-center justify-center px-6 py-10">
+        <div className="rounded-3xl bg-muted/40 p-8 text-center text-sm text-muted-foreground">Préparation de la traversée céleste.</div>
+      </ZeroNumberBoundary>
+    );
+  }
+
+  if (!ssqAssessment.state.hasConsent) {
+    return (
+      <ZeroNumberBoundary className="mx-auto flex min-h-screen max-w-3xl flex-col gap-6 px-6 py-12">
+        <section className="rounded-3xl bg-gradient-to-br from-muted/30 via-background to-background/70 p-8 shadow-sm">
+          <h1 className="text-2xl font-semibold text-foreground">Accord nécessaire pour le voyage céleste</h1>
+          <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
+            Nous avons besoin de ton accord explicite avant de déployer la navigation immersive. La promenade statique reste disponible à tout moment.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={handleConsent}
+              className="rounded-full bg-foreground px-5 py-2 text-sm font-semibold text-background transition hover:bg-foreground/90"
+            >
+              J’autorise le voyage céleste doux
+            </button>
+            <button
+              type="button"
+              onClick={handleDecline}
+              className="rounded-full border border-foreground/20 px-5 py-2 text-sm font-semibold text-foreground transition hover:bg-foreground/5"
+            >
+              Je préfère rester sur la version immobile
+            </button>
+            <button
+              type="button"
+              onClick={openFallback}
+              className="rounded-full border border-foreground/30 px-4 py-2 text-sm font-medium text-foreground/80 transition hover:bg-foreground/5"
+            >
+              Ouvrir la promenade immobile
+            </button>
+          </div>
+        </section>
+      </ZeroNumberBoundary>
+    );
+  }
+
+  if (forceFallback) {
+    return (
+      <ZeroNumberBoundary className="mx-auto flex min-h-screen max-w-3xl flex-col gap-6 px-6 py-12">
+        <section className="rounded-3xl bg-muted/20 p-8 shadow-sm">
+          <h1 className="text-2xl font-semibold text-foreground">{fallbackCopy.headline}</h1>
+          <p className="mt-4 max-w-xl text-sm leading-relaxed text-muted-foreground">{fallbackCopy.body}</p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={openFallback}
+              className="rounded-full bg-foreground px-5 py-2 text-sm font-semibold text-background transition hover:bg-foreground/90"
+            >
+              Rejoindre la promenade immobile
+            </button>
+            {tier.supported && !tier.prm && !profile.fallback2dNext && (
+              <button
+                type="button"
+                onClick={startSession}
+                className="rounded-full border border-foreground/30 px-5 py-2 text-sm font-semibold text-foreground transition hover:bg-foreground/5"
+              >
+                Lancer le voyage doux malgré tout
+              </button>
+            )}
+          </div>
+        </section>
+      </ZeroNumberBoundary>
+    );
+  }
+
+  const content = (
+    <div className="mx-auto flex min-h-screen max-w-4xl flex-col gap-8 px-6 py-12">
+      <section className="rounded-3xl bg-gradient-to-br from-slate-950 via-sky-950 to-slate-900 p-10 text-slate-50 shadow-lg">
+        <div className="flex flex-col gap-6">
+          <header>
+            <h1 className="text-3xl font-semibold">Voyage galactique apaisé</h1>
+            <p className="mt-3 max-w-2xl text-sm leading-relaxed text-slate-200/80">
+              La vitesse, la densité et les halos sont modulés selon ton ressenti. Aucun chiffre, uniquement des nuances.
+            </p>
+          </header>
+
+          <div className="flex flex-wrap gap-3 text-xs font-semibold uppercase tracking-wide text-slate-100/80">
+            <span className="rounded-full bg-slate-800/70 px-3 py-1">{COMFORT_LABELS[profile.comfort]}</span>
+            <span className="rounded-full bg-slate-800/70 px-3 py-1">{DURATION_LABELS[profile.duration]}</span>
+            <span className="rounded-full bg-slate-800/70 px-3 py-1">{LOCOMOTION_LABELS[profile.locomotion]}</span>
+            <span className="rounded-full bg-slate-800/70 px-3 py-1">{FOV_LABELS[profile.fov]}</span>
+            <span className="rounded-full bg-slate-800/70 px-3 py-1">{AUDIO_LABELS[profile.audio]}</span>
+            <span className="rounded-full bg-slate-800/70 px-3 py-1">{NAVIGATION_LABELS[profile.navigation]}</span>
+            <span className="rounded-full bg-slate-800/70 px-3 py-1">{STELLAR_LABELS[profile.stellarDensity]}</span>
+            <span className="rounded-full bg-slate-800/70 px-3 py-1">{VIGNETTE_LABELS[profile.vignette]}</span>
+            <span className="rounded-full bg-slate-800/70 px-3 py-1">{PARTICLE_LABELS[profile.particles]}</span>
+          </div>
+
+          {profile.fallback2dNext && (
+            <div className="rounded-2xl bg-slate-800/60 p-4 text-sm text-slate-100/80">
+              On te proposera la promenade immobile par défaut la prochaine fois.
+            </div>
+          )}
+
+          <div className="flex flex-wrap gap-3">
+            {!sessionActive ? (
+              <button
+                type="button"
+                onClick={startSession}
+                className="rounded-full bg-slate-100 px-5 py-2 text-sm font-semibold text-slate-900 transition hover:bg-slate-200"
+              >
+                Entrer dans le voyage céleste
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={stopSession}
+                disabled={persisting}
+                className="rounded-full bg-slate-100 px-5 py-2 text-sm font-semibold text-slate-900 transition hover:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {persisting ? 'Enregistrement en cours' : 'Terminer en douceur'}
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={openFallback}
+              className="rounded-full border border-slate-100/30 px-5 py-2 text-sm font-semibold text-slate-100 transition hover:bg-slate-100/10"
+            >
+              Rejoindre la promenade immobile
+            </button>
+          </div>
+
+          {sessionSaved && (
+            <p className="text-sm text-slate-200/80">Ta traversée a été enregistrée avec des paramètres doux.</p>
+          )}
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-muted-foreground/20 bg-background/80 p-8 shadow-sm">
+        <h2 className="text-lg font-semibold text-foreground">Partager ton ressenti après le voyage</h2>
+        <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+          Les questionnaires sont facultatifs et sans aucun chiffre. Ils nous guident pour garder la navigation très douce.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <button
+            type="button"
+            disabled={!ssqDue || ssqAssessment.state.isStarting}
+            onClick={() => handleStartAssessments('SSQ')}
+            className="rounded-full bg-foreground px-5 py-2 text-sm font-semibold text-background transition hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Partager mon confort corporel
+          </button>
+          <button
+            type="button"
+            disabled={!tensionDue || tensionAssessment.state.isStarting}
+            onClick={() => handleStartAssessments('POMS_TENSION')}
+            className="rounded-full border border-foreground/20 px-5 py-2 text-sm font-semibold text-foreground transition hover:bg-foreground/5 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Partager ma tension émotionnelle
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+
+  if (!zeroNumberEnabled) {
+    return content;
+  }
+
+  return <ZeroNumberBoundary className="mx-auto flex min-h-screen max-w-4xl flex-col gap-8 px-6 py-12">{content.props.children}</ZeroNumberBoundary>;
+}

--- a/src/features/vr/__tests__/vrBreath.orchestrator.spec.ts
+++ b/src/features/vr/__tests__/vrBreath.orchestrator.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveBreathProfile } from '../deriveProfile';
+import { computeBreathActions } from '../vrBreath.orchestrator';
+
+describe('computeBreathActions', () => {
+  it('forces very soft profile when prefers reduced motion', () => {
+    const actions = computeBreathActions({ vrTier: 'high', prm: true });
+    const profile = deriveBreathProfile(actions);
+
+    expect(profile.comfort).toBe('very_low');
+    expect(profile.duration).toBe('short');
+    expect(profile.locomotion).toBe('teleport');
+    expect(profile.vignette).toBe('comfort');
+    expect(profile.particles).toBe('low');
+    expect(profile.audio).toBe('calm');
+  });
+
+  it('enables fallback and applies very low comfort when SSQ is high', () => {
+    const actions = computeBreathActions({ vrTier: 'mid', prm: false, ssqLevel: 3 });
+    const profile = deriveBreathProfile(actions);
+
+    expect(profile.fallback2dNext).toBe(true);
+    expect(profile.comfort).toBe('very_low');
+    expect(profile.locomotion).toBe('teleport');
+    expect(profile.vignette).toBe('comfort');
+  });
+
+  it('shortens scene and extends guidance when tension is elevated', () => {
+    const actions = computeBreathActions({ vrTier: 'high', prm: false, tensionLevel: 4 });
+    const profile = deriveBreathProfile(actions);
+
+    expect(profile.duration).toBe('short');
+    expect(profile.guidance).toBe('long_exhale');
+    expect(profile.particles).toBe('low');
+  });
+});

--- a/src/features/vr/__tests__/vrGalaxy.orchestrator.spec.ts
+++ b/src/features/vr/__tests__/vrGalaxy.orchestrator.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveGalaxyProfile } from '../deriveProfile';
+import { computeGalaxyActions } from '../vrGalaxy.orchestrator';
+
+describe('computeGalaxyActions', () => {
+  it('keeps a conservative profile on low tier hardware', () => {
+    const actions = computeGalaxyActions({ vrTier: 'low', prm: false });
+    const profile = deriveGalaxyProfile(actions);
+
+    expect(profile.comfort).toBe('low');
+    expect(profile.duration).toBe('short');
+    expect(profile.navigation).toBe('gentle');
+    expect(profile.stellarDensity).toBe('balanced');
+  });
+
+  it('applies fallback and drift navigation when SSQ is high', () => {
+    const actions = computeGalaxyActions({ vrTier: 'mid', prm: false, ssqLevel: 4 });
+    const profile = deriveGalaxyProfile(actions);
+
+    expect(profile.fallback2dNext).toBe(true);
+    expect(profile.navigation).toBe('drift');
+    expect(profile.stellarDensity).toBe('thin');
+  });
+});

--- a/src/features/vr/deriveProfile.ts
+++ b/src/features/vr/deriveProfile.ts
@@ -1,0 +1,91 @@
+import { defaultBreathProfile, defaultGalaxyProfile, type VRBreathProfile, type VRGalaxyProfile } from './types';
+import type { VRActions as BreathActions } from './vrBreath.orchestrator';
+import type { VRActions as GalaxyActions } from './vrGalaxy.orchestrator';
+
+export const deriveBreathProfile = (actions: BreathActions[]): VRBreathProfile => {
+  const profile: VRBreathProfile = { ...defaultBreathProfile };
+
+  actions.forEach((action) => {
+    switch (action.action) {
+      case 'set_comfort':
+        profile.comfort = action.key;
+        break;
+      case 'set_duration':
+        profile.duration = action.key;
+        break;
+      case 'set_locomotion':
+        profile.locomotion = action.key;
+        break;
+      case 'set_fov':
+        profile.fov = action.key;
+        break;
+      case 'set_effects':
+        profile.bloom = action.bloom;
+        profile.vignette = action.vignette;
+        break;
+      case 'set_particles':
+        profile.particles = action.density;
+        break;
+      case 'set_audio':
+        profile.audio = action.key;
+        break;
+      case 'set_guidance':
+        profile.guidance = action.key;
+        break;
+      case 'fallback_2d_next':
+        profile.fallback2dNext = action.enabled;
+        break;
+      default:
+        break;
+    }
+  });
+
+  return profile;
+};
+
+export const deriveGalaxyProfile = (actions: GalaxyActions[]): VRGalaxyProfile => {
+  const profile: VRGalaxyProfile = { ...defaultGalaxyProfile };
+
+  actions.forEach((action) => {
+    switch (action.action) {
+      case 'set_comfort':
+        profile.comfort = action.key;
+        break;
+      case 'set_duration':
+        profile.duration = action.key;
+        break;
+      case 'set_locomotion':
+        profile.locomotion = action.key;
+        break;
+      case 'set_fov':
+        profile.fov = action.key;
+        break;
+      case 'set_effects':
+        profile.bloom = action.bloom;
+        profile.vignette = action.vignette;
+        break;
+      case 'set_particles':
+        profile.particles = action.density;
+        break;
+      case 'set_audio':
+        profile.audio = action.key;
+        break;
+      case 'set_guidance':
+        profile.guidance = action.key;
+        break;
+      case 'fallback_2d_next':
+        profile.fallback2dNext = action.enabled;
+        break;
+      case 'set_navigation':
+        profile.navigation = action.speed;
+        break;
+      case 'set_stars':
+        profile.stellarDensity = action.density;
+        break;
+      default:
+        break;
+    }
+  });
+
+  return profile;
+};

--- a/src/features/vr/types.ts
+++ b/src/features/vr/types.ts
@@ -1,0 +1,81 @@
+export type VRTier = 'low' | 'mid' | 'high';
+
+export type ComfortKey = 'very_low' | 'low' | 'medium';
+export type DurationKey = 'short' | 'normal';
+export type LocomotionKey = 'teleport' | 'smooth';
+export type FovKey = 'narrow' | 'default';
+export type AudioKey = 'calm' | 'soft';
+export type GuidanceKey = 'long_exhale' | 'none';
+export type VignetteKey = 'none' | 'soft' | 'comfort';
+export type ParticleDensity = 'low' | 'medium' | 'high';
+
+export interface VRProfileBase {
+  comfort: ComfortKey;
+  duration: DurationKey;
+  locomotion: LocomotionKey;
+  fov: FovKey;
+  audio: AudioKey;
+  guidance: GuidanceKey;
+  vignette: VignetteKey;
+  bloom: boolean;
+  particles: ParticleDensity;
+  fallback2dNext: boolean;
+}
+
+export interface VRBreathProfile extends VRProfileBase {
+  module: 'vr_breath';
+}
+
+export interface VRGalaxyProfile extends VRProfileBase {
+  module: 'vr_galaxy';
+  navigation: 'drift' | 'gentle' | 'cruise';
+  stellarDensity: 'thin' | 'balanced' | 'lush';
+}
+
+export type VRProfile = VRBreathProfile | VRGalaxyProfile;
+
+export const defaultBreathProfile: VRBreathProfile = {
+  module: 'vr_breath',
+  comfort: 'medium',
+  duration: 'normal',
+  locomotion: 'smooth',
+  fov: 'default',
+  audio: 'soft',
+  guidance: 'none',
+  vignette: 'soft',
+  bloom: true,
+  particles: 'medium',
+  fallback2dNext: false,
+};
+
+export const defaultGalaxyProfile: VRGalaxyProfile = {
+  module: 'vr_galaxy',
+  comfort: 'medium',
+  duration: 'normal',
+  locomotion: 'smooth',
+  fov: 'default',
+  audio: 'soft',
+  guidance: 'none',
+  vignette: 'soft',
+  bloom: true,
+  particles: 'medium',
+  fallback2dNext: false,
+  navigation: 'cruise',
+  stellarDensity: 'lush',
+};
+
+export interface OrchestrationInputs {
+  vrTier: VRTier;
+  prm: boolean;
+  ssqLevel?: 0 | 1 | 2 | 3 | 4;
+  tensionLevel?: 0 | 1 | 2 | 3 | 4;
+}
+
+export interface DerivedProfileResult<TProfile extends VRProfile, TAction> {
+  profile: TProfile;
+  actions: TAction[];
+}
+
+export type MotionPreference = {
+  prefersReducedMotion: boolean;
+};

--- a/src/features/vr/useVRTier.ts
+++ b/src/features/vr/useVRTier.ts
@@ -1,0 +1,221 @@
+import { useEffect, useMemo, useState } from 'react';
+import * as Sentry from '@sentry/react';
+
+import { useMotionPrefs } from '@/hooks/useMotionPrefs';
+
+import type { VRTier } from './types';
+
+type FallbackReason = 'no_xr' | 'prm' | 'low_capability' | null;
+
+type TierDetails = {
+  xrSupported: boolean;
+  webgl2: boolean;
+  missingExtensions: string[];
+  avgFrameMs: number;
+};
+
+const initialDetails: TierDetails = {
+  xrSupported: false,
+  webgl2: false,
+  missingExtensions: [],
+  avgFrameMs: 0,
+};
+
+interface TierState {
+  checking: boolean;
+  supported: boolean;
+  vrTier: VRTier;
+  prm: boolean;
+  fallbackReason: FallbackReason;
+  details: TierDetails;
+}
+
+const initialState: TierState = {
+  checking: true,
+  supported: false,
+  vrTier: 'low',
+  prm: false,
+  fallbackReason: null,
+  details: initialDetails,
+};
+
+const REQUIRED_EXTENSIONS = ['EXT_color_buffer_float', 'EXT_texture_filter_anisotropic', 'EXT_disjoint_timer_query_webgl2'] as const;
+
+const detectXRSupport = async (): Promise<boolean> => {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+
+  const xr = (navigator as Navigator & { xr?: { isSessionSupported?: (mode: string) => Promise<boolean> } }).xr;
+  if (!xr || typeof xr.isSessionSupported !== 'function') {
+    return false;
+  }
+
+  try {
+    return await xr.isSessionSupported('immersive-vr');
+  } catch (error) {
+    console.warn('[useVRTier] xr.isSessionSupported failed', error);
+    return false;
+  }
+};
+
+const detectWebGLSupport = () => {
+  if (typeof document === 'undefined') {
+    return { webgl2: false, missingExtensions: Array.from(REQUIRED_EXTENSIONS) };
+  }
+
+  try {
+    const canvas = document.createElement('canvas');
+    const gl = canvas.getContext('webgl2');
+    if (!gl) {
+      return { webgl2: false, missingExtensions: Array.from(REQUIRED_EXTENSIONS) };
+    }
+
+    const missingExtensions = REQUIRED_EXTENSIONS.filter((ext) => !gl.getExtension(ext));
+    return { webgl2: true, missingExtensions };
+  } catch (error) {
+    console.warn('[useVRTier] webgl detection failed', error);
+    return { webgl2: false, missingExtensions: Array.from(REQUIRED_EXTENSIONS) };
+  }
+};
+
+const measureFramePacing = (): Promise<number> =>
+  new Promise((resolve) => {
+    if (typeof window === 'undefined' || typeof window.requestAnimationFrame === 'undefined') {
+      resolve(16.6);
+      return;
+    }
+
+    let done = false;
+    const start = typeof performance !== 'undefined' ? performance.now() : Date.now();
+    let previous = start;
+    const samples: number[] = [];
+
+    const finish = () => {
+      if (done) return;
+      done = true;
+      const avg = samples.length > 0 ? samples.reduce((acc, value) => acc + value, 0) / samples.length : 16.6;
+      resolve(Math.max(0, avg));
+    };
+
+    const step = (timestamp: number) => {
+      if (done) {
+        return;
+      }
+      samples.push(Math.max(0, timestamp - previous));
+      previous = timestamp;
+      if (timestamp - start >= 2000) {
+        finish();
+        return;
+      }
+      window.requestAnimationFrame(step);
+    };
+
+    window.requestAnimationFrame(step);
+    window.setTimeout(finish, 2200);
+  });
+
+const resolveTier = (input: { webgl2: boolean; missingExtensions: string[]; avgFrameMs: number }): VRTier => {
+  if (!input.webgl2) {
+    return 'low';
+  }
+
+  const hasCriticalMissing = input.missingExtensions.length > 1;
+  if (hasCriticalMissing) {
+    return 'low';
+  }
+
+  if (input.avgFrameMs >= 26) {
+    return 'low';
+  }
+
+  if (input.avgFrameMs >= 20 || input.missingExtensions.length === 1) {
+    return 'mid';
+  }
+
+  return 'high';
+};
+
+export const useVRTier = () => {
+  const { prefersReducedMotion } = useMotionPrefs();
+  const [state, setState] = useState<TierState>({ ...initialState, prm: prefersReducedMotion });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const runDetection = async () => {
+      setState((prev) => ({ ...prev, checking: true, prm: prefersReducedMotion }));
+
+      const [xrSupported, webglInfo, avgFrameMs] = await Promise.all([
+        detectXRSupport(),
+        Promise.resolve().then(() => detectWebGLSupport()),
+        measureFramePacing(),
+      ]);
+
+      if (cancelled) {
+        return;
+      }
+
+      const vrTier = resolveTier({ webgl2: webglInfo.webgl2, missingExtensions: webglInfo.missingExtensions, avgFrameMs });
+      const fallbackReason: FallbackReason = !xrSupported
+        ? 'no_xr'
+        : prefersReducedMotion
+          ? 'prm'
+          : vrTier === 'low' || webglInfo.missingExtensions.length > 0
+            ? 'low_capability'
+            : null;
+
+      if (!xrSupported) {
+        Sentry.addBreadcrumb({
+          category: 'vr',
+          level: 'warning',
+          message: 'vr:capability:xr_unsupported',
+        });
+      }
+
+      setState({
+        checking: false,
+        supported: xrSupported && !prefersReducedMotion,
+        vrTier,
+        prm: prefersReducedMotion,
+        fallbackReason,
+        details: {
+          xrSupported,
+          webgl2: webglInfo.webgl2,
+          missingExtensions: webglInfo.missingExtensions,
+          avgFrameMs: Number.isFinite(avgFrameMs) ? Number(avgFrameMs.toFixed(2)) : 0,
+        },
+      });
+    };
+
+    runDetection().catch((error) => {
+      console.error('[useVRTier] detection failed', error);
+      if (cancelled) {
+        return;
+      }
+      setState({
+        checking: false,
+        supported: false,
+        vrTier: 'low',
+        prm: prefersReducedMotion,
+        fallbackReason: 'low_capability',
+        details: initialDetails,
+      });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [prefersReducedMotion]);
+
+  return useMemo(
+    () => ({
+      ...state,
+    }),
+    [state],
+  );
+};
+
+export type UseVRTierResult = ReturnType<typeof useVRTier>;
+
+export default useVRTier;

--- a/src/features/vr/vrBreath.orchestrator.ts
+++ b/src/features/vr/vrBreath.orchestrator.ts
@@ -1,0 +1,82 @@
+import type { OrchestrationInputs } from './types';
+
+export type VRActions =
+  | { action: 'set_comfort'; key: 'very_low' | 'low' | 'medium' }
+  | { action: 'set_duration'; key: 'short' | 'normal' }
+  | { action: 'set_locomotion'; key: 'teleport' | 'smooth' }
+  | { action: 'set_fov'; key: 'narrow' | 'default' }
+  | { action: 'set_effects'; bloom: boolean; vignette: 'none' | 'soft' | 'comfort' }
+  | { action: 'set_particles'; density: 'low' | 'medium' | 'high' }
+  | { action: 'set_audio'; key: 'calm' | 'soft' }
+  | { action: 'set_guidance'; key: 'long_exhale' | 'none' }
+  | { action: 'fallback_2d_next'; enabled: boolean };
+
+export function computeBreathActions(input: OrchestrationInputs): VRActions[] {
+  const acts: VRActions[] = [];
+
+  if (input.prm) {
+    acts.push(
+      { action: 'set_comfort', key: 'very_low' },
+      { action: 'set_duration', key: 'short' },
+      { action: 'set_locomotion', key: 'teleport' },
+      { action: 'set_fov', key: 'narrow' },
+      { action: 'set_effects', bloom: false, vignette: 'comfort' },
+      { action: 'set_particles', density: 'low' },
+      { action: 'set_audio', key: 'calm' },
+      { action: 'set_guidance', key: 'long_exhale' },
+    );
+    return acts;
+  }
+
+  if (input.vrTier === 'low') {
+    acts.push(
+      { action: 'set_comfort', key: 'low' },
+      { action: 'set_duration', key: 'short' },
+      { action: 'set_locomotion', key: 'teleport' },
+      { action: 'set_effects', bloom: false, vignette: 'comfort' },
+      { action: 'set_particles', density: 'low' },
+      { action: 'set_audio', key: 'calm' },
+    );
+  } else {
+    acts.push(
+      { action: 'set_comfort', key: 'medium' },
+      { action: 'set_duration', key: 'normal' },
+      { action: 'set_locomotion', key: 'smooth' },
+      { action: 'set_effects', bloom: true, vignette: 'soft' },
+      { action: 'set_particles', density: 'medium' },
+      { action: 'set_audio', key: 'soft' },
+    );
+  }
+
+  if (typeof input.ssqLevel === 'number') {
+    if (input.ssqLevel >= 3) {
+      acts.push({ action: 'fallback_2d_next', enabled: true });
+      acts.push(
+        { action: 'set_comfort', key: 'very_low' },
+        { action: 'set_locomotion', key: 'teleport' },
+        { action: 'set_fov', key: 'narrow' },
+        { action: 'set_effects', bloom: false, vignette: 'comfort' },
+        { action: 'set_particles', density: 'low' },
+        { action: 'set_audio', key: 'calm' },
+      );
+    } else if (input.ssqLevel === 2) {
+      acts.push(
+        { action: 'set_comfort', key: 'low' },
+        { action: 'set_locomotion', key: 'teleport' },
+        { action: 'set_fov', key: 'narrow' },
+        { action: 'set_effects', bloom: false, vignette: 'comfort' },
+      );
+    }
+  }
+
+  if (typeof input.tensionLevel === 'number' && input.tensionLevel >= 3) {
+    acts.push(
+      { action: 'set_duration', key: 'short' },
+      { action: 'set_guidance', key: 'long_exhale' },
+      { action: 'set_particles', density: 'low' },
+      { action: 'set_audio', key: 'calm' },
+    );
+  }
+
+  return acts;
+}

--- a/src/features/vr/vrGalaxy.orchestrator.ts
+++ b/src/features/vr/vrGalaxy.orchestrator.ts
@@ -1,0 +1,93 @@
+import type { OrchestrationInputs } from './types';
+
+export type VRActions =
+  | { action: 'set_comfort'; key: 'very_low' | 'low' | 'medium' }
+  | { action: 'set_duration'; key: 'short' | 'normal' }
+  | { action: 'set_locomotion'; key: 'teleport' | 'smooth' }
+  | { action: 'set_fov'; key: 'narrow' | 'default' }
+  | { action: 'set_effects'; bloom: boolean; vignette: 'none' | 'soft' | 'comfort' }
+  | { action: 'set_particles'; density: 'low' | 'medium' | 'high' }
+  | { action: 'set_audio'; key: 'calm' | 'soft' }
+  | { action: 'set_guidance'; key: 'long_exhale' | 'none' }
+  | { action: 'fallback_2d_next'; enabled: boolean }
+  | { action: 'set_navigation'; speed: 'drift' | 'gentle' | 'cruise' }
+  | { action: 'set_stars'; density: 'thin' | 'balanced' | 'lush' };
+
+export function computeGalaxyActions(input: OrchestrationInputs): VRActions[] {
+  const acts: VRActions[] = [];
+
+  if (input.prm) {
+    acts.push(
+      { action: 'set_comfort', key: 'very_low' },
+      { action: 'set_duration', key: 'short' },
+      { action: 'set_locomotion', key: 'teleport' },
+      { action: 'set_fov', key: 'narrow' },
+      { action: 'set_effects', bloom: false, vignette: 'comfort' },
+      { action: 'set_particles', density: 'low' },
+      { action: 'set_audio', key: 'calm' },
+      { action: 'set_navigation', speed: 'drift' },
+      { action: 'set_stars', density: 'thin' },
+    );
+    return acts;
+  }
+
+  if (input.vrTier === 'low') {
+    acts.push(
+      { action: 'set_comfort', key: 'low' },
+      { action: 'set_duration', key: 'short' },
+      { action: 'set_locomotion', key: 'teleport' },
+      { action: 'set_effects', bloom: false, vignette: 'comfort' },
+      { action: 'set_particles', density: 'low' },
+      { action: 'set_audio', key: 'calm' },
+      { action: 'set_navigation', speed: 'gentle' },
+      { action: 'set_stars', density: 'balanced' },
+    );
+  } else {
+    acts.push(
+      { action: 'set_comfort', key: 'medium' },
+      { action: 'set_duration', key: 'normal' },
+      { action: 'set_locomotion', key: 'smooth' },
+      { action: 'set_effects', bloom: true, vignette: 'soft' },
+      { action: 'set_particles', density: 'medium' },
+      { action: 'set_audio', key: 'soft' },
+      { action: 'set_navigation', speed: input.vrTier === 'high' ? 'cruise' : 'gentle' },
+      { action: 'set_stars', density: input.vrTier === 'high' ? 'lush' : 'balanced' },
+    );
+  }
+
+  if (typeof input.ssqLevel === 'number') {
+    if (input.ssqLevel >= 3) {
+      acts.push({ action: 'fallback_2d_next', enabled: true });
+      acts.push(
+        { action: 'set_comfort', key: 'very_low' },
+        { action: 'set_locomotion', key: 'teleport' },
+        { action: 'set_fov', key: 'narrow' },
+        { action: 'set_effects', bloom: false, vignette: 'comfort' },
+        { action: 'set_particles', density: 'low' },
+        { action: 'set_audio', key: 'calm' },
+        { action: 'set_navigation', speed: 'drift' },
+        { action: 'set_stars', density: 'thin' },
+      );
+    } else if (input.ssqLevel === 2) {
+      acts.push(
+        { action: 'set_comfort', key: 'low' },
+        { action: 'set_locomotion', key: 'teleport' },
+        { action: 'set_fov', key: 'narrow' },
+        { action: 'set_effects', bloom: false, vignette: 'comfort' },
+        { action: 'set_navigation', speed: 'gentle' },
+      );
+    }
+  }
+
+  if (typeof input.tensionLevel === 'number' && input.tensionLevel >= 3) {
+    acts.push(
+      { action: 'set_duration', key: 'short' },
+      { action: 'set_particles', density: 'low' },
+      { action: 'set_audio', key: 'calm' },
+      { action: 'set_navigation', speed: 'drift' },
+      { action: 'set_stars', density: 'thin' },
+    );
+  }
+
+  return acts;
+}

--- a/src/services/sessions/sessionsApi.ts
+++ b/src/services/sessions/sessionsApi.ts
@@ -7,6 +7,8 @@ export type SessionType =
   | 'breath'
   | 'music'
   | 'scan'
+  | 'vr_breath'
+  | 'vr_galaxy'
   | 'ambition'
   | 'grit'
   | 'bubble'


### PR DESCRIPTION
## Summary
- add VR orchestration helpers with tier detection, profile derivation, and dedicated unit tests
- implement adaptive vr-breath and vr-galaxy app pages with consent gating, fallback handling, and post-session assessment prompts
- provide 2D fallback experiences and persist sessions using new VR session types

## Testing
- npx vitest run src/features/vr/__tests__/vrBreath.orchestrator.spec.ts src/features/vr/__tests__/vrGalaxy.orchestrator.spec.ts
- npm run lint *(fails: existing parser errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ceed65e094832d9fcc41b063df6b7d