### PR TITLE
Implement adaptive community and social cocon orchestration

### DIFF
--- a/e2e/community.spec.ts
+++ b/e2e/community.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Community orchestration', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        'orchestration:community',
+        JSON.stringify({ uclaLevel: 3, mspssLevel: 0 }),
+      );
+    });
+    await page.route('**session_text_logs**', async (route) => {
+      await route.fulfill({ status: 200, body: '{}' });
+    });
+  });
+
+  test('surfaces empathic replies and gentle banner without digits', async ({ page }) => {
+    await page.goto('/app/community');
+
+    await expect(page.getByRole('dialog', { name: /Écoute deux minutes/ })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Propositions empathiques' })).toBeVisible();
+
+    const mainCopy = await page.locator('main').innerText();
+    expect(mainCopy).not.toMatch(/\d/);
+
+    await page.getByRole('button', { name: 'Prévisualiser & envoyer' }).first().click();
+    await expect(page.getByRole('dialog', { name: 'Prévisualisation douce' })).toBeVisible();
+    await expect(page.getByRole('textbox', { name: 'Texte empathique à personnaliser' })).toBeEnabled();
+  });
+});

--- a/e2e/social-cocon.spec.ts
+++ b/e2e/social-cocon.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Social Cocon orchestration', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        'orchestration:social_cocon',
+        JSON.stringify({ mspssLevel: 0 }),
+      );
+    });
+    await page.route('**session_text_logs**', async (route) => {
+      await route.fulfill({ status: 200, body: '{}' });
+    });
+  });
+
+  test('promotes shared breaks and highlights private rooms', async ({ page }) => {
+    await page.goto('/app/social-cocon');
+
+    await expect(page.getByRole('heading', { name: 'Planifier une pause partagée' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Proposer le créneau' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Ajouter dans mon agenda' })).toBeVisible();
+
+    const firstRoomHeading = page.locator('section[aria-label="Espaces disponibles"] h3').first();
+    await expect(firstRoomHeading).toContainText('Cercle');
+    await expect(page.getByText('Privé').first()).toBeVisible();
+
+    const mainCopy = await page.locator('main').innerText();
+    expect(mainCopy).not.toMatch(/\d/);
+  });
+});

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -1,0 +1,273 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+import * as Sentry from '@sentry/react';
+
+import ZeroNumberBoundary from '@/components/accessibility/ZeroNumberBoundary';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { useFlags } from '@/core/flags';
+import { useConsent } from '@/features/clinical-optin/ConsentProvider';
+import EmpathicRepliesPanel from '@/features/community/EmpathicRepliesPanel';
+import ListenTwoMinutesBanner from '@/features/community/ListenTwoMinutesBanner';
+import {
+  communityOrchestrator,
+  persistOrchestrationSession,
+  serializeHints,
+  type UIHint,
+} from '@/features/orchestration';
+import { useAssessment } from '@/hooks/useAssessment';
+import { useReducedMotion } from '@/components/ui/AccessibilityOptimized';
+
+const baseCards = [
+  {
+    id: 'social_cocon',
+    title: 'Social Cocon',
+    description: 'Rejoins un cocon privé pour respirer avec d’autres sans obligation de parole.',
+    cta: 'Entrer dans le cocon',
+    href: '/app/social-cocon',
+  },
+  {
+    id: 'gentle_threads',
+    title: 'Fils doux',
+    description: 'Dépose quelques mots dans un fil de discussion apaisé, les réponses arrivent quand elles peuvent.',
+    cta: 'Ouvrir un fil',
+    href: '/app/modules',
+  },
+  {
+    id: 'quiet_library',
+    title: 'Coin inspiration',
+    description: 'Découvre des messages soigneusement préparés pour accompagner ton écoute ou proposer un moment de silence.',
+    cta: 'Explorer les ressources',
+    href: '/app/modules',
+  },
+] as const;
+
+const readMockLevels = () => {
+  if (typeof window === 'undefined') return {} as Partial<Record<'uclaLevel' | 'mspssLevel', number>>;
+  try {
+    const raw = window.localStorage.getItem('orchestration:community');
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    const output: Partial<Record<'uclaLevel' | 'mspssLevel', number>> = {};
+    if (typeof parsed?.uclaLevel === 'number') {
+      output.uclaLevel = parsed.uclaLevel;
+    }
+    if (typeof parsed?.mspssLevel === 'number') {
+      output.mspssLevel = parsed.mspssLevel;
+    }
+    return output;
+  } catch (error) {
+    console.warn('[community/page] unable to parse mock levels', error);
+    return {};
+  }
+};
+
+export default function CommunityPage(): JSX.Element {
+  const { flags } = useFlags();
+  const { clinicalAccepted } = useConsent();
+  const prefersReducedMotion = useReducedMotion();
+  const ucla = useAssessment('UCLA3');
+  const mspss = useAssessment('MSPSS');
+  const [mockLevels, setMockLevels] = useState<Partial<Record<'uclaLevel' | 'mspssLevel', number>>>(() => ({}));
+  const [bannerOpen, setBannerOpen] = useState(false);
+  const [bannerDismissed, setBannerDismissed] = useState(false);
+  const persistedSignatureRef = useRef<string | null>(null);
+  const breadcrumbsSignatureRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') return;
+    setMockLevels(readMockLevels());
+  }, []);
+
+  const orchestrationEnabled = Boolean(flags.FF_COMMUNITY && flags.FF_ORCH_COMMUNITY);
+  const assessmentsEnabled = Boolean(flags.FF_ASSESS_UCLA3 && flags.FF_ASSESS_MSPSS);
+
+  const resolvedUclaLevel = useMemo(() => {
+    if (typeof mockLevels.uclaLevel === 'number') return mockLevels.uclaLevel;
+    return typeof ucla.lastLevel === 'number' ? ucla.lastLevel : undefined;
+  }, [mockLevels.uclaLevel, ucla.lastLevel]);
+
+  const resolvedMspssLevel = useMemo(() => {
+    if (typeof mockLevels.mspssLevel === 'number') return mockLevels.mspssLevel;
+    return typeof mspss.lastLevel === 'number' ? mspss.lastLevel : undefined;
+  }, [mockLevels.mspssLevel, mspss.lastLevel]);
+
+  const consented = Boolean(
+    clinicalAccepted && ucla.state.hasConsent && mspss.state.hasConsent && ucla.state.consentDecision !== 'declined' && mspss.state.consentDecision !== 'declined',
+  );
+
+  const hints: UIHint[] = useMemo(() => {
+    if (!orchestrationEnabled || !assessmentsEnabled) {
+      return [{ action: 'none' }];
+    }
+    return communityOrchestrator({
+      uclaLevel: typeof resolvedUclaLevel === 'number' ? resolvedUclaLevel : undefined,
+      mspssLevel: typeof resolvedMspssLevel === 'number' ? resolvedMspssLevel : undefined,
+      consented,
+    });
+  }, [assessmentsEnabled, consented, orchestrationEnabled, resolvedMspssLevel, resolvedUclaLevel]);
+
+  const actionableHints = hints.filter((hint) => hint.action !== 'none');
+
+  const showBanner = actionableHints.some((hint) => hint.action === 'show_banner');
+  const showReplies = actionableHints.some((hint) => hint.action === 'show_empathic_replies');
+  const pinSocialCocon = actionableHints.some(
+    (hint) => hint.action === 'pin_card' && hint.key === 'social_cocon',
+  );
+
+  useEffect(() => {
+    if (showBanner && !bannerDismissed) {
+      setBannerOpen(true);
+    }
+  }, [bannerDismissed, showBanner]);
+
+  useEffect(() => {
+    if (!showBanner && bannerDismissed) {
+      setBannerDismissed(false);
+    }
+  }, [bannerDismissed, showBanner]);
+
+  const cards = useMemo(() => {
+    const ordered = [...baseCards];
+    if (pinSocialCocon) {
+      const index = ordered.findIndex((card) => card.id === 'social_cocon');
+      if (index > 0) {
+        const [card] = ordered.splice(index, 1);
+        ordered.unshift(card);
+      }
+    }
+    return ordered;
+  }, [pinSocialCocon]);
+
+  const metadata = useMemo(() => {
+    const payload: Record<string, string | undefined> = {};
+    if (showBanner) payload.banner = 'listen_two_minutes';
+    if (showReplies) payload.panel = 'empathic_replies';
+    if (pinSocialCocon) payload.pin = 'social_cocon';
+    return payload;
+  }, [pinSocialCocon, showBanner, showReplies]);
+
+  const serializedHints = useMemo(() => serializeHints(actionableHints), [actionableHints]);
+
+  useEffect(() => {
+    if (!consented) return;
+    const signature = JSON.stringify(metadata);
+    if (!signature || signature === '{}' || signature === persistedSignatureRef.current) return;
+    persistedSignatureRef.current = signature;
+    void persistOrchestrationSession('community', metadata);
+  }, [consented, metadata]);
+
+  useEffect(() => {
+    if (serializedHints.length === 0) return;
+    const signature = serializedHints.join('|');
+    if (breadcrumbsSignatureRef.current === signature) return;
+    breadcrumbsSignatureRef.current = signature;
+
+    serializedHints.forEach((entry) => {
+      if (entry.startsWith('show_banner')) {
+        Sentry.addBreadcrumb({
+          category: 'social',
+          level: 'info',
+          message: 'social:community:banner_shown',
+        });
+      }
+      if (entry === 'show_empathic_replies') {
+        Sentry.addBreadcrumb({
+          category: 'social',
+          level: 'info',
+          message: 'social:replies_shown',
+        });
+      }
+    });
+  }, [serializedHints]);
+
+  const cardMotionClass = prefersReducedMotion ? 'transition-none' : 'transition-transform duration-150 ease-out hover:-translate-y-1';
+
+  const handleBannerAccept = () => {
+    Sentry.addBreadcrumb({
+      category: 'social',
+      level: 'info',
+      message: 'social:community:banner_accepted',
+    });
+    setBannerOpen(false);
+    setBannerDismissed(true);
+  };
+
+  const handleBannerLater = () => {
+    Sentry.addBreadcrumb({
+      category: 'social',
+      level: 'info',
+      message: 'social:community:banner_later',
+    });
+    setBannerOpen(false);
+    setBannerDismissed(true);
+  };
+
+  if (!consented) {
+    return (
+      <ZeroNumberBoundary className="min-h-screen bg-gradient-to-b from-emerald-50 via-white to-emerald-50">
+        <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-8 px-6 py-16 text-emerald-950">
+          <header className="space-y-4">
+            <h1 className="text-3xl font-semibold">Communauté en douceur</h1>
+            <p className="text-base text-emerald-800">
+              Tu peux explorer les espaces partagés sans activer la collecte clinique. Quand tu seras prêt·e, tu pourras accepter l’accompagnement plus structuré.
+            </p>
+          </header>
+          <div className="space-y-4">
+            <Card className="border-emerald-100 bg-white/80">
+              <CardHeader>
+                <CardTitle>Partager un moment</CardTitle>
+                <CardDescription className="text-emerald-700">
+                  Retrouve un cocon de conversation, même sans indicateur clinique. Les échanges restent libres et non mesurés.
+                </CardDescription>
+              </CardHeader>
+              <CardFooter>
+                <Button asChild className="bg-emerald-900 text-emerald-50 hover:bg-emerald-800">
+                  <Link href="/app/social-cocon">Rejoindre le Social Cocon</Link>
+                </Button>
+              </CardFooter>
+            </Card>
+          </div>
+        </main>
+      </ZeroNumberBoundary>
+    );
+  }
+
+  return (
+    <ZeroNumberBoundary className="min-h-screen bg-gradient-to-b from-emerald-50 via-white to-emerald-50">
+      <main className="mx-auto flex w-full max-w-4xl flex-col gap-8 px-6 py-12 text-emerald-950">
+        <header className="space-y-3">
+          <p className="text-sm uppercase tracking-wide text-emerald-600">Communauté apaisée</p>
+          <h1 className="text-3xl font-semibold leading-tight">Trouver un soutien sans chiffres</h1>
+          <p className="max-w-2xl text-base text-emerald-800">
+            Cette page adapte les propositions selon ton ressenti récent. Tout reste textuel et doux, aucune donnée chiffrée n’est affichée.
+          </p>
+        </header>
+
+        {bannerOpen && (
+          <ListenTwoMinutesBanner open={bannerOpen} onAccept={handleBannerAccept} onLater={handleBannerLater} />
+        )}
+
+        {showReplies && <EmpathicRepliesPanel />}
+
+        <section aria-label="Espaces suggérés" className="grid gap-6 md:grid-cols-3">
+          {cards.map((card) => (
+            <Card key={card.id} className={`border-emerald-100 bg-white/80 shadow-sm ${cardMotionClass}`}>
+              <CardHeader>
+                <CardTitle className="text-xl text-emerald-900">{card.title}</CardTitle>
+                <CardDescription className="text-sm text-emerald-700">{card.description}</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Button asChild className="w-full bg-emerald-900 text-emerald-50 hover:bg-emerald-800">
+                  <Link href={card.href}>{card.cta}</Link>
+                </Button>
+              </CardContent>
+            </Card>
+          ))}
+        </section>
+      </main>
+    </ZeroNumberBoundary>
+  );
+}

