### PR TITLE
Add B2C orchestration modules for story, activity, screen care, and weekly bars

### DIFF
--- a/e2e/activity.spec.ts
+++ b/e2e/activity.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Activity Jardin orchestration', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem('orchestration:activity', JSON.stringify({ who5Level: 1 }));
+    });
+    await page.route('**/rest/v1/sessions**', async (route) => {
+      await route.fulfill({ status: 200, body: '{}' });
+    });
+  });
+
+  test('shows supportive highlights without digits', async ({ page }) => {
+    await page.goto('/app/activity');
+
+    await expect(page.getByRole('heading', { name: 'Trois appuis qui aident cette semaine' })).toBeVisible();
+    await expect(page.getByText(/Respirer doucement/)).toBeVisible();
+    await expect(page.getByText(/Journal doux/)).toBeVisible();
+
+    const textContent = await page.locator('main#main-content').innerText();
+    expect(textContent).not.toMatch(/\d/);
+  });
+});

--- a/e2e/screen-silk.spec.ts
+++ b/e2e/screen-silk.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Screen Silk orchestration', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem('orchestration:screen_silk', JSON.stringify({ cvsqLevel: 3 }));
+    });
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await page.route('**/rest/v1/sessions**', async (route) => {
+      await route.fulfill({ status: 200, body: '{}' });
+    });
+  });
+
+  test('activates blink reminder and gentle blur with no digits', async ({ page }) => {
+    await page.goto('/app/screen-silk');
+
+    await expect(page.getByText('Rappel de clignement doux activé.')).toBeVisible();
+    await expect(page.getByText(/Flou extrêmement léger/)).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Lancer Flash Glow apaisé' })).toBeVisible();
+
+    const textContent = await page.locator('main#main-content').innerText();
+    expect(textContent).not.toMatch(/\d/);
+  });
+});

--- a/e2e/story-synth.spec.ts
+++ b/e2e/story-synth.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Story Synth orchestration boundary', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        'orchestration:story_synth',
+        JSON.stringify({ tensionLevel: 3, fatigueLevel: 3 }),
+      );
+    });
+    await page.route('**/rest/v1/sessions**', async (route) => {
+      await route.fulfill({ status: 200, body: '{}' });
+    });
+  });
+
+  test('applies cocon bed and slow voice with text-only output', async ({ page }) => {
+    await page.goto('/app/story-synth');
+
+    await expect(page.getByText('Ambiance cocon')).toBeVisible();
+    await expect(page.getByText('Voix apaisée')).toBeVisible();
+    await expect(page.getByText(/Scène resserrée/)).toBeVisible();
+
+    const textContent = await page.locator('main#main-content').innerText();
+    expect(textContent).not.toMatch(/\d/);
+  });
+});

--- a/e2e/weekly-bars.spec.ts
+++ b/e2e/weekly-bars.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Weekly Bars orchestration', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem('orchestration:weekly_bars', JSON.stringify({ who5Level: 3 }));
+    });
+    await page.route('**/rest/v1/sessions**', async (route) => {
+      await route.fulfill({ status: 200, body: '{}' });
+    });
+  });
+
+  test('renders textual bars and a gentle cta', async ({ page }) => {
+    await page.goto('/app/weekly-bars');
+
+    await expect(page.getByText('clair')).toBeVisible();
+    await expect(page.getByText('actif')).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Respirer deux minutes avec Flash Glow' })).toBeVisible();
+
+    const textContent = await page.locator('main#main-content').innerText();
+    expect(textContent).not.toMatch(/\d/);
+  });
+});

