### PR TITLE
Add B2C module orchestrations for story synth, activity, screen silk and weekly bars

### DIFF
--- a/e2e/activity.spec.ts
+++ b/e2e/activity.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test('activity jardin surfaces textual highlights', async ({ page }) => {
+  await page.goto('/activity');
+  await page.getByRole('button', { name: /j'accepte volontiers/i }).click();
+
+  await expect(page.getByRole('heading', { name: /trois appuis/i })).toBeVisible();
+  await expect(page.getByText('Respirer doucement une minute')).toBeVisible();
+  await expect(page.getByText('Journal court deux phrases')).toBeVisible();
+
+  const text = await page.locator('body').innerText();
+  expect(text).not.toMatch(/\d/);
+});

--- a/e2e/screen-silk.spec.ts
+++ b/e2e/screen-silk.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+test('screen silk adapts blur and reminders without numbers', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      'orchestration:screen_silk',
+      JSON.stringify({ cvsqLevel: 3 }),
+    );
+  });
+
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+
+  await page.goto('/screen-silk');
+  await page.getByRole('button', { name: /j'accepte volontiers/i }).click();
+
+  await expect(page.getByText('Pense à cligner doucement')).toBeVisible();
+  await expect(page.getByText('Voile à peine perceptible')).toBeVisible();
+
+  const text = await page.locator('body').innerText();
+  expect(text).not.toMatch(/\d/);
+});

--- a/e2e/story-synth.spec.ts
+++ b/e2e/story-synth.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+test('story synth adapts in text only', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      'orchestration:story_synth',
+      JSON.stringify({ tensionLevel: 3, fatigueLevel: 3 }),
+    );
+  });
+
+  await page.goto('/story-synth');
+  await page.getByRole('button', { name: /j'accepte volontiers/i }).click();
+
+  await expect(page.getByRole('heading', { name: /histoire modulée/i })).toBeVisible();
+  await expect(page.getByText('Ambiance cocon')).toBeVisible();
+  await expect(page.getByText('Voix apaisée')).toBeVisible();
+
+  const text = await page.locator('body').innerText();
+  expect(text).not.toMatch(/\d/);
+});