--- a/src/app/social-cocon/page.tsx
+++ b/src/app/social-cocon/page.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import * as Sentry from '@sentry/react';
+
+import ZeroNumberBoundary from '@/components/accessibility/ZeroNumberBoundary';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useFlags } from '@/core/flags';
+import { useConsent } from '@/features/clinical-optin/ConsentProvider';
+import SchedulePrompt from '@/features/social-cocon/SchedulePrompt';
+import { useSocialRooms } from '@/features/social-cocon/hooks/useSocialRooms';
+import { socialCoconOrchestrator, persistOrchestrationSession, serializeHints, type UIHint } from '@/features/orchestration';
+import { useAssessment } from '@/hooks/useAssessment';
+import type { SocialRoom } from '@/features/social-cocon/types';
+import { useReducedMotion } from '@/components/ui/AccessibilityOptimized';
+
+const readMockLevel = () => {
+  if (typeof window === 'undefined') return undefined;
+  try {
+    const raw = window.localStorage.getItem('orchestration:social_cocon');
+    if (!raw) return undefined;
+    const parsed = JSON.parse(raw);
+    return typeof parsed?.mspssLevel === 'number' ? parsed.mspssLevel : undefined;
+  } catch (error) {
+    console.warn('[social-cocon/page] unable to parse mock level', error);
+    return undefined;
+  }
+};
+
+const describeRoom = (room: SocialRoom) => {
+  if (room.isPrivate) {
+    return 'Espace réservé, invitations discrètes et accès limité.';
+  }
+  if (room.allowAudio) {
+    return 'Salle à la fois vocale et écrite pour improviser ensemble.';
+  }
+  return 'Salon texte idéal pour échanger par messages apaisés.';
+};
+
+export default function SocialCoconPage(): JSX.Element {
+  const { flags } = useFlags();
+  const { clinicalAccepted } = useConsent();
+  const prefersReducedMotion = useReducedMotion();
+  const mspss = useAssessment('MSPSS');
+  const { rooms, isLoading: roomsLoading } = useSocialRooms({ enabled: true });
+  const [mockLevel, setMockLevel] = useState<number | undefined>(undefined);
+  const persistedSignatureRef = useRef<string | null>(null);
+  const breadcrumbsSignatureRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') return;
+    setMockLevel(readMockLevel());
+  }, []);
+
+  const orchestrationEnabled = Boolean(flags.FF_SOCIAL_COCON && flags.FF_ORCH_SOCIAL_COCON);
+  const assessmentEnabled = Boolean(flags.FF_ASSESS_MSPSS);
+
+  const resolvedMspssLevel = useMemo(() => {
+    if (typeof mockLevel === 'number') return mockLevel;
+    return typeof mspss.lastLevel === 'number' ? mspss.lastLevel : undefined;
+  }, [mockLevel, mspss.lastLevel]);
+
+  const consented = Boolean(
+    clinicalAccepted && mspss.state.hasConsent && mspss.state.consentDecision !== 'declined',
+  );
+
+  const hints: UIHint[] = useMemo(() => {
+    if (!orchestrationEnabled || !assessmentEnabled) {
+      return [{ action: 'none' }];
+    }
+    return socialCoconOrchestrator({
+      mspssLevel: typeof resolvedMspssLevel === 'number' ? resolvedMspssLevel : undefined,
+      consented,
+    });
+  }, [assessmentEnabled, consented, orchestrationEnabled, resolvedMspssLevel]);
+
+  const actionableHints = hints.filter((hint) => hint.action !== 'none');
+  const showSchedulePrompt = actionableHints.some(
+    (hint) => hint.action === 'promote_cta' && hint.key === 'schedule_break',
+  );
+  const highlightPrivateRooms = actionableHints.some((hint) => hint.action === 'highlight_rooms_private');
+
+  const metadata = useMemo(() => {
+    const payload: Record<string, string | undefined> = {};
+    if (showSchedulePrompt) payload.cta = 'schedule_break';
+    if (highlightPrivateRooms) payload.highlight = 'rooms_private';
+    return payload;
+  }, [highlightPrivateRooms, showSchedulePrompt]);
+
+  useEffect(() => {
+    if (!consented) return;
+    const signature = JSON.stringify(metadata);
+    if (!signature || signature === '{}' || signature === persistedSignatureRef.current) return;
+    persistedSignatureRef.current = signature;
+    void persistOrchestrationSession('social_cocon', metadata);
+  }, [consented, metadata]);
+
+  const serializedHints = useMemo(() => serializeHints(actionableHints), [actionableHints]);
+
+  useEffect(() => {
+    if (serializedHints.length === 0) return;
+    const signature = serializedHints.join('|');
+    if (breadcrumbsSignatureRef.current === signature) return;
+    breadcrumbsSignatureRef.current = signature;
+
+    serializedHints.forEach((entry) => {
+      if (entry.startsWith('promote_cta:schedule_break')) {
+        Sentry.addBreadcrumb({
+          category: 'social',
+          level: 'info',
+          message: 'social:schedule_prompt_shown',
+        });
+      }
+      if (entry === 'highlight_rooms_private') {
+        Sentry.addBreadcrumb({
+          category: 'social',
+          level: 'info',
+          message: 'social:room_highlighted',
+        });
+      }
+    });
+  }, [serializedHints]);
+
+  const sortedRooms = useMemo(() => {
+    if (!highlightPrivateRooms) return rooms;
+    return [...rooms].sort((a, b) => Number(b.isPrivate) - Number(a.isPrivate));
+  }, [highlightPrivateRooms, rooms]);
+
+  const cardMotionClass = prefersReducedMotion
+    ? 'transition-none'
+    : 'transition-transform duration-150 ease-out hover:-translate-y-1';
+
+  if (!consented) {
+    return (
+      <ZeroNumberBoundary className="min-h-screen bg-gradient-to-b from-indigo-50 via-white to-indigo-100">
+        <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-8 px-6 py-16 text-indigo-950">
+          <header className="space-y-4">
+            <h1 className="text-3xl font-semibold">Social Cocon</h1>
+            <p className="text-base text-indigo-800">
+              Les rooms restent accessibles même sans instrumentation clinique. Tu peux observer ou rejoindre une conversation librement.
+            </p>
+          </header>
+        </main>
+      </ZeroNumberBoundary>
+    );
+  }
+
+  return (
+    <ZeroNumberBoundary className="min-h-screen bg-gradient-to-b from-indigo-50 via-white to-indigo-100">
+      <main className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-6 py-12 text-indigo-950">
+        <header className="space-y-3">
+          <p className="text-sm uppercase tracking-wide text-indigo-600">Cocon social</p>
+          <h1 className="text-3xl font-semibold leading-tight">Planifier des respirations ensemble</h1>
+          <p className="max-w-2xl text-base text-indigo-800">
+            Les suggestions ci-dessous évoluent selon ton ressenti de soutien social. Les messages restent textuels, aucune valeur chiffrée n’est affichée.
+          </p>
+        </header>
+
+        {showSchedulePrompt && <SchedulePrompt highlightRooms={highlightPrivateRooms} />}
+
+        <section aria-label="Espaces disponibles" className="space-y-4">
+          <h2 className="text-2xl font-semibold text-indigo-900">Rooms tranquilles</h2>
+          <div className="grid gap-4 md:grid-cols-2">
+            {sortedRooms.map((room) => (
+              <Card
+                key={room.id}
+                className={`border-indigo-100 bg-white/80 shadow-sm ${cardMotionClass} ${
+                  highlightPrivateRooms && room.isPrivate ? 'ring-2 ring-indigo-400' : ''
+                }`}
+              >
+                <CardHeader>
+                  <CardTitle className="flex items-center justify-between text-lg text-indigo-900">
+                    {room.name}
+                    {room.isPrivate && <Badge className="bg-indigo-900 text-indigo-50">Privé</Badge>}
+                  </CardTitle>
+                  <CardDescription className="text-sm text-indigo-700">{room.topic}</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-2 text-sm text-indigo-800">
+                  <p>{describeRoom(room)}</p>
+                  <div className="flex flex-wrap gap-2 text-xs uppercase tracking-wide text-indigo-600">
+                    {room.allowAudio ? <span className="rounded-full bg-indigo-100 px-3 py-1">Voix douce</span> : null}
+                    <span className="rounded-full bg-indigo-100 px-3 py-1">Messages</span>
+                    {room.softModeEnabled ? (
+                      <span className="rounded-full bg-indigo-100 px-3 py-1">Mode feutré</span>
+                    ) : (
+                      <span className="rounded-full bg-indigo-100 px-3 py-1">Ambiance libre</span>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+            {!roomsLoading && sortedRooms.length === 0 && (
+              <Card className="border-indigo-100 bg-white/70 shadow-none">
+                <CardHeader>
+                  <CardTitle className="text-lg text-indigo-900">Pas encore de rooms</CardTitle>
+                  <CardDescription className="text-indigo-700">
+                    Lance la première invitation depuis le module de planification ci-dessus.
+                  </CardDescription>
+                </CardHeader>
+              </Card>
+            )}
+          </div>
+        </section>
+      </main>
+    </ZeroNumberBoundary>
+  );
+}

--- a/src/features/community/EmpathicRepliesPanel.tsx
+++ b/src/features/community/EmpathicRepliesPanel.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import * as Sentry from '@sentry/react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/components/ui/use-toast';
+import { FocusTrap, useReducedMotion } from '@/components/ui/AccessibilityOptimized';
+
+const REPLIES = [
+  {
+    id: 'listen_here',
+    title: 'Présence discrète',
+    suggestion: 'Je suis là si tu veux en parler.',
+    description: 'Un message doux pour signaler une oreille attentive.',
+  },
+  {
+    id: 'two_minutes',
+    title: 'Pause silencieuse',
+    suggestion: 'On prend deux minutes en silence si tu veux.',
+    description: 'Invitation à respirer ensemble sans obligation.',
+  },
+  {
+    id: 'validating',
+    title: 'Validation rassurante',
+    suggestion: 'Ce que tu ressens compte et peut être partagé ici.',
+    description: 'Pour rappeler que chaque émotion est légitime.',
+  },
+] as const;
+
+const sanitize = (value: string) =>
+  value
+    .replace(/<[^>]+>/g, '')
+    .replace(/\r?\n/g, '\n')
+    .replace(/[^\S\n]+/g, ' ')
+    .trim();
+
+type PreviewState = {
+  id: string;
+  text: string;
+};
+
+const dialogMotionClass = 'data-[state=open]:animate-in data-[state=closed]:animate-out';
+
+export default function EmpathicRepliesPanel(): JSX.Element {
+  const prefersReducedMotion = useReducedMotion();
+  const { toast } = useToast();
+  const [preview, setPreview] = useState<PreviewState | null>(null);
+  const [copySuccess, setCopySuccess] = useState<string | null>(null);
+
+  const openPreview = useCallback((templateId: string) => {
+    const template = REPLIES.find((entry) => entry.id === templateId);
+    if (!template) return;
+
+    setPreview({ id: template.id, text: template.suggestion });
+    setCopySuccess(null);
+    Sentry.addBreadcrumb({
+      category: 'social',
+      level: 'info',
+      message: 'social:replies_preview_open',
+      data: { template: templateId },
+    });
+  }, []);
+
+  const closePreview = useCallback(() => {
+    setPreview(null);
+    setCopySuccess(null);
+  }, []);
+
+  const handleChange = useCallback((value: string) => {
+    setPreview((current) => (current ? { ...current, text: sanitize(value) } : current));
+  }, []);
+
+  const handleCopy = useCallback(async () => {
+    if (!preview) return;
+    try {
+      await navigator.clipboard?.writeText(preview.text);
+      setCopySuccess('Texte copié, tu peux l’envoyer à ton rythme.');
+      toast({
+        title: 'Texte prêt',
+        description: 'Le message est dans le presse-papiers. Tu peux encore l’adapter.',
+        variant: 'success',
+      });
+      Sentry.addBreadcrumb({
+        category: 'social',
+        level: 'info',
+        message: 'social:reply_copied',
+        data: { template: preview.id },
+      });
+    } catch (error) {
+      console.warn('[EmpathicRepliesPanel] copy failed', error);
+      toast({
+        title: 'Copie impossible',
+        description: 'Tu peux sélectionner le texte et le copier manuellement.',
+        variant: 'warning',
+      });
+      Sentry.captureException(error, {
+        tags: { scope: 'community', action: 'copy_reply' },
+      });
+    }
+  }, [preview, toast]);
+
+  const dialogClasses = useMemo(() => (
+    prefersReducedMotion ? dialogMotionClass.replace(/data-\[state=.*?\]:animate-[^\s]+/g, 'transition-none') : dialogMotionClass
+  ), [prefersReducedMotion]);
+
+  return (
+    <section
+      aria-labelledby="community-empathic-replies"
+      aria-live="polite"
+      className="space-y-6 rounded-xl border border-emerald-100/70 bg-emerald-50/70 p-6 text-emerald-950 shadow-sm"
+    >
+      <header className="space-y-2">
+        <p className="text-sm uppercase tracking-wide text-emerald-600">Soutien prêt à envoyer</p>
+        <h2 id="community-empathic-replies" className="text-2xl font-semibold">Propositions empathiques</h2>
+        <p className="max-w-2xl text-sm text-emerald-700">
+          Ces phrases sont des points de départ. Tu peux les personnaliser avant de les partager, elles n’impliquent aucun envoi automatique.
+        </p>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        {REPLIES.map((entry) => (
+          <Card key={entry.id} className="border-transparent bg-white/80 shadow-none transition-colors hover:bg-white">
+            <CardHeader>
+              <CardTitle className="text-lg font-medium text-emerald-900">{entry.title}</CardTitle>
+              <CardDescription className="text-sm text-emerald-700">{entry.description}</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <p className="rounded-md bg-emerald-100/80 p-3 text-sm text-emerald-900">{entry.suggestion}</p>
+              <Button
+                type="button"
+                variant="secondary"
+                className="w-full bg-emerald-900 text-emerald-50 hover:bg-emerald-800"
+                onClick={() => openPreview(entry.id)}
+              >
+                Prévisualiser & envoyer
+              </Button>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <Dialog open={Boolean(preview)} onOpenChange={(open) => (open ? undefined : closePreview())}>
+        {preview && (
+          <DialogContent className={`${dialogClasses} bg-white text-emerald-950`}>
+            <FocusTrap active>
+              <DialogHeader>
+                <DialogTitle>Prévisualisation douce</DialogTitle>
+                <DialogDescription>
+                  Ajuste librement le message avant de le partager. Aucun envoi automatique n’est déclenché.
+                </DialogDescription>
+              </DialogHeader>
+              <Textarea
+                value={preview.text}
+                onChange={(event) => handleChange(event.target.value)}
+                aria-label="Texte empathique à personnaliser"
+                className="min-h-[8rem] resize-none border-emerald-200 focus:border-emerald-400 focus:ring-emerald-200"
+              />
+              {copySuccess && (
+                <p className="text-sm text-emerald-700" role="status" aria-live="polite">
+                  {copySuccess}
+                </p>
+              )}
+              <DialogFooter className="gap-3">
+                <Button
+                  type="button"
+                  onClick={handleCopy}
+                  className="bg-emerald-900 text-emerald-50 hover:bg-emerald-800"
+                >
+                  Copier pour l’envoyer
+                </Button>
+                <DialogClose asChild>
+                  <Button type="button" variant="ghost" className="text-emerald-700 hover:bg-emerald-100">
+                    Fermer
+                  </Button>
+                </DialogClose>
+              </DialogFooter>
+            </FocusTrap>
+          </DialogContent>
+        )}
+      </Dialog>
+    </section>
+  );
+}

--- a/src/features/community/ListenTwoMinutesBanner.tsx
+++ b/src/features/community/ListenTwoMinutesBanner.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { FocusTrap, useReducedMotion } from '@/components/ui/AccessibilityOptimized';
+
+interface ListenTwoMinutesBannerProps {
+  open: boolean;
+  onAccept: () => void;
+  onLater: () => void;
+}
+
+export default function ListenTwoMinutesBanner({
+  open,
+  onAccept,
+  onLater,
+}: ListenTwoMinutesBannerProps): JSX.Element | null {
+  const [isOpen, setIsOpen] = useState(open);
+  const prefersReducedMotion = useReducedMotion();
+  const bannerRef = useRef<HTMLDivElement | null>(null);
+  const primaryRef = useRef<HTMLButtonElement | null>(null);
+
+  const handleAccept = useCallback(() => {
+    onAccept();
+    setIsOpen(false);
+  }, [onAccept]);
+
+  const handleLater = useCallback(() => {
+    onLater();
+    setIsOpen(false);
+  }, [onLater]);
+
+  useEffect(() => {
+    setIsOpen(open);
+  }, [open]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const node = bannerRef.current;
+
+    if (node) {
+      requestAnimationFrame(() => {
+        primaryRef.current?.focus({ preventScroll: true });
+      });
+    }
+
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        handleLater();
+      }
+    };
+
+    document.addEventListener('keydown', handleKey);
+
+    return () => {
+      document.removeEventListener('keydown', handleKey);
+      previouslyFocused?.focus?.();
+    };
+  }, [handleLater, isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const motionClass = prefersReducedMotion
+    ? 'transition-none'
+    : 'transition-all duration-150 ease-out';
+
+  return (
+    <div
+      ref={bannerRef}
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby="listen-banner-title"
+      aria-describedby="listen-banner-description"
+      aria-live="polite"
+      className={`rounded-2xl border border-emerald-100 bg-white p-6 shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 ${motionClass}`}
+    >
+      <FocusTrap active>
+        <div className="space-y-3">
+          <p className="text-sm uppercase tracking-wide text-emerald-600" id="listen-banner-title">
+            Écoute deux minutes ?
+          </p>
+          <p className="text-base text-emerald-900" id="listen-banner-description">
+            On peut simplement rester côte à côte, en silence ou avec un souffle doux. Tu choisis le rythme.
+          </p>
+          <div className="flex flex-wrap gap-3 pt-2">
+            <Button
+              ref={primaryRef}
+              type="button"
+              className="bg-emerald-900 text-emerald-50 hover:bg-emerald-800"
+              onClick={handleAccept}
+            >
+              Oui
+            </Button>
+            <Button type="button" variant="ghost" className="text-emerald-800 hover:bg-emerald-100" onClick={handleLater}>
+              Plus tard
+            </Button>
+          </div>
+        </div>
+      </FocusTrap>
+    </div>
+  );
+}

--- a/src/features/orchestration/community.orchestrator.spec.ts
+++ b/src/features/orchestration/community.orchestrator.spec.ts
@@ -4,7 +4,7 @@ import { communityOrchestrator } from './community.orchestrator';
 
 describe('communityOrchestrator', () => {
   it('returns banner and pinned card when UCLA level is high', () => {
-    const hints = communityOrchestrator({ ucla3Level: 3 });
+    const hints = communityOrchestrator({ uclaLevel: 3, consented: true });
     expect(hints).toEqual([
       { action: 'show_banner', key: 'listen_two_minutes' },
       { action: 'pin_card', key: 'social_cocon' },
@@ -12,21 +12,26 @@ describe('communityOrchestrator', () => {
   });
 
   it('returns empathic reply suggestions when MSPSS is low', () => {
-    const hints = communityOrchestrator({ mspssLevel: 1 });
-    expect(hints).toEqual([{ action: 'suggest_replies', key: 'empathic_templates' }]);
+    const hints = communityOrchestrator({ mspssLevel: 1, consented: true });
+    expect(hints).toEqual([{ action: 'show_empathic_replies' }]);
   });
 
   it('combines hints when both signals are present', () => {
-    const hints = communityOrchestrator({ ucla3Level: 4, mspssLevel: 0 });
+    const hints = communityOrchestrator({ uclaLevel: 4, mspssLevel: 0, consented: true });
     expect(hints).toEqual([
       { action: 'show_banner', key: 'listen_two_minutes' },
       { action: 'pin_card', key: 'social_cocon' },
-      { action: 'suggest_replies', key: 'empathic_templates' },
+      { action: 'show_empathic_replies' },
     ]);
   });
 
   it('ignores undefined levels', () => {
-    const hints = communityOrchestrator({});
-    expect(hints).toEqual([]);
+    const hints = communityOrchestrator({ consented: true });
+    expect(hints).toEqual([{ action: 'none' }]);
+  });
+
+  it('suppresses orchestration when consent is missing', () => {
+    const hints = communityOrchestrator({ uclaLevel: 4, mspssLevel: 0, consented: false });
+    expect(hints).toEqual([{ action: 'none' }]);
   });
 });

--- a/src/features/orchestration/community.orchestrator.ts
+++ b/src/features/orchestration/community.orchestrator.ts
@@ -2,19 +2,27 @@ import type { CommunityLevels, Orchestrator, UIHint } from './types';
 
 const isLevelDefined = (value: number | undefined): value is number => typeof value === 'number';
 
-export const communityOrchestrator: Orchestrator<CommunityLevels> = ({ ucla3Level, mspssLevel }) => {
+export const communityOrchestrator: Orchestrator<CommunityLevels> = ({
+  uclaLevel,
+  mspssLevel,
+  consented,
+}) => {
+  if (!consented) {
+    return [{ action: 'none' }];
+  }
+
   const hints: UIHint[] = [];
 
-  if (isLevelDefined(ucla3Level) && ucla3Level >= 3) {
+  if (isLevelDefined(uclaLevel) && uclaLevel >= 3) {
     hints.push({ action: 'show_banner', key: 'listen_two_minutes' });
     hints.push({ action: 'pin_card', key: 'social_cocon' });
   }
 
   if (isLevelDefined(mspssLevel) && mspssLevel <= 1) {
-    hints.push({ action: 'suggest_replies', key: 'empathic_templates' });
+    hints.push({ action: 'show_empathic_replies' });
   }
 
-  return hints;
+  return hints.length ? hints : [{ action: 'none' }];
 };
 
 export const computeCommunityUIHints = (levels: CommunityLevels) => communityOrchestrator(levels);

--- a/src/features/orchestration/index.ts
+++ b/src/features/orchestration/index.ts
@@ -4,3 +4,4 @@ export * from './socialCocon.orchestrator';
 export * from './leaderboardAuras.orchestrator';
 export * from './journal.orchestrator';
 export * from './moodMixer.orchestrator';
+export * from './persistOrchestrationSession';

--- a/src/features/orchestration/persistOrchestrationSession.ts
+++ b/src/features/orchestration/persistOrchestrationSession.ts
@@ -1,0 +1,60 @@
+import * as Sentry from '@sentry/react';
+
+import { supabase } from '@/integrations/supabase/client';
+
+export type OrchestrationModule = 'community' | 'social_cocon';
+export type OrchestrationMetadata = Record<string, string | undefined>;
+
+const TABLE = 'session_text_logs';
+
+const sanitizeMetadata = (metadata: OrchestrationMetadata) =>
+  Object.entries(metadata).reduce<Record<string, string>>((acc, [key, value]) => {
+    if (typeof value === 'string' && value.trim().length > 0) {
+      acc[key] = value.trim();
+    }
+    return acc;
+  }, {});
+
+export async function persistOrchestrationSession(
+  module: OrchestrationModule,
+  metadata: OrchestrationMetadata,
+): Promise<void> {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const sanitized = sanitizeMetadata(metadata);
+  if (!Object.keys(sanitized).length) {
+    return;
+  }
+
+  const createdAt = new Date().toISOString();
+
+  Sentry.addBreadcrumb({
+    category: 'session',
+    message: 'session:persist:orchestration',
+    level: 'info',
+    data: { module, ...sanitized },
+  });
+
+  console.info('[orchestration] persist', { module, metadata: sanitized });
+
+  try {
+    const { error } = await supabase
+      .from(TABLE)
+      .insert({
+        module,
+        created_at: createdAt,
+        metadata: sanitized,
+      });
+
+    if (error) {
+      throw error;
+    }
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: { module, scope: 'orchestration' },
+      extra: { metadata: sanitized },
+    });
+  }
+}

--- a/src/features/orchestration/socialCocon.orchestrator.spec.ts
+++ b/src/features/orchestration/socialCocon.orchestrator.spec.ts
@@ -3,20 +3,24 @@ import { describe, expect, it } from 'vitest';
 import { socialCoconOrchestrator } from './socialCocon.orchestrator';
 
 describe('socialCoconOrchestrator', () => {
-  it('prioritises CTA and promotes rooms when MSPSS is low', () => {
-    const hints = socialCoconOrchestrator({ mspssLevel: 1 });
+  it('promotes planning and highlights rooms when MSPSS is low', () => {
+    const hints = socialCoconOrchestrator({ mspssLevel: 1, consented: true });
     expect(hints).toEqual([
-      { action: 'prioritize_cta', key: 'plan_pause' },
-      { action: 'promote_rooms_private', enabled: true },
+      { action: 'promote_cta', key: 'schedule_break' },
+      { action: 'highlight_rooms_private' },
     ]);
   });
 
   it('returns empty hints when MSPSS is not low', () => {
-    const hints = socialCoconOrchestrator({ mspssLevel: 3 });
-    expect(hints).toEqual([]);
+    const hints = socialCoconOrchestrator({ mspssLevel: 3, consented: true });
+    expect(hints).toEqual([{ action: 'none' }]);
   });
 
   it('ignores undefined level', () => {
-    expect(socialCoconOrchestrator({})).toEqual([]);
+    expect(socialCoconOrchestrator({ consented: true })).toEqual([{ action: 'none' }]);
+  });
+
+  it('suppresses orchestration when consent missing', () => {
+    expect(socialCoconOrchestrator({ mspssLevel: 0, consented: false })).toEqual([{ action: 'none' }]);
   });
 });

--- a/src/features/orchestration/socialCocon.orchestrator.ts
+++ b/src/features/orchestration/socialCocon.orchestrator.ts
@@ -2,15 +2,19 @@ import type { Orchestrator, SocialCoconLevels, UIHint } from './types';
 
 const isLevelDefined = (value: number | undefined): value is number => typeof value === 'number';
 
-export const socialCoconOrchestrator: Orchestrator<SocialCoconLevels> = ({ mspssLevel }) => {
+export const socialCoconOrchestrator: Orchestrator<SocialCoconLevels> = ({ mspssLevel, consented }) => {
+  if (!consented) {
+    return [{ action: 'none' }];
+  }
+
   const hints: UIHint[] = [];
 
   if (isLevelDefined(mspssLevel) && mspssLevel <= 1) {
-    hints.push({ action: 'prioritize_cta', key: 'plan_pause' });
-    hints.push({ action: 'promote_rooms_private', enabled: true });
+    hints.push({ action: 'promote_cta', key: 'schedule_break' });
+    hints.push({ action: 'highlight_rooms_private' });
   }
 
-  return hints;
+  return hints.length ? hints : [{ action: 'none' }];
 };
 
 export const computeSocialCoconUIHints = (levels: SocialCoconLevels) => socialCoconOrchestrator(levels);

--- a/src/features/orchestration/types.ts
+++ b/src/features/orchestration/types.ts
@@ -58,21 +58,26 @@ export interface BossGritOrchestratorInput {
 export interface BubbleBeatOrchestratorInput {
   pss10Level: number;
 }
+export type AssessmentLevel = 0 | 1 | 2 | 3 | 4;
+
 export type UIHint =
   | { action: 'show_banner'; key: 'listen_two_minutes' }
   | { action: 'pin_card'; key: 'social_cocon' }
-  | { action: 'suggest_replies'; key: 'empathic_templates' }
-  | { action: 'prioritize_cta'; key: 'plan_pause' }
-  | { action: 'promote_rooms_private'; enabled: boolean }
+  | { action: 'show_empathic_replies' }
+  | { action: 'promote_cta'; key: 'schedule_break' }
+  | { action: 'highlight_rooms_private' }
+  | { action: 'none' }
   | { action: 'set_aura'; key: 'cool_gentle' | 'neutral' | 'warm_soft' };
 
 export interface CommunityLevels {
-  ucla3Level?: number;
+  uclaLevel?: number;
   mspssLevel?: number;
+  consented: boolean;
 }
 
 export interface SocialCoconLevels {
   mspssLevel?: number;
+  consented: boolean;
 }
 
 export interface AurasLevels {

--- a/src/features/social-cocon/SchedulePrompt.tsx
+++ b/src/features/social-cocon/SchedulePrompt.tsx
@@ -1,0 +1,264 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import * as Sentry from '@sentry/react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { useReducedMotion } from '@/components/ui/AccessibilityOptimized';
+import { useSocialBreakPlanner } from '@/features/social-cocon/hooks/useSocialBreakPlanner';
+import { useSocialRooms } from '@/features/social-cocon/hooks/useSocialRooms';
+import type { SocialRoom } from '@/features/social-cocon/types';
+
+const DURATION_OPTIONS = [
+  { id: 'soft', label: 'Moment très court (autour de dix minutes)', minutes: 10 },
+  { id: 'tender', label: 'Moment prolongé (presque un quart d’heure)', minutes: 15 },
+] as const;
+
+const DELIVERY_CHANNELS: Array<{ id: 'in-app' | 'email'; label: string }> = [
+  { id: 'in-app', label: 'Petit rappel discret dans l’app' },
+  { id: 'email', label: 'Courriel doux pour prévenir la pause' },
+];
+
+const formatIcsDate = (date: Date) => {
+  const pad = (value: number) => String(value).padStart(2, '0');
+  return `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}T${pad(date.getUTCHours())}${pad(date.getUTCMinutes())}${pad(date.getUTCSeconds())}Z`;
+};
+
+const createIcsFile = (durationMinutes: number) => {
+  const start = new Date(Date.now() + 5 * 60 * 1000);
+  const end = new Date(start.getTime() + durationMinutes * 60 * 1000);
+  const body = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//EmotionsCare//Social Cocon//FR',
+    'BEGIN:VEVENT',
+    `UID:${start.getTime()}@social-cocon`,
+    `DTSTAMP:${formatIcsDate(new Date())}`,
+    `DTSTART:${formatIcsDate(start)}`,
+    `DTEND:${formatIcsDate(end)}`,
+    'SUMMARY:Pause douce à partager',
+    'DESCRIPTION:Un moment calme proposé depuis le Social Cocon.',
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].join('\n');
+
+  return new Blob([body], { type: 'text/calendar' });
+};
+
+interface SchedulePromptProps {
+  highlightRooms?: boolean;
+}
+
+export default function SchedulePrompt({ highlightRooms = false }: SchedulePromptProps): JSX.Element {
+  const prefersReducedMotion = useReducedMotion();
+  const { rooms, isLoading: roomsLoading } = useSocialRooms({ enabled: true });
+  const { scheduleBreak, isScheduling } = useSocialBreakPlanner({ enabled: true });
+  const [roomId, setRoomId] = useState<string>('');
+  const [durationId, setDurationId] = useState<(typeof DURATION_OPTIONS)[number]['id']>('soft');
+  const [reminderOptIn, setReminderOptIn] = useState(true);
+  const [deliveryChannel, setDeliveryChannel] = useState<'in-app' | 'email'>('in-app');
+  const [status, setStatus] = useState<string | null>(null);
+  const icsUrlRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!roomId && rooms.length > 0) {
+      const preferred = rooms.find((room) => room.isPrivate) ?? rooms[0];
+      setRoomId(preferred.id);
+    }
+  }, [roomId, rooms]);
+
+  useEffect(() => () => {
+    if (icsUrlRef.current) {
+      URL.revokeObjectURL(icsUrlRef.current);
+      icsUrlRef.current = null;
+    }
+  }, []);
+
+  const sortedRooms = useMemo(() => {
+    if (!highlightRooms) return rooms;
+    return [...rooms].sort((a, b) => Number(b.isPrivate) - Number(a.isPrivate));
+  }, [highlightRooms, rooms]);
+
+  const durationMinutes = useMemo(() => {
+    const option = DURATION_OPTIONS.find((entry) => entry.id === durationId) ?? DURATION_OPTIONS[0];
+    return option.minutes;
+  }, [durationId]);
+
+  const selectedRoom = useMemo<SocialRoom | undefined>(
+    () => sortedRooms.find((room) => room.id === roomId),
+    [roomId, sortedRooms],
+  );
+
+  const handlePlan = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setStatus(null);
+
+      if (!roomId) {
+        setStatus('Choisis un espace à rejoindre avant de planifier.');
+        return;
+      }
+
+      const startsAt = new Date(Date.now() + 10 * 60 * 1000);
+
+      try {
+        const result = await scheduleBreak({
+          roomId,
+          startsAtUtc: startsAt.toISOString(),
+          durationMinutes,
+          reminderOptIn,
+          deliveryChannel,
+          invitees: [],
+        });
+
+        if (!result) {
+          throw new Error('schedule_failed');
+        }
+
+        Sentry.addBreadcrumb({
+          category: 'social',
+          level: 'info',
+          message: 'social:break_planned',
+          data: { roomId, deliveryChannel },
+        });
+
+        setStatus('Pause planifiée, un rappel sera glissé en douceur.');
+      } catch (error) {
+        console.warn('[SchedulePrompt] scheduleBreak failed', error);
+        Sentry.captureException(error, {
+          tags: { scope: 'social_cocon', action: 'schedule_break' },
+        });
+        setStatus('Impossible de planifier automatiquement. Tu peux ajouter la pause à ton agenda.');
+      }
+    },
+    [deliveryChannel, durationMinutes, reminderOptIn, roomId, scheduleBreak],
+  );
+
+  const handleDownloadIcs = useCallback(() => {
+    if (icsUrlRef.current) {
+      URL.revokeObjectURL(icsUrlRef.current);
+      icsUrlRef.current = null;
+    }
+    const blob = createIcsFile(durationMinutes);
+    icsUrlRef.current = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = icsUrlRef.current;
+    anchor.download = 'pause-douce.ics';
+    document.body.append(anchor);
+    anchor.click();
+    anchor.remove();
+  }, [durationMinutes]);
+
+  const motionClass = prefersReducedMotion ? 'transition-none' : 'transition-all duration-150 ease-out';
+
+  return (
+    <Card className={`border-emerald-100 bg-emerald-50/80 text-emerald-950 shadow-sm ${motionClass}`}>
+      <CardHeader>
+        <CardTitle className="text-xl">Planifier une pause partagée</CardTitle>
+        <CardDescription className="text-sm text-emerald-700">
+          Choisis un cocon, propose un moment respiré et précise si tu souhaites un rappel discret.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form className="space-y-5" onSubmit={handlePlan}>
+          <div className="space-y-2">
+              <Label htmlFor="schedule-room">Espace choisi</Label>
+              <Select value={roomId} onValueChange={setRoomId} disabled={roomsLoading || sortedRooms.length === 0}>
+                <SelectTrigger id="schedule-room" className={highlightRooms ? 'border-emerald-400' : undefined}>
+                  <SelectValue placeholder="Sélectionne un cocon" />
+                </SelectTrigger>
+                <SelectContent>
+                  {sortedRooms.map((room) => (
+                    <SelectItem key={room.id} value={room.id} className={room.isPrivate ? 'font-semibold text-emerald-900' : ''}>
+                      {room.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {selectedRoom && selectedRoom.isPrivate && (
+                <p className="text-sm text-emerald-700">Cet espace est réservé, parfait pour une conversation intime.</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="schedule-duration">Durée souhaitée</Label>
+              <Select value={durationId} onValueChange={(value) => setDurationId(value as typeof durationId)}>
+                <SelectTrigger id="schedule-duration">
+                  <SelectValue placeholder="Choisis la durée" />
+                </SelectTrigger>
+                <SelectContent>
+                  {DURATION_OPTIONS.map((option) => (
+                    <SelectItem key={option.id} value={option.id}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-3">
+              <Label htmlFor="schedule-reminder">Souhaites-tu un rappel ?</Label>
+              <div className="flex items-center gap-3 rounded-lg bg-white/70 p-3">
+                <Switch
+                  id="schedule-reminder"
+                  checked={reminderOptIn}
+                  onCheckedChange={setReminderOptIn}
+                  aria-label="Activer un rappel"
+                />
+                <span className="text-sm text-emerald-800">
+                  Recevoir une douce notification avant la pause.
+                </span>
+              </div>
+            </div>
+
+            {reminderOptIn && (
+              <div className="space-y-2">
+                <Label htmlFor="schedule-channel">Canal préféré</Label>
+                <Select value={deliveryChannel} onValueChange={(value) => setDeliveryChannel(value as 'in-app' | 'email')}>
+                  <SelectTrigger id="schedule-channel">
+                    <SelectValue placeholder="Choisis le canal" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {DELIVERY_CHANNELS.map((entry) => (
+                      <SelectItem key={entry.id} value={entry.id}>
+                        {entry.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            <div className="flex flex-wrap items-center gap-3 pt-2">
+              <Button
+                type="submit"
+                className="bg-emerald-900 text-emerald-50 hover:bg-emerald-800"
+                disabled={roomsLoading || isScheduling || !roomId}
+              >
+                {isScheduling ? 'Planification en cours…' : 'Proposer le créneau'}
+              </Button>
+              <Button type="button" variant="ghost" className="text-emerald-800 hover:bg-emerald-100" onClick={handleDownloadIcs}>
+                Ajouter dans mon agenda
+              </Button>
+            </div>
+
+            {status && (
+              <p className="text-sm text-emerald-800" role="status" aria-live="polite">
+                {status}
+              </p>
+            )}
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/B2CCommunautePage.tsx
+++ b/src/pages/B2CCommunautePage.tsx
@@ -214,12 +214,15 @@ const B2CCommunautePage: React.FC = () => {
     ? latestMSPSS?.level ?? mspAssessment.state.lastComputation?.level
     : undefined;
 
+  const consented = Boolean(uclaAssessment.state.hasConsent && mspAssessment.state.hasConsent);
+
   const communityLevels = useMemo(
     () => ({
-      ucla3Level: typeof resolvedUclaLevel === 'number' ? resolvedUclaLevel : undefined,
+      uclaLevel: typeof resolvedUclaLevel === 'number' ? resolvedUclaLevel : undefined,
       mspssLevel: typeof resolvedMspssLevel === 'number' ? resolvedMspssLevel : undefined,
+      consented,
     }),
-    [resolvedUclaLevel, resolvedMspssLevel],
+    [consented, resolvedMspssLevel, resolvedUclaLevel],
   );
 
   const rawCommunityHints = useMemo(
@@ -244,7 +247,7 @@ const B2CCommunautePage: React.FC = () => {
     (hint) => hint.action === 'pin_card' && hint.key === 'social_cocon',
   );
   const shouldSuggestReplies = communityHints.some(
-    (hint) => hint.action === 'suggest_replies' && hint.key === 'empathic_templates',
+    (hint) => hint.action === 'show_empathic_replies',
   );
 
   const bannerTrapRef = useRef<HTMLDivElement | null>(null);

--- a/src/pages/B2CSocialCoconPage.tsx
+++ b/src/pages/B2CSocialCoconPage.tsx
@@ -138,16 +138,24 @@ const B2CSocialCoconPage: React.FC = () => {
     ? mspssHistory?.[0]?.level ?? mspssAssessment.state.lastComputation?.level
     : undefined;
 
+  const consented = Boolean(mspssAssessment.state.hasConsent);
+
   const socialHints = useMemo(
-    () => (orchestratorEnabled ? computeSocialCoconUIHints({ mspssLevel }) : []),
-    [mspssLevel, orchestratorEnabled],
+    () =>
+      orchestratorEnabled
+        ? computeSocialCoconUIHints({
+            mspssLevel: typeof mspssLevel === 'number' ? mspssLevel : undefined,
+            consented,
+          })
+        : [],
+    [consented, mspssLevel, orchestratorEnabled],
   );
 
   const shouldPrioritizeCta = socialHints.some(
-    (hint) => hint.action === 'prioritize_cta' && hint.key === 'plan_pause',
+    (hint) => hint.action === 'promote_cta' && hint.key === 'schedule_break',
   );
   const shouldPromoteRooms = socialHints.some(
-    (hint) => hint.action === 'promote_rooms_private' && hint.enabled,
+    (hint) => hint.action === 'highlight_rooms_private',
   );
 
   const serializedHints = useMemo(() => serializeHints(socialHints), [socialHints]);


### PR DESCRIPTION
## Summary
- add Next.js community and social cocon pages that adapt UI based on assessment-driven orchestration
- introduce empathic replies panel, gentle banner, and schedule prompt components with Sentry breadcrumbs and session logging
- update orchestration logic, persistence helper, legacy pages, and add e2e coverage for the new flows

## Testing
- npx vitest run src/features/orchestration/community.orchestrator.spec.ts src/features/orchestration/socialCocon.orchestrator.spec.ts
- npx playwright test e2e/community.spec.ts e2e/social-cocon.spec.ts *(fails: playwright not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ceee8503d0832d89d994de19fafe7d