--- a/src/app/activity/page.tsx
+++ b/src/app/activity/page.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+import * as Sentry from '@sentry/react';
+
+import ZeroNumberBoundary from '@/components/accessibility/ZeroNumberBoundary';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useFlags } from '@/core/flags';
+import { ConsentGate } from '@/features/clinical-optin/ConsentGate';
+import { activityJardinOrchestrator } from '@/features/orchestration/activityJardin.orchestrator';
+import type { ShowHighlightsAction } from '@/features/orchestration/types';
+import { useAssessment } from '@/hooks/useAssessment';
+import { createSession } from '@/services/sessions/sessionsApi';
+
+const STORAGE_KEY = 'orchestration:activity';
+
+const readStoredLevel = (): number | undefined => {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return undefined;
+    const parsed = JSON.parse(raw) as { who5Level?: number } | null;
+    return typeof parsed?.who5Level === 'number' ? parsed.who5Level : undefined;
+  } catch (error) {
+    console.warn('[activity] unable to parse stored level', error);
+    return undefined;
+  }
+};
+
+const humanizeHighlight = (item: string) =>
+  item
+    .replace(/1\s*min/gi, 'une minute')
+    .replace(/2\s*phrases/gi, 'deux phrases')
+    .replace(/\d+/g, (match) => (match === '1' ? 'une' : match === '2' ? 'deux' : 'quelques'));
+
+const persistActivitySession = async () => {
+  try {
+    await createSession({
+      type: 'activity',
+      duration_sec: 0,
+      mood_delta: null,
+      meta: {
+        module: 'activity',
+        highlights: ['respirer', 'journal', 'nyvée'],
+      },
+    });
+  } catch (error) {
+    Sentry.captureException(error);
+  }
+};
+
+export default function ActivityPage(): JSX.Element {
+  const { flags } = useFlags();
+  const assessment = useAssessment('WHO5');
+  const [storedLevel, setStoredLevel] = useState<number | undefined>(undefined);
+  const persistedRef = useRef<boolean>(false);
+  const breadcrumbRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production') {
+      setStoredLevel(readStoredLevel());
+    }
+  }, []);
+
+  const zeroNumbersReady = flags.FF_ZERO_NUMBERS !== false;
+  const orchestrationEnabled = Boolean(flags.FF_ORCH_ACTIVITY);
+  const assessmentEnabled = Boolean(flags.FF_ASSESS_WHO5);
+
+  const resolvedLevel =
+    typeof storedLevel === 'number'
+      ? storedLevel
+      : typeof assessment.lastLevel === 'number'
+        ? assessment.lastLevel
+        : undefined;
+
+  const hints = useMemo(() => {
+    if (!orchestrationEnabled || !assessmentEnabled) {
+      return [{ action: 'none' as const }];
+    }
+    return activityJardinOrchestrator({ who5Level: resolvedLevel });
+  }, [assessmentEnabled, orchestrationEnabled, resolvedLevel]);
+
+  const highlightAction = hints.find((hint) => hint.action === 'show_highlights') as ShowHighlightsAction | undefined;
+  const displayHighlights = (highlightAction?.items ?? []).map(humanizeHighlight);
+
+  useEffect(() => {
+    if (highlightAction && !breadcrumbRef.current) {
+      Sentry.addBreadcrumb({ category: 'orch:activity', level: 'info', message: 'orch:activity:highlights' });
+      breadcrumbRef.current = true;
+    }
+  }, [highlightAction]);
+
+  useEffect(() => {
+    if (!highlightAction || !zeroNumbersReady || !orchestrationEnabled || persistedRef.current) {
+      return;
+    }
+    persistedRef.current = true;
+    void persistActivitySession();
+  }, [highlightAction, orchestrationEnabled, zeroNumbersReady]);
+
+  const ready = zeroNumbersReady && orchestrationEnabled && assessmentEnabled;
+
+  const fallback = (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-6 px-6 py-12 text-emerald-950">
+      <h1 className="text-3xl font-semibold">Activity Jardin</h1>
+      <p className="text-base text-emerald-800">
+        Autorise le partage clinique pour recevoir des suggestions apaisantes adaptées à ton ressenti.
+      </p>
+    </main>
+  );
+
+  return (
+    <ZeroNumberBoundary className="min-h-screen bg-gradient-to-b from-emerald-50 via-white to-emerald-100">
+      <ConsentGate fallback={fallback}>
+        {ready ? (
+          <main className="mx-auto flex w-full max-w-4xl flex-col gap-8 px-6 py-12 text-emerald-950" id="main-content">
+            <header className="space-y-3">
+              <Badge className="bg-emerald-900 text-emerald-100" variant="secondary">
+                Activity Jardin
+              </Badge>
+              <h1 className="text-3xl font-semibold leading-tight">Trois appuis qui aident cette semaine</h1>
+              <p className="max-w-2xl text-base text-emerald-800">
+                Les propositions ci-dessous s’appuient sur ton dernier ressenti bien-être. Tout est exprimé en mots doux, sans
+                chiffres ni graphiques.
+              </p>
+            </header>
+
+            <Card aria-live="polite">
+              <CardHeader>
+                <CardTitle>Palette de soutien</CardTitle>
+                <CardDescription>Nous avons sélectionné trois gestes pour nourrir ton énergie</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4 text-emerald-900">
+                <ul className="space-y-3">
+                  {displayHighlights.map((item) => (
+                    <li key={item} className="rounded-lg bg-emerald-50 px-4 py-3">
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+                <p className="text-sm text-emerald-700">
+                  Choisis ce qui résonne le plus aujourd’hui. Tu peux noter ton ressenti après chaque geste pour affiner les
+                  prochaines suggestions.
+                </p>
+              </CardContent>
+            </Card>
+
+            <section className="grid gap-6 md:grid-cols-2" aria-label="Continuer l’exploration">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Journal doux</CardTitle>
+                  <CardDescription>Écris deux phrases pour ancrer ton ressenti</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm text-emerald-900">
+                  <p>
+                    Tu peux ouvrir la section Journal pour déposer quelques mots. Nous te suggérons un format très court, sans
+                    contrainte.
+                  </p>
+                  <Link
+                    href="/app/modules"
+                    className="inline-flex items-center justify-center rounded-full bg-emerald-900 px-4 py-2 text-emerald-50 hover:bg-emerald-800 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                  >
+                    Ouvrir le journal
+                  </Link>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardHeader>
+                  <CardTitle>Respiration douce</CardTitle>
+                  <CardDescription>Prolonge ta pause par une lumière respirante</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm text-emerald-900">
+                  <p>
+                    Un détour par Flash Glow peut prolonger la détente. La session se cale automatiquement sur ton état du moment.
+                  </p>
+                  <Link
+                    href="/app/flash-glow"
+                    className="inline-flex items-center justify-center rounded-full bg-emerald-900 px-4 py-2 text-emerald-50 hover:bg-emerald-800 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                  >
+                    Rejoindre Flash Glow
+                  </Link>
+                </CardContent>
+              </Card>
+            </section>
+          </main>
+        ) : (
+          <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-8 px-6 py-12 text-emerald-950">
+            <h1 className="text-3xl font-semibold">Activity Jardin</h1>
+            <p className="max-w-2xl text-base text-emerald-800">
+              Active les évaluations bien-être pour révéler les trois appuis de soutien personnalisés.
+            </p>
+          </main>
+        )}
+      </ConsentGate>
+    </ZeroNumberBoundary>
+  );
+}

--- a/src/app/screen-silk/page.tsx
+++ b/src/app/screen-silk/page.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+import * as Sentry from '@sentry/react';
+
+import ZeroNumberBoundary from '@/components/accessibility/ZeroNumberBoundary';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useReducedMotion } from '@/components/ui/AccessibilityOptimized';
+import { useFlags } from '@/core/flags';
+import { ConsentGate } from '@/features/clinical-optin/ConsentGate';
+import { screenSilkOrchestrator } from '@/features/orchestration/screenSilk.orchestrator';
+import type { SetBlinkReminderAction, SetBlurOpacityAction } from '@/features/orchestration/types';
+import { useAssessment } from '@/hooks/useAssessment';
+import { createSession } from '@/services/sessions/sessionsApi';
+
+const STORAGE_KEY = 'orchestration:screen_silk';
+
+const readStoredLevel = (): number | undefined => {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return undefined;
+    const parsed = JSON.parse(raw) as { cvsqLevel?: number } | null;
+    return typeof parsed?.cvsqLevel === 'number' ? parsed.cvsqLevel : undefined;
+  } catch (error) {
+    console.warn('[screen-silk] unable to parse stored level', error);
+    return undefined;
+  }
+};
+
+const blinkLabel = (action: SetBlinkReminderAction | undefined) =>
+  action?.key === 'gentle' ? 'Rappel de clignement doux activé.' : 'Rappel visuel désactivé pour laisser ton rythme naturel.';
+
+const blurLabel = (action: SetBlurOpacityAction | undefined) => {
+  if (!action) {
+    return 'Affichage net sans filtre supplémentaire.';
+  }
+  if (action.key === 'very_low') {
+    return 'Flou extrêmement léger pour ménager la sensibilité visuelle.';
+  }
+  return 'Flou discret pour adoucir la lumière de l’écran.';
+};
+
+const persistScreenSilkSession = async (payload: { blink: 'gentle' | 'none'; blur: 'very_low' | 'low' | 'none' }) => {
+  try {
+    await createSession({
+      type: 'screen_silk',
+      duration_sec: 0,
+      mood_delta: null,
+      meta: {
+        module: 'screen_silk',
+        blink: payload.blink,
+        blur: payload.blur,
+      },
+    });
+  } catch (error) {
+    Sentry.captureException(error);
+  }
+};
+
+export default function ScreenSilkPage(): JSX.Element {
+  const { flags } = useFlags();
+  const assessment = useAssessment('CVSQ');
+  const prefersReducedMotion = useReducedMotion();
+  const [storedLevel, setStoredLevel] = useState<number | undefined>(undefined);
+  const persistedSignatureRef = useRef<string | null>(null);
+  const breadcrumbRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production') {
+      setStoredLevel(readStoredLevel());
+    }
+  }, []);
+
+  const zeroNumbersReady = flags.FF_ZERO_NUMBERS !== false;
+  const orchestrationEnabled = Boolean(flags.FF_ORCH_SCREENSILK);
+  const assessmentEnabled = Boolean(flags.FF_ASSESS_CVSQ);
+
+  const resolvedLevel =
+    typeof storedLevel === 'number'
+      ? storedLevel
+      : typeof assessment.lastLevel === 'number'
+        ? assessment.lastLevel
+        : undefined;
+
+  const hints = useMemo(() => {
+    if (!orchestrationEnabled || !assessmentEnabled) {
+      return [{ action: 'none' as const }];
+    }
+    return screenSilkOrchestrator({ cvsqLevel: resolvedLevel, prm: prefersReducedMotion });
+  }, [assessmentEnabled, orchestrationEnabled, prefersReducedMotion, resolvedLevel]);
+
+  const blinkAction = hints.find((hint) => hint.action === 'set_blink_reminder') as SetBlinkReminderAction | undefined;
+  const blurActions = hints.filter((hint) => hint.action === 'set_blur_opacity') as SetBlurOpacityAction[];
+  const blurAction = blurActions.length ? blurActions[blurActions.length - 1] : undefined;
+  const ctaVisible = hints.some((hint) => hint.action === 'post_cta' && hint.key === 'screen_silk');
+
+  useEffect(() => {
+    if (blinkAction && breadcrumbRef.current !== 'gentle') {
+      Sentry.addBreadcrumb({ category: 'orch:screensilk', level: 'info', message: 'orch:screensilk:gentle' });
+      breadcrumbRef.current = 'gentle';
+    }
+  }, [blinkAction]);
+
+  useEffect(() => {
+    if (!zeroNumbersReady || !orchestrationEnabled) {
+      return;
+    }
+    const payload = {
+      blink: blinkAction ? 'gentle' : 'none',
+      blur: blurAction ? blurAction.key : 'none',
+    } as const;
+    const signature = JSON.stringify(payload);
+    if (persistedSignatureRef.current === signature) {
+      return;
+    }
+    persistedSignatureRef.current = signature;
+    void persistScreenSilkSession(payload);
+  }, [blinkAction, blurAction, orchestrationEnabled, zeroNumbersReady]);
+
+  const ready = zeroNumbersReady && orchestrationEnabled && assessmentEnabled;
+
+  const fallback = (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-6 px-6 py-12 text-slate-950">
+      <h1 className="text-3xl font-semibold">Screen Silk</h1>
+      <p className="text-base text-slate-700">
+        Autorise l’opt-in clinique pour adapter les rappels de clignement et la douceur visuelle.
+      </p>
+    </main>
+  );
+
+  return (
+    <ZeroNumberBoundary className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-slate-100">
+      <ConsentGate fallback={fallback}>
+        {ready ? (
+          <main className="mx-auto flex w-full max-w-4xl flex-col gap-8 px-6 py-12 text-slate-950" id="main-content">
+            <header className="space-y-3">
+              <Badge className="bg-slate-900 text-slate-100" variant="secondary">
+                Screen Silk
+              </Badge>
+              <h1 className="text-3xl font-semibold leading-tight">Repos visuel piloté par tes signaux</h1>
+              <p className="max-w-2xl text-base text-slate-700">
+                Le module ajuste automatiquement les rappels et le léger flou pour apaiser ton regard, sans jamais afficher de
+                chiffres.
+              </p>
+            </header>
+
+            <section className="grid gap-6 md:grid-cols-2" aria-label="Réglages Screen Silk">
+              <Card aria-live="polite">
+                <CardHeader>
+                  <CardTitle>Rappels doux</CardTitle>
+                  <CardDescription>Un signal léger t’invite à cligner en douceur</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm text-slate-900">
+                  <p>{blinkLabel(blinkAction)}</p>
+                  <p>
+                    Le rappel reste discret. Aucun son n’est utilisé, uniquement une légère pulsation visuelle lorsque nécessaire.
+                  </p>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle>Filtre visuel</CardTitle>
+                  <CardDescription>Le flou adaptatif s’ajuste à ton besoin</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm text-slate-900">
+                  <p>{blurLabel(blurAction)}</p>
+                  <p>
+                    Tu peux réduire encore davantage les mouvements dans les préférences d’accessibilité si besoin. Screen Silk
+                    respecte toujours le mode réduit.
+                  </p>
+                </CardContent>
+              </Card>
+            </section>
+
+            {ctaVisible && (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Aller plus loin</CardTitle>
+                  <CardDescription>Prolonge le confort après ta pause écran</CardDescription>
+                </CardHeader>
+                <CardContent className="flex flex-col gap-4 text-sm text-slate-900">
+                  <p>
+                    Lorsque tu termines la routine Screen Silk, tu peux enchaîner avec une lumière respirante pour relancer
+                    l’humidité oculaire.
+                  </p>
+                  <Link
+                    href="/app/flash-glow"
+                    className="inline-flex items-center justify-center rounded-full bg-slate-900 px-4 py-2 text-slate-50 hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-500"
+                  >
+                    Lancer Flash Glow apaisé
+                  </Link>
+                </CardContent>
+              </Card>
+            )}
+          </main>
+        ) : (
+          <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-8 px-6 py-12 text-slate-950">
+            <h1 className="text-3xl font-semibold">Screen Silk</h1>
+            <p className="max-w-2xl text-base text-slate-700">
+              Active l’orchestration clinique pour que Screen Silk module automatiquement les rappels et le voile visuel.
+            </p>
+          </main>
+        )}
+      </ConsentGate>
+    </ZeroNumberBoundary>
+  );
+}