--- a/e2e/weekly-bars.spec.ts
+++ b/e2e/weekly-bars.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+test('weekly bars displays verbal palette only', async ({ page }) => {
+  await page.goto('/weekly-bars');
+  await page.getByRole('button', { name: /j'accepte volontiers/i }).click();
+
+  await expect(page.getByRole('heading', { name: /ta semaine en mots/i })).toBeVisible();
+  await expect(page.getByText('Rejoindre Flash Glow')).toBeVisible();
+
+  const text = await page.locator('body').innerText();
+  expect(text).not.toMatch(/\d/);
+});

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,7 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './tests/e2e',
+  testDir: '.',
+  testMatch: ['tests/e2e/**/*.spec.ts', 'e2e/**/*.spec.ts'],
   globalSetup: 'tests/e2e/_setup/global-setup.ts',
   reporter: [
     ['list'],

--- a/src/app/activity/page.tsx
+++ b/src/app/activity/page.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import * as Sentry from '@sentry/react';
+
+import { ZeroNumberBoundary } from '@/components/a11y/ZeroNumberBoundary';
+import ConsentGate from '@/components/consent/ConsentGate';
+import { ConsentProvider, useConsent } from '@/features/clinical-optin/ConsentProvider';
+import { useFlags } from '@/core/flags';
+import { useAssessment } from '@/hooks/useAssessment';
+import { activityJardinOrchestrator, persistOrchestrationSession } from '@/features/orchestration';
+
+function ActivityExperience() {
+  const { flags } = useFlags();
+  const { clinicalAccepted } = useConsent();
+  const assessment = useAssessment('WHO5');
+
+  const zeroNumbersActive = flags.FF_ZERO_NUMBERS !== false;
+  const orchestrationEnabled = flags.FF_ORCH_ACTIVITY !== false;
+  const assessmentEnabled = flags.FF_ASSESS_WHO5 !== false;
+
+  const who5Level = assessment.lastLevel ?? undefined;
+
+  const hints = useMemo(() => {
+    if (!orchestrationEnabled || !assessmentEnabled) {
+      return [{ action: 'none' as const }];
+    }
+    return activityJardinOrchestrator({ who5Level: typeof who5Level === 'number' ? who5Level : undefined });
+  }, [assessmentEnabled, orchestrationEnabled, who5Level]);
+
+  const actionable = hints.filter((hint) => hint.action !== 'none');
+  const highlightsHint = actionable.find((hint) => hint.action === 'show_highlights');
+  const highlights = highlightsHint && 'items' in highlightsHint ? highlightsHint.items : [];
+
+  const metadata = useMemo(() => {
+    if (!highlights?.length) {
+      return {};
+    }
+    return {
+      highlights: highlights.map((item) => item.toLowerCase().replace(/[^a-zàâçéèêëîïôûùüÿñœ\s-]/gi, '')).join('|'),
+    } satisfies Record<string, string | undefined>;
+  }, [highlights]);
+
+  const consented = clinicalAccepted && assessment.state.hasConsent;
+  const persistedSignature = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!consented) {
+      return;
+    }
+    const signature = JSON.stringify(metadata);
+    if (!signature || signature === '{}' || persistedSignature.current === signature) {
+      return;
+    }
+    persistedSignature.current = signature;
+    void persistOrchestrationSession('activity_jardin', metadata);
+  }, [consented, metadata]);
+
+  const breadcrumbLogged = useRef<boolean>(false);
+  useEffect(() => {
+    if (!breadcrumbLogged.current && highlights.length) {
+      Sentry.addBreadcrumb({
+        category: 'orchestration',
+        level: 'info',
+        message: 'orch:activity:highlights',
+      });
+      breadcrumbLogged.current = true;
+    }
+  }, [highlights.length]);
+
+  const handleShare = useCallback(() => {
+    void assessment.triggerAssessment('WHO5');
+  }, [assessment]);
+
+  if (!zeroNumbersActive) {
+    return (
+      <section className="mx-auto flex min-h-screen max-w-2xl flex-col justify-center gap-4 px-6 py-16 text-emerald-900">
+        <h1 className="text-2xl font-semibold">Jardin en pause</h1>
+        <p className="text-base text-emerald-700">Active la protection sans chiffres pour recevoir ces appuis tout en douceur.</p>
+      </section>
+    );
+  }
+
+  if (!assessmentEnabled) {
+    return (
+      <section className="mx-auto flex min-h-screen max-w-2xl flex-col justify-center gap-4 px-6 py-16 text-emerald-900">
+        <h1 className="text-2xl font-semibold">Jardin apaisé</h1>
+        <p className="text-base text-emerald-700">L'instrument bien-être est en veille. Tu peux toutefois profiter d'une promenade calme.</p>
+      </section>
+    );
+  }
+
+  if (!orchestrationEnabled) {
+    return (
+      <section className="mx-auto flex min-h-screen max-w-2xl flex-col justify-center gap-4 px-6 py-16 text-emerald-900">
+        <h1 className="text-2xl font-semibold">Activités libres</h1>
+        <p className="text-base text-emerald-700">L'orchestration est momentanément désactivée. Choisis les gestes qui te semblent soutenants.</p>
+      </section>
+    );
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col gap-8 px-6 py-12 text-emerald-900">
+      <header className="space-y-3">
+        <p className="text-sm uppercase tracking-wide text-emerald-600">Activity Jardin</p>
+        <h1 className="text-3xl font-semibold leading-tight">Trois appuis pour la semaine</h1>
+        <p className="max-w-2xl text-base text-emerald-700">
+          Ton ressenti partagé via le WHO cinq inspire une sélection douce, sans aucun chiffre.
+        </p>
+      </header>
+
+      <section className="rounded-3xl bg-emerald-50 px-6 py-5 text-emerald-800 shadow-sm">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-emerald-500">Ce qui peut aider</h2>
+        <ul className="mt-3 space-y-3">
+          {(highlights.length ? highlights : ['Respiration calme', 'Écriture brève', 'Moment Nyvée']).map((item) => (
+            <li key={item} className="rounded-2xl bg-white px-4 py-3 text-base">
+              {item}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <div className="flex flex-wrap gap-3">
+        <button
+          type="button"
+          onClick={handleShare}
+          className="rounded-full bg-emerald-900 px-5 py-2 text-sm font-semibold text-emerald-50 transition hover:bg-emerald-900/90"
+        >
+          Partager un ressenti WHO cinq
+        </button>
+        <button
+          type="button"
+          className="rounded-full border border-emerald-400 px-5 py-2 text-sm font-semibold text-emerald-700 transition hover:bg-emerald-100"
+        >
+          Planter une pause
+        </button>
+      </div>
+
+      <footer className="rounded-3xl bg-emerald-50 px-6 py-5 text-sm text-emerald-700">
+        {consented
+          ? 'Merci pour ton partage, ces appuis s\'ajustent selon ton équilibre émotionnel.'
+          : 'Tu peux explorer le jardin sans partage, les suggestions resteront très douces.'}
+      </footer>
+    </main>
+  );
+}
+
+export default function ActivityPage() {
+  return (
+    <ConsentProvider defaultAccepted={false}>
+      <ZeroNumberBoundary className="min-h-screen bg-gradient-to-b from-emerald-50 via-white to-emerald-100 text-emerald-900">
+        <ConsentGate>
+          <ActivityExperience />
+        </ConsentGate>
+      </ZeroNumberBoundary>
+    </ConsentProvider>
+  );
+}
+

--- a/src/app/screen-silk/page.tsx
+++ b/src/app/screen-silk/page.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import * as Sentry from '@sentry/react';
+
+import { ZeroNumberBoundary } from '@/components/a11y/ZeroNumberBoundary';
+import ConsentGate from '@/components/consent/ConsentGate';
+import { ConsentProvider, useConsent } from '@/features/clinical-optin/ConsentProvider';
+import { useFlags } from '@/core/flags';
+import { useAssessment } from '@/hooks/useAssessment';
+import { persistOrchestrationSession, screenSilkOrchestrator } from '@/features/orchestration';
+import { useReducedMotion } from '@/components/ui/AccessibilityOptimized';
+
+const BLINK_LABEL = 'Pense à cligner doucement';
+const BLUR_LABELS: Record<'neutral' | 'low' | 'very_low', string> = {
+  neutral: 'Clarté normale',
+  low: 'Voile très doux',
+  very_low: 'Voile à peine perceptible',
+};
+
+function ScreenSilkExperience() {
+  const { flags } = useFlags();
+  const { clinicalAccepted } = useConsent();
+  const assessment = useAssessment('CVSQ');
+  const prefersReducedMotion = useReducedMotion();
+  const [overrideLevel, setOverrideLevel] = useState<number | null>(null);
+
+  const zeroNumbersActive = flags.FF_ZERO_NUMBERS !== false;
+  const orchestrationEnabled = flags.FF_ORCH_SCREENSILK !== false;
+  const assessmentEnabled = flags.FF_ASSESS_CVSQ !== false;
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || process.env.NODE_ENV === 'production') {
+      return;
+    }
+    try {
+      const raw = window.localStorage.getItem('orchestration:screen_silk');
+      if (!raw) {
+        return;
+      }
+      const parsed = JSON.parse(raw);
+      setOverrideLevel(typeof parsed?.cvsqLevel === 'number' ? parsed.cvsqLevel : null);
+    } catch (error) {
+      console.warn('[screen-silk/page] unable to parse override level', error);
+    }
+  }, []);
+
+  const cvsqLevel = overrideLevel ?? (assessment.lastLevel ?? undefined);
+
+  const hints = useMemo(() => {
+    if (!orchestrationEnabled || !assessmentEnabled) {
+      return [{ action: 'none' as const }];
+    }
+    return screenSilkOrchestrator({
+      cvsqLevel: typeof cvsqLevel === 'number' ? cvsqLevel : undefined,
+      prm: prefersReducedMotion,
+    });
+  }, [assessmentEnabled, cvsqLevel, orchestrationEnabled, prefersReducedMotion]);
+
+  const actionable = hints.filter((hint) => hint.action !== 'none');
+  const blinkHint = actionable.find((hint) => hint.action === 'set_blink_reminder');
+  const blurHints = actionable.filter((hint) => hint.action === 'set_blur_opacity');
+  const ctaHint = actionable.find((hint) => hint.action === 'post_cta' && hint.key === 'screen_silk');
+
+  const blurKey = blurHints.length ? blurHints[blurHints.length - 1].key : ('neutral' as const);
+
+  const metadata = useMemo(() => {
+    if (!actionable.length) {
+      return {};
+    }
+    return {
+      blink: blinkHint ? 'gentle' : undefined,
+      blur: blurKey === 'neutral' ? undefined : blurKey,
+      cta: ctaHint ? 'screen_silk' : undefined,
+    } satisfies Record<string, string | undefined>;
+  }, [actionable.length, blinkHint, blurKey, ctaHint]);
+
+  const consented = clinicalAccepted && assessment.state.hasConsent;
+  const persistedSignature = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!consented) {
+      return;
+    }
+    const signature = JSON.stringify(metadata);
+    if (!signature || signature === '{}' || persistedSignature.current === signature) {
+      return;
+    }
+    persistedSignature.current = signature;
+    void persistOrchestrationSession('screen_silk', metadata);
+  }, [consented, metadata]);
+
+  const breadcrumbLogged = useRef<boolean>(false);
+  useEffect(() => {
+    if (!breadcrumbLogged.current && (blinkHint || blurHints.length)) {
+      Sentry.addBreadcrumb({
+        category: 'orchestration',
+        level: 'info',
+        message: 'orch:screensilk:gentle',
+      });
+      breadcrumbLogged.current = true;
+    }
+  }, [blinkHint, blurHints.length]);
+
+  const handleShare = useCallback(() => {
+    void assessment.triggerAssessment('CVSQ');
+  }, [assessment]);
+
+  if (!zeroNumbersActive) {
+    return (
+      <section className="mx-auto flex min-h-screen max-w-2xl flex-col justify-center gap-4 px-6 py-16 text-sky-900">
+        <h1 className="text-2xl font-semibold">Screen Silk en veille</h1>
+        <p className="text-base text-sky-700">Active la protection sans chiffres pour recevoir les conseils optiques humanisés.</p>
+      </section>
+    );
+  }
+
+  if (!assessmentEnabled) {
+    return (
+      <section className="mx-auto flex min-h-screen max-w-2xl flex-col justify-center gap-4 px-6 py-16 text-sky-900">
+        <h1 className="text-2xl font-semibold">Hygiène visuelle douce</h1>
+        <p className="text-base text-sky-700">L'instrument Screen Silk repose pour l'instant. Les rappels restent neutres.</p>
+      </section>
+    );
+  }
+
+  if (!orchestrationEnabled) {
+    return (
+      <section className="mx-auto flex min-h-screen max-w-2xl flex-col justify-center gap-4 px-6 py-16 text-sky-900">
+        <h1 className="text-2xl font-semibold">Ajustements neutres</h1>
+        <p className="text-base text-sky-700">L'orchestration Screen Silk est en pause. Tu peux conserver tes habitudes visuelles.</p>
+      </section>
+    );
+  }
+
+  const blinkLabel = blinkHint ? BLINK_LABEL : 'Clignements spontanés';
+  const blurLabel = BLUR_LABELS[blurKey];
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col gap-8 px-6 py-12 text-sky-900">
+      <header className="space-y-3">
+        <p className="text-sm uppercase tracking-wide text-sky-600">Screen Silk</p>
+        <h1 className="text-3xl font-semibold leading-tight">Repos visuel orchestré</h1>
+        <p className="max-w-2xl text-base text-sky-700">
+          Ton partage CVS Q ajuste le rappel de clignement et la douceur du flou, sans chiffres ni intensités abruptes.
+        </p>
+      </header>
+
+      <section className="grid gap-4 sm:grid-cols-3">
+        <article className="rounded-2xl bg-white px-5 py-4 shadow-sm">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-sky-500">Rappel</h2>
+          <p className="mt-2 text-base text-sky-800">{blinkLabel}</p>
+        </article>
+        <article className="rounded-2xl bg-white px-5 py-4 shadow-sm">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-sky-500">Voile visuel</h2>
+          <p className="mt-2 text-base text-sky-800">{blurLabel}</p>
+        </article>
+        <article className="rounded-2xl bg-white px-5 py-4 shadow-sm">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-sky-500">Confort</h2>
+          <p className="mt-2 text-base text-sky-800">
+            {prefersReducedMotion ? 'Animations adoucies pour ton confort' : 'Transitions fluides et légères'}
+          </p>
+        </article>
+      </section>
+
+      <div className="flex flex-wrap gap-3">
+        <button
+          type="button"
+          onClick={handleShare}
+          className="rounded-full bg-sky-900 px-5 py-2 text-sm font-semibold text-sky-50 transition hover:bg-sky-900/90"
+        >
+          Partager un ressenti Screen Silk
+        </button>
+        {ctaHint && (
+          <button
+            type="button"
+            className="rounded-full border border-sky-400 px-5 py-2 text-sm font-semibold text-sky-700 transition hover:bg-sky-100"
+          >
+            Ouvrir l'espace repos écran
+          </button>
+        )}
+      </div>
+
+      <footer className="rounded-3xl bg-sky-50 px-6 py-5 text-sm text-sky-700">
+        {consented
+          ? 'Merci pour ton partage, chaque session ajuste la douceur visuelle automatiquement.'
+          : 'Tu peux profiter de Screen Silk sans partage, l\'expérience reste calme par défaut.'}
+      </footer>
+    </main>
+  );
+}
+
+export default function ScreenSilkPage() {
+  return (
+    <ConsentProvider defaultAccepted={false}>
+      <ZeroNumberBoundary className="min-h-screen bg-gradient-to-b from-sky-50 via-white to-sky-100 text-sky-900">
+        <ConsentGate>
+          <ScreenSilkExperience />
+        </ConsentGate>
+      </ZeroNumberBoundary>
+    </ConsentProvider>
+  );
+}
+