--- a/src/app/story-synth/page.tsx
+++ b/src/app/story-synth/page.tsx
@@ -1,0 +1,272 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+import * as Sentry from '@sentry/react';
+
+import ZeroNumberBoundary from '@/components/accessibility/ZeroNumberBoundary';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useFlags } from '@/core/flags';
+import { ConsentGate } from '@/features/clinical-optin/ConsentGate';
+import { storySynthOrchestrator } from '@/features/orchestration/storySynth.orchestrator';
+import type { SetStoryBedAction, SetStoryVoiceAction } from '@/features/orchestration/types';
+import { useAssessment } from '@/hooks/useAssessment';
+import { createSession } from '@/services/sessions/sessionsApi';
+
+const STORAGE_KEY = 'orchestration:story_synth';
+
+interface StoredLevels {
+  tensionLevel?: number;
+  fatigueLevel?: number;
+}
+
+const readStoredLevels = (): StoredLevels => {
+  if (typeof window === 'undefined') {
+    return {};
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as StoredLevels | null;
+    return {
+      tensionLevel: typeof parsed?.tensionLevel === 'number' ? parsed.tensionLevel : undefined,
+      fatigueLevel: typeof parsed?.fatigueLevel === 'number' ? parsed.fatigueLevel : undefined,
+    };
+  } catch (error) {
+    console.warn('[story-synth] unable to parse stored levels', error);
+    return {};
+  }
+};
+
+const bedLabel = (action: SetStoryBedAction | undefined) =>
+  action?.key === 'cocon' ? 'Ambiance cocon' : 'Ambiance libre';
+
+const voiceLabel = (action: SetStoryVoiceAction | undefined) =>
+  action?.key === 'slow' ? 'Voix apaisée' : 'Voix naturelle';
+
+const lengthLabel = (shortened: boolean) =>
+  shortened
+    ? 'Scène resserrée pour ménager ton énergie.'
+    : 'Scène ample pour vagabonder autant que tu le souhaites.';
+
+const sanitizeAnnouncement = (message: string) => message.replace(/\d/g, '');
+
+const persistStorySession = async (payload: {
+  bed: 'cocon' | 'libre';
+  voice: 'slow' | 'natural';
+  shorten: 'short' | 'full';
+}) => {
+  try {
+    await createSession({
+      type: 'story_synth',
+      duration_sec: 0,
+      mood_delta: null,
+      meta: {
+        module: 'story_synth',
+        bed: payload.bed,
+        voice: payload.voice,
+        shorten: payload.shorten,
+      },
+    });
+  } catch (error) {
+    Sentry.captureException(error);
+  }
+};
+
+const STORY_SNIPPET = [
+  'La lumière se dépose comme une couverture chaude sur les épaules.',
+  'Un souffle calme accompagne chaque phrase, laissant le temps aux images de flotter.',
+  'Les pas du personnage résonnent doucement sur un sol moelleux, sans urgence.',
+];
+
+export default function StorySynthPage(): JSX.Element {
+  const { flags } = useFlags();
+  const assessment = useAssessment('POMS_TENSION');
+  const [storedLevels, setStoredLevels] = useState<StoredLevels>({});
+  const [announcement, setAnnouncement] = useState('Narration neutre prête à t’accueillir.');
+  const persistedSignatureRef = useRef<string | null>(null);
+  const breadcrumbSignatureRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production') {
+      setStoredLevels(readStoredLevels());
+    }
+  }, []);
+
+  const zeroNumbersReady = flags.FF_ZERO_NUMBERS !== false;
+  const orchestrationEnabled = Boolean(flags.FF_ORCH_STORY);
+  const assessmentEnabled = Boolean(flags.FF_ASSESS_POMS || flags.FF_ASSESS_POMS_TENSION);
+
+  const computedTension = assessment.lastSubscaleLevel('tension');
+  const computedFatigue = assessment.lastSubscaleLevel('fatigue');
+
+  const tensionLevel = typeof storedLevels.tensionLevel === 'number' ? storedLevels.tensionLevel : computedTension;
+  const fatigueLevel = typeof storedLevels.fatigueLevel === 'number' ? storedLevels.fatigueLevel : computedFatigue;
+
+  const hints = useMemo(() => {
+    if (!orchestrationEnabled || !assessmentEnabled) {
+      return [{ action: 'none' as const }];
+    }
+    return storySynthOrchestrator({ tensionLevel, fatigueLevel });
+  }, [assessmentEnabled, fatigueLevel, orchestrationEnabled, tensionLevel]);
+
+  const bedAction = useMemo(() => hints.find((hint) => hint.action === 'set_story_bed') as SetStoryBedAction | undefined, [
+    hints,
+  ]);
+  const voiceAction = useMemo(
+    () => hints.find((hint) => hint.action === 'set_story_voice') as SetStoryVoiceAction | undefined,
+    [hints],
+  );
+  const shortenAction = useMemo(() => hints.some((hint) => hint.action === 'shorten_scene'), [hints]);
+
+  useEffect(() => {
+    const parts: string[] = [];
+    if (bedAction?.key === 'cocon') {
+      parts.push('Ambiance cocon installée.');
+    } else {
+      parts.push('Ambiance libre maintenue.');
+    }
+    if (voiceAction?.key === 'slow') {
+      parts.push('Voix ralentie pour envelopper le récit.');
+    } else {
+      parts.push('Voix naturelle prête à raconter.');
+    }
+    if (shortenAction) {
+      parts.push('Scène resserrée pour préserver ton énergie.');
+    } else {
+      parts.push('Scène ample et libre.');
+    }
+    setAnnouncement(sanitizeAnnouncement(parts.join(' ')));
+  }, [bedAction?.key, shortenAction, voiceAction?.key]);
+
+  useEffect(() => {
+    if (!orchestrationEnabled) {
+      return;
+    }
+    const signature = JSON.stringify({ bed: bedAction?.key, voice: voiceAction?.key, shorten: shortenAction });
+    if (breadcrumbSignatureRef.current === signature) {
+      return;
+    }
+    breadcrumbSignatureRef.current = signature;
+
+    if (bedAction?.key === 'cocon') {
+      Sentry.addBreadcrumb({ category: 'orch:story', level: 'info', message: 'orch:story:cocon' });
+    }
+  }, [bedAction?.key, orchestrationEnabled, shortenAction, voiceAction?.key]);
+
+  useEffect(() => {
+    if (!orchestrationEnabled || !zeroNumbersReady) {
+      return;
+    }
+    const payload = {
+      bed: bedAction?.key === 'cocon' ? 'cocon' : 'libre',
+      voice: voiceAction?.key === 'slow' ? 'slow' : 'natural',
+      shorten: shortenAction ? 'short' : 'full',
+    } as const;
+    const payloadSignature = JSON.stringify(payload);
+    if (persistedSignatureRef.current === payloadSignature) {
+      return;
+    }
+    persistedSignatureRef.current = payloadSignature;
+
+    void persistStorySession(payload);
+  }, [bedAction?.key, orchestrationEnabled, shortenAction, voiceAction?.key, zeroNumbersReady]);
+
+  const ready = zeroNumbersReady && orchestrationEnabled && assessmentEnabled;
+
+  const fallback = (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-6 px-6 py-12 text-indigo-950">
+      <h1 className="text-3xl font-semibold">Story Synth</h1>
+      <p className="text-base text-indigo-800">
+        Pour activer l’histoire adaptée, accepte le partage clinique en douceur depuis la fenêtre qui s’ouvre.
+      </p>
+    </main>
+  );
+
+  return (
+    <ZeroNumberBoundary className="min-h-screen bg-gradient-to-b from-indigo-50 via-white to-indigo-100">
+      <ConsentGate fallback={fallback}>
+        {ready ? (
+          <main className="mx-auto flex w-full max-w-4xl flex-col gap-8 px-6 py-12 text-indigo-950" id="main-content">
+            <div role="status" aria-live="polite" className="sr-only">
+              {announcement}
+            </div>
+            <header className="space-y-3">
+              <Badge className="bg-indigo-900 text-indigo-100" variant="secondary">
+                Story Synth
+              </Badge>
+              <h1 className="text-3xl font-semibold leading-tight">Histoires orchestrées pour relâcher la tension</h1>
+              <p className="max-w-2xl text-base text-indigo-800">
+                La narration s’ajuste à tes signaux de tension et de fatigue sans jamais montrer de chiffres. Tu peux savourer un
+                récit sur mesure en toute confiance.
+              </p>
+            </header>
+
+            <section className="grid gap-6 md:grid-cols-2" aria-label="Réglages narratifs">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Cadre sensoriel</CardTitle>
+                  <CardDescription>Réglages appliqués automatiquement</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4 text-sm text-indigo-900">
+                  <p>{bedLabel(bedAction)}</p>
+                  <p>{voiceLabel(voiceAction)}</p>
+                  <p>{lengthLabel(shortenAction)}</p>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardHeader>
+                  <CardTitle>Invitation</CardTitle>
+                  <CardDescription>Prends place dans la scène choisie pour toi</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4 text-sm text-indigo-900">
+                  <p>
+                    Installe-toi confortablement, laisse ton souffle guider la lecture. La voix suit un débit feutré pour t’aider à
+                    relâcher la pression.
+                  </p>
+                  <Button type="button" className="w-full justify-center">
+                    Lancer la narration douce
+                  </Button>
+                  <p className="text-xs text-indigo-700">
+                    Tu peux interrompre à tout moment. La scène restera disponible tant que tu en as besoin.
+                  </p>
+                </CardContent>
+              </Card>
+            </section>
+
+            <section aria-label="Extrait narratif" className="space-y-4">
+              <h2 className="text-2xl font-semibold text-indigo-900">Extrait du cocon</h2>
+              <Card>
+                <CardContent className="space-y-4 py-6 text-indigo-900">
+                  {STORY_SNIPPET.map((line) => (
+                    <p key={line}>{line}</p>
+                  ))}
+                </CardContent>
+              </Card>
+            </section>
+
+            <footer className="flex flex-wrap items-center justify-between gap-4 text-sm text-indigo-800">
+              <span>Besoin d’une transition plus visuelle ?</span>
+              <Link
+                href="/app/screen-silk"
+                className="rounded-full bg-indigo-900 px-4 py-2 text-indigo-50 hover:bg-indigo-800 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              >
+                Rejoindre Screen Silk
+              </Link>
+            </footer>
+          </main>
+        ) : (
+          <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-8 px-6 py-12 text-indigo-950">
+            <h1 className="text-3xl font-semibold">Story Synth</h1>
+            <p className="max-w-2xl text-base text-indigo-800">
+              Active l’orchestration clinique depuis tes paramètres pour que l’histoire épouse ton niveau de tension et de fatigue.
+            </p>
+          </main>
+        )}
+      </ConsentGate>
+    </ZeroNumberBoundary>
+  );
+}

--- a/src/app/weekly-bars/page.tsx
+++ b/src/app/weekly-bars/page.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+import * as Sentry from '@sentry/react';
+
+import ZeroNumberBoundary from '@/components/accessibility/ZeroNumberBoundary';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useFlags } from '@/core/flags';
+import { ConsentGate } from '@/features/clinical-optin/ConsentGate';
+import { weeklyBarsOrchestrator } from '@/features/orchestration/weeklyBars.orchestrator';
+import type { ShowBarsTextAction } from '@/features/orchestration/types';
+import { useAssessment } from '@/hooks/useAssessment';
+import { createSession } from '@/services/sessions/sessionsApi';
+
+const STORAGE_KEY = 'orchestration:weekly_bars';
+
+const readStoredLevel = (): number | undefined => {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return undefined;
+    const parsed = JSON.parse(raw) as { who5Level?: number } | null;
+    return typeof parsed?.who5Level === 'number' ? parsed.who5Level : undefined;
+  } catch (error) {
+    console.warn('[weekly-bars] unable to parse stored level', error);
+    return undefined;
+  }
+};
+
+const describeBars = (items: string[]) =>
+  items.length
+    ? `Ta semaine se traduit par les couleurs « ${items.join(' » et « ')} ». `
+    : 'Ta semaine reste ouverte à interprétation, aucune barre n’est affichée.';
+
+const persistWeeklyBarsSession = async (payload: { bars: string[]; cta: 'flash_glow' | 'none' }) => {
+  try {
+    await createSession({
+      type: 'weekly_bars',
+      duration_sec: 0,
+      mood_delta: null,
+      meta: {
+        module: 'weekly_bars',
+        bars: payload.bars,
+        cta: payload.cta,
+      },
+    });
+  } catch (error) {
+    Sentry.captureException(error);
+  }
+};
+
+export default function WeeklyBarsPage(): JSX.Element {
+  const { flags } = useFlags();
+  const assessment = useAssessment('WHO5');
+  const [storedLevel, setStoredLevel] = useState<number | undefined>(undefined);
+  const persistedSignatureRef = useRef<string | null>(null);
+  const breadcrumbRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production') {
+      setStoredLevel(readStoredLevel());
+    }
+  }, []);
+
+  const zeroNumbersReady = flags.FF_ZERO_NUMBERS !== false;
+  const orchestrationEnabled = Boolean(flags.FF_ORCH_WEEKLYBARS);
+  const assessmentEnabled = Boolean(flags.FF_ASSESS_WHO5);
+
+  const resolvedLevel =
+    typeof storedLevel === 'number'
+      ? storedLevel
+      : typeof assessment.lastLevel === 'number'
+        ? assessment.lastLevel
+        : undefined;
+
+  const hints = useMemo(() => {
+    if (!orchestrationEnabled || !assessmentEnabled) {
+      return [{ action: 'none' as const }];
+    }
+    return weeklyBarsOrchestrator({ who5Level: resolvedLevel });
+  }, [assessmentEnabled, orchestrationEnabled, resolvedLevel]);
+
+  const barsAction = hints.find((hint) => hint.action === 'show_bars_text') as ShowBarsTextAction | undefined;
+  const barItems = barsAction?.items ?? [];
+  const ctaAction = hints.find((hint) => hint.action === 'post_cta' && hint.key === 'flash_glow');
+
+  useEffect(() => {
+    if (barItems.length && !breadcrumbRef.current) {
+      Sentry.addBreadcrumb({ category: 'orch:weekly', level: 'info', message: 'orch:weekly:bars' });
+      breadcrumbRef.current = true;
+    }
+  }, [barItems]);
+
+  useEffect(() => {
+    if (!zeroNumbersReady || !orchestrationEnabled) {
+      return;
+    }
+    const payload = {
+      bars: barItems,
+      cta: ctaAction ? 'flash_glow' : 'none',
+    } as const;
+    const signature = JSON.stringify(payload);
+    if (persistedSignatureRef.current === signature) {
+      return;
+    }
+    persistedSignatureRef.current = signature;
+    void persistWeeklyBarsSession(payload);
+  }, [barItems, ctaAction, orchestrationEnabled, zeroNumbersReady]);
+
+  const ready = zeroNumbersReady && orchestrationEnabled && assessmentEnabled;
+
+  const fallback = (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-6 px-6 py-12 text-amber-950">
+      <h1 className="text-3xl font-semibold">Weekly Bars</h1>
+      <p className="text-base text-amber-800">
+        Active les évaluations bien-être pour découvrir les barres verbales personnalisées.
+      </p>
+    </main>
+  );
+
+  return (
+    <ZeroNumberBoundary className="min-h-screen bg-gradient-to-b from-amber-50 via-white to-amber-100">
+      <ConsentGate fallback={fallback}>
+        {ready ? (
+          <main className="mx-auto flex w-full max-w-4xl flex-col gap-8 px-6 py-12 text-amber-950" id="main-content">
+            <header className="space-y-3">
+              <Badge className="bg-amber-900 text-amber-100" variant="secondary">
+                Weekly Bars
+              </Badge>
+              <h1 className="text-3xl font-semibold leading-tight">Ta semaine en mots vivants</h1>
+              <p className="max-w-2xl text-base text-amber-800">
+                Les barres verbales reflètent ton état général sans afficher de chiffres. Laisse-toi guider par la texture des
+                mots proposés.
+              </p>
+            </header>
+
+            <Card aria-live="polite">
+              <CardHeader>
+                <CardTitle>Palette hebdomadaire</CardTitle>
+                <CardDescription>{describeBars(barItems)}</CardDescription>
+              </CardHeader>
+              <CardContent className="flex flex-wrap gap-3 text-sm text-amber-900">
+                {barItems.map((item) => (
+                  <span key={item} className="rounded-full bg-amber-900 px-4 py-2 text-amber-50">
+                    {item}
+                  </span>
+                ))}
+                {!barItems.length && (
+                  <span className="rounded-full bg-amber-100 px-4 py-2 text-amber-700">
+                    Aucun repère cette fois-ci, écoute ton ressenti du moment.
+                  </span>
+                )}
+              </CardContent>
+            </Card>
+
+            {ctaAction && (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Proposition apaisante</CardTitle>
+                  <CardDescription>Respire doucement pour prolonger cet état</CardDescription>
+                </CardHeader>
+                <CardContent className="flex flex-col gap-4 text-sm text-amber-900">
+                  <p>
+                    Lorsque la barre « posé » ressort, Flash Glow offre une lumière qui accompagne ton rythme sans chiffres ni
+                    compte à rebours.
+                  </p>
+                  <Link
+                    href="/app/flash-glow"
+                    className="inline-flex items-center justify-center rounded-full bg-amber-900 px-4 py-2 text-amber-50 hover:bg-amber-800 focus:outline-none focus:ring-2 focus:ring-amber-500"
+                    aria-label="Respirer deux minutes avec Flash Glow"
+                  >
+                    Respirer deux minutes ?
+                  </Link>
+                </CardContent>
+              </Card>
+            )}
+          </main>
+        ) : (
+          <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-8 px-6 py-12 text-amber-950">
+            <h1 className="text-3xl font-semibold">Weekly Bars</h1>
+            <p className="max-w-2xl text-base text-amber-800">
+              Active l’orchestration clinique pour visualiser ta semaine en mots plutôt qu’en chiffres.
+            </p>
+          </main>
+        )}
+      </ConsentGate>
+    </ZeroNumberBoundary>
+  );
+}