--- a/src/app/story-synth/page.tsx
+++ b/src/app/story-synth/page.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import * as Sentry from '@sentry/react';
+
+import { ZeroNumberBoundary } from '@/components/a11y/ZeroNumberBoundary';
+import ConsentGate from '@/components/consent/ConsentGate';
+import { ConsentProvider, useConsent } from '@/features/clinical-optin/ConsentProvider';
+import { useFlags } from '@/core/flags';
+import { useAssessment } from '@/hooks/useAssessment';
+import { persistOrchestrationSession, storySynthOrchestrator } from '@/features/orchestration';
+
+const BED_LABELS = {
+  cocon: 'Ambiance cocon',
+} as const;
+
+const VOICE_LABELS = {
+  slow: 'Voix apaisée',
+} as const;
+
+const SCENE_LABEL = 'Scène concentrée';
+
+function StorySynthExperience() {
+  const { flags } = useFlags();
+  const { clinicalAccepted } = useConsent();
+  const assessment = useAssessment('POMS');
+  const [overrideLevels, setOverrideLevels] = useState<{ tension?: number; fatigue?: number } | null>(null);
+
+  const zeroNumbersActive = flags.FF_ZERO_NUMBERS !== false;
+  const orchestrationEnabled = flags.FF_ORCH_STORY !== false;
+  const assessmentEnabled = flags.FF_ASSESS_POMS !== false;
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || process.env.NODE_ENV === 'production') {
+      return;
+    }
+    try {
+      const raw = window.localStorage.getItem('orchestration:story_synth');
+      if (!raw) {
+        return;
+      }
+      const parsed = JSON.parse(raw);
+      setOverrideLevels({
+        tension: typeof parsed?.tensionLevel === 'number' ? parsed.tensionLevel : undefined,
+        fatigue: typeof parsed?.fatigueLevel === 'number' ? parsed.fatigueLevel : undefined,
+      });
+    } catch (error) {
+      console.warn('[story-synth/page] unable to parse override levels', error);
+    }
+  }, []);
+
+  const tensionLevel = overrideLevels?.tension ?? assessment.lastSubscaleLevel('tension');
+  const fatigueLevel = overrideLevels?.fatigue ?? assessment.lastSubscaleLevel('fatigue');
+
+  const hints = useMemo(() => {
+    if (!orchestrationEnabled || !assessmentEnabled) {
+      return [{ action: 'none' as const }];
+    }
+    return storySynthOrchestrator({
+      tensionLevel: typeof tensionLevel === 'number' ? tensionLevel : undefined,
+      fatigueLevel: typeof fatigueLevel === 'number' ? fatigueLevel : undefined,
+    });
+  }, [assessmentEnabled, fatigueLevel, orchestrationEnabled, tensionLevel]);
+
+  const actionable = hints.filter((hint) => hint.action !== 'none');
+  const bedHint = actionable.find((hint) => hint.action === 'set_story_bed' && hint.key === 'cocon');
+  const voiceHint = actionable.find((hint) => hint.action === 'set_story_voice' && hint.key === 'slow');
+  const shortenHint = actionable.find((hint) => hint.action === 'shorten_scene');
+
+  const announcement = useMemo(() => {
+    if (!actionable.length) {
+      return 'Narration douce maintenue sans adaptation particulière.';
+    }
+
+    const parts: string[] = [];
+    if (bedHint) {
+      parts.push('Ambiance cocon enclenchée');
+    }
+    if (voiceHint) {
+      parts.push('Voix ralentie pour accompagner la détente');
+    }
+    if (shortenHint) {
+      parts.push('Scène condensée pour économiser l\'énergie');
+    }
+    return parts.join('. ');
+  }, [actionable.length, bedHint, shortenHint, voiceHint]);
+
+  const metadata = useMemo(() => {
+    if (!actionable.length) {
+      return {};
+    }
+    return {
+      bed: bedHint ? 'cocon' : undefined,
+      voice: voiceHint ? 'slow' : undefined,
+      shorten: shortenHint ? 'short' : undefined,
+    } satisfies Record<string, string | undefined>;
+  }, [actionable.length, bedHint, shortenHint, voiceHint]);
+
+  const consented = clinicalAccepted && assessment.state.hasConsent;
+  const persistedSignature = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!consented) {
+      return;
+    }
+    const signature = JSON.stringify(metadata);
+    if (!signature || signature === '{}' || persistedSignature.current === signature) {
+      return;
+    }
+    persistedSignature.current = signature;
+    void persistOrchestrationSession('story_synth', metadata);
+  }, [consented, metadata]);
+
+  const breadcrumbLogged = useRef<boolean>(false);
+  useEffect(() => {
+    if (!breadcrumbLogged.current && (bedHint || voiceHint || shortenHint)) {
+      Sentry.addBreadcrumb({
+        category: 'orchestration',
+        level: 'info',
+        message: 'orch:story:cocon',
+      });
+      breadcrumbLogged.current = true;
+    }
+  }, [bedHint, shortenHint, voiceHint]);
+
+  const handleShare = useCallback(() => {
+    void assessment.triggerAssessment('POMS_TENSION');
+  }, [assessment]);
+
+  if (!zeroNumbersActive) {
+    return (
+      <section className="mx-auto flex min-h-screen max-w-2xl flex-col justify-center gap-4 px-6 py-16 text-slate-900">
+        <h1 className="text-2xl font-semibold">Story Synth en veille</h1>
+        <p className="text-base text-slate-700">
+          Active la protection sans chiffres pour profiter de la narration adaptée.
+        </p>
+      </section>
+    );
+  }
+
+  if (!assessmentEnabled) {
+    return (
+      <section className="mx-auto flex min-h-screen max-w-2xl flex-col justify-center gap-4 px-6 py-16 text-slate-900">
+        <h1 className="text-2xl font-semibold">Narration standard</h1>
+        <p className="text-base text-slate-700">
+          L'instrument POMS est momentanément indisponible. La narration reste douce par défaut.
+        </p>
+      </section>
+    );
+  }
+
+  if (!orchestrationEnabled) {
+    return (
+      <section className="mx-auto flex min-h-screen max-w-2xl flex-col justify-center gap-4 px-6 py-16 text-slate-900">
+        <h1 className="text-2xl font-semibold">Narration neutre</h1>
+        <p className="text-base text-slate-700">
+          L'orchestration Story Synth est en pause. Tu peux tout de même lancer une lecture apaisée.
+        </p>
+      </section>
+    );
+  }
+
+  const bedLabel = bedHint ? BED_LABELS.cocon : 'Ambiance neutre';
+  const voiceLabel = voiceHint ? VOICE_LABELS.slow : 'Voix fluide';
+  const sceneLabel = shortenHint ? SCENE_LABEL : 'Scène ample';
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col gap-8 px-6 py-12 text-slate-900">
+      <header className="space-y-3">
+        <p className="text-sm uppercase tracking-wide text-slate-600">Story Synth</p>
+        <h1 className="text-3xl font-semibold leading-tight">Histoire modulée par ton ressenti</h1>
+        <p className="max-w-2xl text-base text-slate-700">
+          Ton partage POMS ajuste le lit sonore, la voix et la durée de la scène. Aucun chiffre n'est affiché, seulement des nuances.
+        </p>
+      </header>
+
+      <section aria-live="polite" className="rounded-3xl bg-slate-100 px-6 py-5 text-slate-800 shadow-sm">
+        {announcement}
+      </section>
+
+      <section className="grid gap-4 sm:grid-cols-3">
+        <article className="rounded-2xl bg-white px-5 py-4 shadow-sm">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Lit de l'histoire</h2>
+          <p className="mt-2 text-base text-slate-800">{bedLabel}</p>
+        </article>
+        <article className="rounded-2xl bg-white px-5 py-4 shadow-sm">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Voix</h2>
+          <p className="mt-2 text-base text-slate-800">{voiceLabel}</p>
+        </article>
+        <article className="rounded-2xl bg-white px-5 py-4 shadow-sm">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Tempo de scène</h2>
+          <p className="mt-2 text-base text-slate-800">{sceneLabel}</p>
+        </article>
+      </section>
+
+      <div className="flex flex-wrap gap-3">
+        <button
+          type="button"
+          onClick={handleShare}
+          className="rounded-full bg-slate-900 px-5 py-2 text-sm font-semibold text-white transition hover:bg-slate-900/90"
+        >
+          Partager un ressenti récent
+        </button>
+        <button
+          type="button"
+          className="rounded-full border border-slate-400 px-5 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100"
+        >
+          Lancer la narration apaisée
+        </button>
+      </div>
+
+      <footer className="rounded-3xl bg-slate-50 px-6 py-5 text-sm text-slate-600">
+        {consented
+          ? 'Merci pour ton partage : la scène s\'adapte automatiquement à ton niveau de tension et de fatigue.'
+          : 'Tu peux profiter de la narration même sans partage, elle restera douce et enveloppante.'}
+      </footer>
+    </main>
+  );
+}
+
+export default function StorySynthPage() {
+  return (
+    <ConsentProvider defaultAccepted={false}>
+      <ZeroNumberBoundary className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-slate-100 text-slate-900">
+        <ConsentGate>
+          <StorySynthExperience />
+        </ConsentGate>
+      </ZeroNumberBoundary>
+    </ConsentProvider>
+  );
+}
+

--- a/src/app/weekly-bars/page.tsx
+++ b/src/app/weekly-bars/page.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import * as Sentry from '@sentry/react';
+
+import { ZeroNumberBoundary } from '@/components/a11y/ZeroNumberBoundary';
+import ConsentGate from '@/components/consent/ConsentGate';
+import { ConsentProvider, useConsent } from '@/features/clinical-optin/ConsentProvider';
+import { useFlags } from '@/core/flags';
+import { useAssessment } from '@/hooks/useAssessment';
+import { persistOrchestrationSession, weeklyBarsOrchestrator } from '@/features/orchestration';
+
+function WeeklyBarsExperience() {
+  const { flags } = useFlags();
+  const { clinicalAccepted } = useConsent();
+  const assessment = useAssessment('WHO5');
+
+  const zeroNumbersActive = flags.FF_ZERO_NUMBERS !== false;
+  const orchestrationEnabled = flags.FF_ORCH_WEEKLYBARS !== false;
+  const assessmentEnabled = flags.FF_ASSESS_WHO5 !== false;
+
+  const who5Level = assessment.lastLevel ?? undefined;
+
+  const hints = useMemo(() => {
+    if (!orchestrationEnabled || !assessmentEnabled) {
+      return [{ action: 'none' as const }];
+    }
+    return weeklyBarsOrchestrator({ who5Level: typeof who5Level === 'number' ? who5Level : undefined });
+  }, [assessmentEnabled, orchestrationEnabled, who5Level]);
+
+  const actionable = hints.filter((hint) => hint.action !== 'none');
+  const barsHint = actionable.find((hint) => hint.action === 'show_bars_text');
+  const ctaHint = actionable.find((hint) => hint.action === 'post_cta' && hint.key === 'flash_glow');
+
+  const bars = barsHint && 'items' in barsHint ? barsHint.items : ['posé', 'doux'];
+
+  const metadata = useMemo(() => {
+    if (!bars?.length) {
+      return {};
+    }
+    return {
+      bars: bars.join('|'),
+      cta: ctaHint ? 'flash_glow' : undefined,
+    } satisfies Record<string, string | undefined>;
+  }, [bars, ctaHint]);
+
+  const consented = clinicalAccepted && assessment.state.hasConsent;
+  const persistedSignature = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!consented) {
+      return;
+    }
+    const signature = JSON.stringify(metadata);
+    if (!signature || signature === '{}' || persistedSignature.current === signature) {
+      return;
+    }
+    persistedSignature.current = signature;
+    void persistOrchestrationSession('weekly_bars', metadata);
+  }, [consented, metadata]);
+
+  const breadcrumbLogged = useRef<boolean>(false);
+  useEffect(() => {
+    if (!breadcrumbLogged.current && bars.length) {
+      Sentry.addBreadcrumb({
+        category: 'orchestration',
+        level: 'info',
+        message: 'orch:weekly:bars',
+      });
+      breadcrumbLogged.current = true;
+    }
+  }, [bars.length]);
+
+  const handleShare = useCallback(() => {
+    void assessment.triggerAssessment('WHO5');
+  }, [assessment]);
+
+  const handleFlashGlow = useCallback(() => {
+    window.open('/flash-glow', '_blank', 'noopener');
+  }, []);
+
+  if (!zeroNumbersActive) {
+    return (
+      <section className="mx-auto flex min-h-screen max-w-2xl flex-col justify-center gap-4 px-6 py-16 text-indigo-900">
+        <h1 className="text-2xl font-semibold">Weekly Bars en veille</h1>
+        <p className="text-base text-indigo-700">Active la protection sans chiffres pour découvrir les barres verbales apaisées.</p>
+      </section>
+    );
+  }
+
+  if (!assessmentEnabled) {
+    return (
+      <section className="mx-auto flex min-h-screen max-w-2xl flex-col justify-center gap-4 px-6 py-16 text-indigo-900">
+        <h1 className="text-2xl font-semibold">Semaine contemplative</h1>
+        <p className="text-base text-indigo-700">L'instrument WHO cinq se repose. La lecture reste poétique et neutre.</p>
+      </section>
+    );
+  }
+
+  if (!orchestrationEnabled) {
+    return (
+      <section className="mx-auto flex min-h-screen max-w-2xl flex-col justify-center gap-4 px-6 py-16 text-indigo-900">
+        <h1 className="text-2xl font-semibold">Barres libres</h1>
+        <p className="text-base text-indigo-700">L'orchestration Weekly Bars est en pause. Tu peux inventer tes propres mots.</p>
+      </section>
+    );
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col gap-8 px-6 py-12 text-indigo-900">
+      <header className="space-y-3">
+        <p className="text-sm uppercase tracking-wide text-indigo-600">Weekly Bars</p>
+        <h1 className="text-3xl font-semibold leading-tight">Ta semaine en mots</h1>
+        <p className="max-w-2xl text-base text-indigo-700">
+          Ces barres verbales se nourrissent de ton ressenti WHO cinq tout en restant pleinement textuelles.
+        </p>
+      </header>
+
+      <section className="rounded-3xl bg-indigo-50 px-6 py-5 text-indigo-800 shadow-sm">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-indigo-500">Palette actuelle</h2>
+        <div className="mt-4 flex flex-wrap gap-3">
+          {bars.map((item) => (
+            <span
+              key={item}
+              className="rounded-full bg-white px-4 py-2 text-sm font-semibold text-indigo-800 shadow-sm"
+            >
+              {item}
+            </span>
+          ))}
+        </div>
+      </section>
+
+      <div className="flex flex-wrap gap-3">
+        <button
+          type="button"
+          onClick={handleShare}
+          className="rounded-full bg-indigo-900 px-5 py-2 text-sm font-semibold text-indigo-50 transition hover:bg-indigo-900/90"
+        >
+          Partager un ressenti WHO cinq
+        </button>
+        {ctaHint && (
+          <button
+            type="button"
+            onClick={handleFlashGlow}
+            className="rounded-full border border-indigo-400 px-5 py-2 text-sm font-semibold text-indigo-700 transition hover:bg-indigo-100"
+          >
+            Rejoindre Flash Glow
+          </button>
+        )}
+      </div>
+
+      <footer className="rounded-3xl bg-indigo-50 px-6 py-5 text-sm text-indigo-700">
+        {consented
+          ? 'Merci pour ton partage, ces mots évoluent au rythme de ton équilibre émotionnel.'
+          : 'Tu peux savourer ces mots sans partage, ils resteront enveloppants et doux.'}
+      </footer>
+    </main>
+  );
+}
+
+export default function WeeklyBarsPage() {
+  return (
+    <ConsentProvider defaultAccepted={false}>
+      <ZeroNumberBoundary className="min-h-screen bg-gradient-to-b from-indigo-50 via-white to-indigo-100 text-indigo-900">
+        <ConsentGate>
+          <WeeklyBarsExperience />
+        </ConsentGate>
+      </ZeroNumberBoundary>
+    </ConsentProvider>
+  );
+}
+