--- a/src/core/flags.ts
+++ b/src/core/flags.ts
@@ -46,6 +46,10 @@ interface FeatureFlags {
   FF_ORCH_GRIT: boolean;
   FF_ORCH_BUBBLE: boolean;
   FF_ORCH_MIXER: boolean;
+  FF_ORCH_STORY: boolean;
+  FF_ORCH_ACTIVITY: boolean;
+  FF_ORCH_SCREENSILK: boolean;
+  FF_ORCH_WEEKLYBARS: boolean;
   FF_ZERO_NUMBERS?: boolean;
   FF_REQUIRE_CLINICAL_OPTIN: boolean;
 
@@ -99,6 +103,10 @@ const DEFAULT_FLAGS: FeatureFlags = {
   FF_ORCH_GRIT: true,
   FF_ORCH_BUBBLE: true,
   FF_ORCH_MIXER: true,
+  FF_ORCH_STORY: true,
+  FF_ORCH_ACTIVITY: true,
+  FF_ORCH_SCREENSILK: true,
+  FF_ORCH_WEEKLYBARS: true,
   FF_ZERO_NUMBERS: true,
   FF_REQUIRE_CLINICAL_OPTIN: true,
 };

--- a/src/features/orchestration/__tests__/activityJardin.orchestrator.spec.ts
+++ b/src/features/orchestration/__tests__/activityJardin.orchestrator.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { activityJardinOrchestrator } from '../activityJardin.orchestrator';
+
+describe('activityJardinOrchestrator', () => {
+  it('always proposes the supportive highlights', () => {
+    const hints = activityJardinOrchestrator({ who5Level: 2 });
+    expect(hints).toHaveLength(1);
+    expect(hints[0]).toEqual({
+      action: 'show_highlights',
+      items: ['Respirer doucement 1 min', 'Journal court (2 phrases)', 'Nyvée en silence'],
+    });
+  });
+});

--- a/src/features/orchestration/__tests__/screenSilk.orchestrator.spec.ts
+++ b/src/features/orchestration/__tests__/screenSilk.orchestrator.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { screenSilkOrchestrator } from '../screenSilk.orchestrator';
+
+describe('screenSilkOrchestrator', () => {
+  it('returns none when signals are calm and no prm', () => {
+    expect(screenSilkOrchestrator({ cvsqLevel: 0, prm: false })).toEqual([{ action: 'none' }]);
+  });
+
+  it('activates blink reminders and gentle blur when level is elevated', () => {
+    const hints = screenSilkOrchestrator({ cvsqLevel: 2, prm: false });
+    expect(hints).toContainEqual({ action: 'set_blink_reminder', key: 'gentle' });
+    expect(hints).toContainEqual({ action: 'set_blur_opacity', key: 'low' });
+    expect(hints).toContainEqual({ action: 'post_cta', key: 'screen_silk' });
+  });
+
+  it('lowers blur further when reduced motion is requested', () => {
+    const hints = screenSilkOrchestrator({ cvsqLevel: 3, prm: true });
+    expect(hints).toContainEqual({ action: 'set_blur_opacity', key: 'very_low' });
+  });
+});

--- a/src/features/orchestration/__tests__/storySynth.orchestrator.spec.ts
+++ b/src/features/orchestration/__tests__/storySynth.orchestrator.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { storySynthOrchestrator } from '../storySynth.orchestrator';
+
+describe('storySynthOrchestrator', () => {
+  it('returns none when no signals', () => {
+    expect(storySynthOrchestrator({ tensionLevel: 1, fatigueLevel: 1 })).toEqual([{ action: 'none' }]);
+  });
+
+  it('sets the story bed when tension is elevated', () => {
+    const hints = storySynthOrchestrator({ tensionLevel: 3, fatigueLevel: 1 });
+    expect(hints).toContainEqual({ action: 'set_story_bed', key: 'cocon' });
+  });
+
+  it('shortens and slows the scene when fatigue is high', () => {
+    const hints = storySynthOrchestrator({ tensionLevel: 1, fatigueLevel: 3 });
+    expect(hints).toContainEqual({ action: 'shorten_scene', ms: 60_000 });
+    expect(hints).toContainEqual({ action: 'set_story_voice', key: 'slow' });
+  });
+});

--- a/src/features/orchestration/__tests__/weeklyBars.orchestrator.spec.ts
+++ b/src/features/orchestration/__tests__/weeklyBars.orchestrator.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { weeklyBarsOrchestrator } from '../weeklyBars.orchestrator';
+
+describe('weeklyBarsOrchestrator', () => {
+  it('defaults to calm bars when level is missing', () => {
+    const hints = weeklyBarsOrchestrator({});
+    expect(hints).toContainEqual({ action: 'show_bars_text', items: ['posé', 'doux'] });
+  });
+
+  it('keeps calm palette for low wellbeing', () => {
+    const hints = weeklyBarsOrchestrator({ who5Level: 1 });
+    expect(hints).toContainEqual({ action: 'show_bars_text', items: ['posé', 'doux'] });
+  });
+
+  it('activates brighter bars when level is high', () => {
+    const hints = weeklyBarsOrchestrator({ who5Level: 4 });
+    expect(hints).toContainEqual({ action: 'show_bars_text', items: ['clair', 'actif'] });
+  });
+
+  it('always includes the flash glow cta', () => {
+    const hints = weeklyBarsOrchestrator({ who5Level: 2 });
+    expect(hints).toContainEqual({ action: 'post_cta', key: 'flash_glow' });
+  });
+});

--- a/src/features/orchestration/activityJardin.orchestrator.ts
+++ b/src/features/orchestration/activityJardin.orchestrator.ts
@@ -1,0 +1,13 @@
+import type { UIHint } from './types';
+
+export interface ActivityJardinOrchestratorInput {
+  who5Level?: number;
+}
+
+export const activityJardinOrchestrator = ({ who5Level }: ActivityJardinOrchestratorInput): UIHint[] => {
+  void who5Level;
+  const items = ['Respirer doucement 1 min', 'Journal court (2 phrases)', 'Nyvée en silence'];
+  return [{ action: 'show_highlights', items }];
+};
+
+export default activityJardinOrchestrator;

--- a/src/features/orchestration/index.ts
+++ b/src/features/orchestration/index.ts
@@ -4,4 +4,8 @@ export * from './socialCocon.orchestrator';
 export * from './leaderboardAuras.orchestrator';
 export * from './journal.orchestrator';
 export * from './moodMixer.orchestrator';
+export * from './storySynth.orchestrator';
+export * from './activityJardin.orchestrator';
+export * from './screenSilk.orchestrator';
+export * from './weeklyBars.orchestrator';
 export * from './persistOrchestrationSession';

--- a/src/features/orchestration/screenSilk.orchestrator.ts
+++ b/src/features/orchestration/screenSilk.orchestrator.ts
@@ -1,0 +1,28 @@
+import type { UIHint } from './types';
+
+export interface ScreenSilkOrchestratorInput {
+  cvsqLevel?: number;
+  prm: boolean;
+}
+
+export const screenSilkOrchestrator = ({ cvsqLevel, prm }: ScreenSilkOrchestratorInput): UIHint[] => {
+  const hints: UIHint[] = [];
+
+  if ((cvsqLevel ?? 0) >= 2) {
+    hints.push({ action: 'set_blink_reminder', key: 'gentle' });
+    hints.push({ action: 'set_blur_opacity', key: 'low' });
+    hints.push({ action: 'post_cta', key: 'screen_silk' });
+  }
+
+  if (prm) {
+    hints.push({ action: 'set_blur_opacity', key: 'very_low' });
+  }
+
+  if (hints.length === 0) {
+    return [{ action: 'none' }];
+  }
+
+  return hints;
+};
+
+export default screenSilkOrchestrator;

--- a/src/features/orchestration/storySynth.orchestrator.ts
+++ b/src/features/orchestration/storySynth.orchestrator.ts
@@ -1,0 +1,30 @@
+import type { UIHint } from './types';
+
+export interface StorySynthOrchestratorInput {
+  tensionLevel?: number;
+  fatigueLevel?: number;
+}
+
+export const storySynthOrchestrator = ({
+  tensionLevel,
+  fatigueLevel,
+}: StorySynthOrchestratorInput): UIHint[] => {
+  const hints: UIHint[] = [];
+
+  if ((tensionLevel ?? 2) >= 3) {
+    hints.push({ action: 'set_story_bed', key: 'cocon' });
+  }
+
+  if ((fatigueLevel ?? 2) >= 3) {
+    hints.push({ action: 'shorten_scene', ms: 60_000 });
+    hints.push({ action: 'set_story_voice', key: 'slow' });
+  }
+
+  if (hints.length === 0) {
+    return [{ action: 'none' }];
+  }
+
+  return hints;
+};
+
+export default storySynthOrchestrator;

--- a/src/features/orchestration/types.ts
+++ b/src/features/orchestration/types.ts
@@ -36,15 +36,12 @@ export interface SetPathDurationAction {
   ms: number;
 }
 
-export interface PostCtaAction {
-  action: 'post_cta';
-  key: 'nyvee_suggest';
-}
+export type PostCtaAction =
+  | { action: 'post_cta'; key: 'nyvee_suggest' }
+  | { action: 'post_cta'; key: 'screen_silk' }
+  | { action: 'post_cta'; key: 'flash_glow' };
 
-export type BubbleBeatOrchestrationAction =
-  | SetPathVariantAction
-  | SetPathDurationAction
-  | PostCtaAction;
+export type BubbleBeatOrchestrationAction = SetPathVariantAction | SetPathDurationAction | PostCtaAction;
 
 export interface AmbitionOrchestratorInput {
   gasLevel: number;
@@ -60,6 +57,41 @@ export interface BubbleBeatOrchestratorInput {
 }
 export type AssessmentLevel = 0 | 1 | 2 | 3 | 4;
 
+export interface SetStoryBedAction {
+  action: 'set_story_bed';
+  key: 'cocon';
+}
+
+export interface SetStoryVoiceAction {
+  action: 'set_story_voice';
+  key: 'slow';
+}
+
+export interface ShortenSceneAction {
+  action: 'shorten_scene';
+  ms: number;
+}
+
+export interface ShowHighlightsAction {
+  action: 'show_highlights';
+  items: string[];
+}
+
+export interface SetBlinkReminderAction {
+  action: 'set_blink_reminder';
+  key: 'gentle';
+}
+
+export interface SetBlurOpacityAction {
+  action: 'set_blur_opacity';
+  key: 'low' | 'very_low';
+}
+
+export interface ShowBarsTextAction {
+  action: 'show_bars_text';
+  items: string[];
+}
+
 export type UIHint =
   | { action: 'show_banner'; key: 'listen_two_minutes' }
   | { action: 'pin_card'; key: 'social_cocon' }
@@ -67,7 +99,15 @@ export type UIHint =
   | { action: 'promote_cta'; key: 'schedule_break' }
   | { action: 'highlight_rooms_private' }
   | { action: 'none' }
-  | { action: 'set_aura'; key: 'cool_gentle' | 'neutral' | 'warm_soft' };
+  | { action: 'set_aura'; key: 'cool_gentle' | 'neutral' | 'warm_soft' }
+  | SetStoryBedAction
+  | SetStoryVoiceAction
+  | ShortenSceneAction
+  | ShowHighlightsAction
+  | SetBlinkReminderAction
+  | SetBlurOpacityAction
+  | ShowBarsTextAction
+  | PostCtaAction;
 
 export interface CommunityLevels {
   uclaLevel?: number;

--- a/src/features/orchestration/weeklyBars.orchestrator.ts
+++ b/src/features/orchestration/weeklyBars.orchestrator.ts
@@ -1,0 +1,23 @@
+import type { UIHint } from './types';
+
+export interface WeeklyBarsOrchestratorInput {
+  who5Level?: number;
+}
+
+export const weeklyBarsOrchestrator = ({ who5Level }: WeeklyBarsOrchestratorInput): UIHint[] => {
+  const items =
+    who5Level == null
+      ? ['posé', 'doux']
+      : who5Level <= 1
+        ? ['posé', 'doux']
+        : who5Level >= 3
+          ? ['clair', 'actif']
+          : ['posé', 'doux'];
+
+  return [
+    { action: 'show_bars_text', items },
+    { action: 'post_cta', key: 'flash_glow' },
+  ];
+};
+
+export default weeklyBarsOrchestrator;

--- a/src/services/sessions/sessionsApi.ts
+++ b/src/services/sessions/sessionsApi.ts
@@ -17,6 +17,10 @@ export type SessionType =
   | 'social_cocon'
   | 'auras'
   | 'coach'
+  | 'story_synth'
+  | 'activity'
+  | 'screen_silk'
+  | 'weekly_bars'
 
 export type SessionRecord = {
   id: string
@@ -163,7 +167,15 @@ const mkDefaultText = (input: { type: SessionType; mood_delta?: number | null })
           ? 'Voyage sonore clôturé.'
           : input.type === 'scan'
             ? 'Exploration sensorielle finalisée.'
-            : 'Séance terminée.'
+            : input.type === 'story_synth'
+              ? 'Conte apaisant consigné.'
+              : input.type === 'activity'
+                ? 'Moments ressources consignés.'
+                : input.type === 'screen_silk'
+                  ? 'Pause Screen Silk notée.'
+                  : input.type === 'weekly_bars'
+                    ? 'Lecture hebdomadaire enregistrée.'
+                    : 'Séance terminée.'
   const change = input.mood_delta != null ? "Je me sens un peu différent·e qu'avant." : 'Je prends note de mon ressenti présent.'
   return `${label} ${change}`
 }


### PR DESCRIPTION
## Summary
- add Story Synth, Activity Jardin, Screen Silk, and Weekly Bars orchestrators with new UI hint types and feature flags
- implement text-only Next.js pages for each module with consent gating, zero-number guardrails, and session persistence
- cover the new flows with dedicated unit specs and Playwright checks

## Testing
- npx eslint src/app/story-synth/page.tsx src/app/activity/page.tsx src/app/screen-silk/page.tsx src/app/weekly-bars/page.tsx src/features/orchestration/storySynth.orchestrator.ts src/features/orchestration/activityJardin.orchestrator.ts src/features/orchestration/screenSilk.orchestrator.ts src/features/orchestration/weeklyBars.orchestrator.ts e2e/story-synth.spec.ts e2e/activity.spec.ts e2e/screen-silk.spec.ts e2e/weekly-bars.spec.ts --no-warn-ignored
- npx vitest run src/features/orchestration/__tests__/storySynth.orchestrator.spec.ts src/features/orchestration/__tests__/activityJardin.orchestrator.spec.ts src/features/orchestration/__tests__/screenSilk.orchestrator.spec.ts src/features/orchestration/__tests__/weeklyBars.orchestrator.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cf0b7eaf0c832db362482759f9fbbd