--- a/src/components/consent/ConsentGate.tsx
+++ b/src/components/consent/ConsentGate.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useState } from 'react';
+
+import { useConsent } from '@/features/clinical-optin/ConsentProvider';
+
+interface ConsentGateProps {
+  children: React.ReactNode;
+}
+
+export function ConsentGate({ children }: ConsentGateProps) {
+  const { clinicalAccepted, setClinicalAccepted } = useConsent();
+  const [pending, setPending] = useState(false);
+
+  if (clinicalAccepted) {
+    return <>{children}</>;
+  }
+
+  const handleDecision = (accepted: boolean) => {
+    setPending(true);
+    setTimeout(() => {
+      setClinicalAccepted(accepted);
+      setPending(false);
+    }, 10);
+  };
+
+  return (
+    <section className="mx-auto flex min-h-screen max-w-2xl flex-col justify-center gap-6 px-6 py-16 text-slate-900">
+      <header className="space-y-3">
+        <p className="text-sm font-semibold uppercase tracking-wide text-slate-600">Activation douce</p>
+        <h1 className="text-3xl font-semibold">Partager ton ressenti ?</h1>
+      </header>
+      <p className="text-base leading-relaxed text-slate-700">
+        Ces expériences s&apos;ajustent selon ton ressenti émotionnel. Tu peux accepter pour recevoir des
+        retours personnalisés, ou continuer sans instrumentation clinique.
+      </p>
+      <div className="flex flex-wrap gap-3">
+        <button
+          type="button"
+          disabled={pending}
+          onClick={() => handleDecision(true)}
+          className="rounded-full bg-slate-900 px-5 py-2 text-sm font-semibold text-white transition hover:bg-slate-900/90 disabled:cursor-not-allowed disabled:opacity-70"
+        >
+          J&apos;accepte volontiers
+        </button>
+        <button
+          type="button"
+          disabled={pending}
+          onClick={() => handleDecision(false)}
+          className="rounded-full border border-slate-400 px-5 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-70"
+        >
+          Peut-être plus tard
+        </button>
+      </div>
+      <footer className="rounded-2xl bg-slate-100 px-4 py-3 text-sm text-slate-600">
+        Ton choix est réversible dans les paramètres. Aucune valeur chiffrée ne sera affichée.
+      </footer>
+    </section>
+  );
+}
+
+export default ConsentGate;

--- a/src/core/flags.ts
+++ b/src/core/flags.ts
@@ -45,6 +45,10 @@ interface FeatureFlags {
   FF_ORCH_GRIT: boolean;
   FF_ORCH_BUBBLE: boolean;
   FF_ORCH_MIXER: boolean;
+  FF_ORCH_STORY: boolean;
+  FF_ORCH_ACTIVITY: boolean;
+  FF_ORCH_SCREENSILK: boolean;
+  FF_ORCH_WEEKLYBARS: boolean;
   FF_ZERO_NUMBERS?: boolean;
 
   [key: string]: boolean;
@@ -96,6 +100,10 @@ const DEFAULT_FLAGS: FeatureFlags = {
   FF_ORCH_GRIT: true,
   FF_ORCH_BUBBLE: true,
   FF_ORCH_MIXER: true,
+  FF_ORCH_STORY: true,
+  FF_ORCH_ACTIVITY: true,
+  FF_ORCH_SCREENSILK: true,
+  FF_ORCH_WEEKLYBARS: true,
   FF_ZERO_NUMBERS: true,
 };
 

--- a/src/features/orchestration/__tests__/activityJardin.orchestrator.spec.ts
+++ b/src/features/orchestration/__tests__/activityJardin.orchestrator.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { activityJardinOrchestrator } from '../activityJardin.orchestrator';
+
+describe('activityJardinOrchestrator', () => {
+  it('always returns the highlight list', () => {
+    const hints = activityJardinOrchestrator({ who5Level: 2 });
+    expect(hints).toEqual([
+      {
+        action: 'show_highlights',
+        items: ['Respirer doucement une minute', 'Journal court deux phrases', 'Nyvée en silence'],
+      },
+    ]);
+  });
+});

--- a/src/features/orchestration/__tests__/screenSilk.orchestrator.spec.ts
+++ b/src/features/orchestration/__tests__/screenSilk.orchestrator.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { screenSilkOrchestrator } from '../screenSilk.orchestrator';
+
+describe('screenSilkOrchestrator', () => {
+  it('activates gentle blink reminder and low blur when cvsq is high enough', () => {
+    const hints = screenSilkOrchestrator({ cvsqLevel: 2, prm: false });
+    expect(hints).toContainEqual({ action: 'set_blink_reminder', key: 'gentle' });
+    expect(hints).toContainEqual({ action: 'set_blur_opacity', key: 'low' });
+    expect(hints).toContainEqual({ action: 'post_cta', key: 'screen_silk' });
+  });
+
+  it('lowers blur further when prefers reduced motion is true', () => {
+    const hints = screenSilkOrchestrator({ cvsqLevel: 1, prm: true });
+    expect(hints).toContainEqual({ action: 'set_blur_opacity', key: 'very_low' });
+  });
+
+  it('returns none when nothing applies', () => {
+    const hints = screenSilkOrchestrator({ cvsqLevel: 0, prm: false });
+    expect(hints).toEqual([{ action: 'none' }]);
+  });
+});

--- a/src/features/orchestration/__tests__/storySynth.orchestrator.spec.ts
+++ b/src/features/orchestration/__tests__/storySynth.orchestrator.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { storySynthOrchestrator } from '../storySynth.orchestrator';
+
+const SHORT_SCENE_MS = 60_000;
+
+describe('storySynthOrchestrator', () => {
+  it('returns bed cocon when tension is high', () => {
+    const hints = storySynthOrchestrator({ tensionLevel: 3 });
+    expect(hints).toContainEqual({ action: 'set_story_bed', key: 'cocon' });
+  });
+
+  it('shortens scene and slows voice when fatigue is high', () => {
+    const hints = storySynthOrchestrator({ fatigueLevel: 3 });
+    expect(hints).toContainEqual({ action: 'shorten_scene', ms: SHORT_SCENE_MS });
+    expect(hints).toContainEqual({ action: 'set_story_voice', key: 'slow' });
+  });
+
+  it('returns none when no hints apply', () => {
+    const hints = storySynthOrchestrator({ tensionLevel: 1, fatigueLevel: 1 });
+    expect(hints).toEqual([{ action: 'none' }]);
+  });
+});

--- a/src/features/orchestration/__tests__/weeklyBars.orchestrator.spec.ts
+++ b/src/features/orchestration/__tests__/weeklyBars.orchestrator.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { weeklyBarsOrchestrator } from '../weeklyBars.orchestrator';
+
+describe('weeklyBarsOrchestrator', () => {
+  it('returns calm bars when level is low', () => {
+    const hints = weeklyBarsOrchestrator({ who5Level: 1 });
+    expect(hints).toContainEqual({ action: 'show_bars_text', items: ['posé', 'doux'] });
+  });
+
+  it('returns active bars when level is high', () => {
+    const hints = weeklyBarsOrchestrator({ who5Level: 3 });
+    expect(hints).toContainEqual({ action: 'show_bars_text', items: ['clair', 'actif'] });
+  });
+
+  it('always adds the soft cta', () => {
+    const hints = weeklyBarsOrchestrator({ who5Level: 2 });
+    expect(hints).toContainEqual({ action: 'post_cta', key: 'flash_glow' });
+  });
+});

--- a/src/features/orchestration/activityJardin.orchestrator.ts
+++ b/src/features/orchestration/activityJardin.orchestrator.ts
@@ -1,0 +1,12 @@
+import type { UIHint } from './types';
+
+interface ActivityJardinInput {
+  who5Level?: number;
+}
+
+const HIGHLIGHTS = ['Respirer doucement une minute', 'Journal court deux phrases', 'Nyvée en silence'];
+
+export function activityJardinOrchestrator({ who5Level }: ActivityJardinInput): UIHint[] {
+  void who5Level;
+  return [{ action: 'show_highlights', items: HIGHLIGHTS }];
+}

--- a/src/features/orchestration/index.ts
+++ b/src/features/orchestration/index.ts
@@ -5,3 +5,7 @@ export * from './leaderboardAuras.orchestrator';
 export * from './journal.orchestrator';
 export * from './moodMixer.orchestrator';
 export * from './persistOrchestrationSession';
+export * from './storySynth.orchestrator';
+export * from './activityJardin.orchestrator';
+export * from './screenSilk.orchestrator';
+export * from './weeklyBars.orchestrator';

--- a/src/features/orchestration/persistOrchestrationSession.ts
+++ b/src/features/orchestration/persistOrchestrationSession.ts
@@ -2,7 +2,13 @@ import * as Sentry from '@sentry/react';
 
 import { supabase } from '@/integrations/supabase/client';
 
-export type OrchestrationModule = 'community' | 'social_cocon';
+export type OrchestrationModule =
+  | 'community'
+  | 'social_cocon'
+  | 'story_synth'
+  | 'activity_jardin'
+  | 'screen_silk'
+  | 'weekly_bars';
 export type OrchestrationMetadata = Record<string, string | undefined>;
 
 const TABLE = 'session_text_logs';

--- a/src/features/orchestration/screenSilk.orchestrator.ts
+++ b/src/features/orchestration/screenSilk.orchestrator.ts
@@ -1,0 +1,22 @@
+import type { UIHint } from './types';
+
+interface ScreenSilkInput {
+  cvsqLevel?: number;
+  prm: boolean;
+}
+
+export function screenSilkOrchestrator({ cvsqLevel, prm }: ScreenSilkInput): UIHint[] {
+  const hints: UIHint[] = [];
+
+  if ((cvsqLevel ?? 0) >= 2) {
+    hints.push({ action: 'set_blink_reminder', key: 'gentle' });
+    hints.push({ action: 'set_blur_opacity', key: 'low' });
+    hints.push({ action: 'post_cta', key: 'screen_silk' });
+  }
+
+  if (prm) {
+    hints.push({ action: 'set_blur_opacity', key: 'very_low' });
+  }
+
+  return hints.length ? hints : [{ action: 'none' }];
+}

--- a/src/features/orchestration/storySynth.orchestrator.ts
+++ b/src/features/orchestration/storySynth.orchestrator.ts
@@ -1,0 +1,20 @@
+import type { UIHint } from './types';
+
+interface StorySynthInput {
+  tensionLevel?: number;
+  fatigueLevel?: number;
+}
+
+export function storySynthOrchestrator({ tensionLevel, fatigueLevel }: StorySynthInput): UIHint[] {
+  const hints: UIHint[] = [];
+
+  if ((tensionLevel ?? 2) >= 3) {
+    hints.push({ action: 'set_story_bed', key: 'cocon' });
+  }
+
+  if ((fatigueLevel ?? 2) >= 3) {
+    hints.push({ action: 'shorten_scene', ms: 60_000 }, { action: 'set_story_voice', key: 'slow' });
+  }
+
+  return hints.length ? hints : [{ action: 'none' }];
+}

--- a/src/features/orchestration/types.ts
+++ b/src/features/orchestration/types.ts
@@ -60,6 +60,8 @@ export interface BubbleBeatOrchestratorInput {
 }
 export type AssessmentLevel = 0 | 1 | 2 | 3 | 4;
 
+export type PostCtaKey = 'nyvee_suggest' | 'screen_silk' | 'flash_glow';
+
 export type UIHint =
   | { action: 'show_banner'; key: 'listen_two_minutes' }
   | { action: 'pin_card'; key: 'social_cocon' }
@@ -67,7 +69,15 @@ export type UIHint =
   | { action: 'promote_cta'; key: 'schedule_break' }
   | { action: 'highlight_rooms_private' }
   | { action: 'none' }
-  | { action: 'set_aura'; key: 'cool_gentle' | 'neutral' | 'warm_soft' };
+  | { action: 'set_aura'; key: 'cool_gentle' | 'neutral' | 'warm_soft' }
+  | { action: 'set_story_bed'; key: 'cocon' }
+  | { action: 'set_story_voice'; key: 'slow' }
+  | { action: 'shorten_scene'; ms: number }
+  | { action: 'show_highlights'; items: string[] }
+  | { action: 'set_blink_reminder'; key: 'gentle' }
+  | { action: 'set_blur_opacity'; key: 'low' | 'very_low' }
+  | { action: 'post_cta'; key: PostCtaKey }
+  | { action: 'show_bars_text'; items: string[] };
 
 export interface CommunityLevels {
   uclaLevel?: number;

--- a/src/features/orchestration/weeklyBars.orchestrator.ts
+++ b/src/features/orchestration/weeklyBars.orchestrator.ts
@@ -1,0 +1,24 @@
+import type { UIHint } from './types';
+
+interface WeeklyBarsInput {
+  who5Level?: number;
+}
+
+const DEFAULT_ITEMS = ['posé', 'doux'];
+const HIGH_ITEMS = ['clair', 'actif'];
+
+export function weeklyBarsOrchestrator({ who5Level }: WeeklyBarsInput): UIHint[] {
+  const items =
+    who5Level == null
+      ? DEFAULT_ITEMS
+      : who5Level <= 1
+      ? DEFAULT_ITEMS
+      : who5Level >= 3
+      ? HIGH_ITEMS
+      : DEFAULT_ITEMS;
+
+  return [
+    { action: 'show_bars_text', items },
+    { action: 'post_cta', key: 'flash_glow' },
+  ];
+}


### PR DESCRIPTION
## Summary
- add Story Synth, Activity Jardin, Screen Silk and Weekly Bars orchestrators with textual hints and persistence logging
- introduce consent gate wrapper and new zero-number guarded Next.js pages for each module
- add end-to-end smoke tests and extend Playwright config to cover new e2e directory alongside updated feature flags

## Testing
- npx vitest run src/features/orchestration/__tests__/storySynth.orchestrator.spec.ts src/features/orchestration/__tests__/activityJardin.orchestrator.spec.ts src/features/orchestration/__tests__/screenSilk.orchestrator.spec.ts src/features/orchestration/__tests__/weeklyBars.orchestrator.spec.ts
- npx eslint src/app/activity/page.tsx src/app/screen-silk/page.tsx src/app/story-synth/page.tsx src/app/weekly-bars/page.tsx src/components/consent/ConsentGate.tsx src/features/orchestration/activityJardin.orchestrator.ts src/features/orchestration/screenSilk.orchestrator.ts src/features/orchestration/storySynth.orchestrator.ts src/features/orchestration/weeklyBars.orchestrator.ts
- node node_modules/@playwright/test/cli.js test e2e/story-synth.spec.ts e2e/activity.spec.ts e2e/screen-silk.spec.ts e2e/weekly-bars.spec.ts *(fails: missing system dependencies for chromium)*

------
https://chatgpt.com/codex/tasks/task_e_68cef346cc68832d927a47cdaa904356