### PR TITLE
Ensure Sentry web client uses React SDK and redacts payloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,22 @@ jobs:
       - id: versions
         run: echo "node=20" >> "$GITHUB_OUTPUT"
 
+  sentry-guard:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure web Sentry client does not use Next.js SDK or env vars
+        run: |
+          if rg --files-with-matches '@sentry/nextjs' src/lib/obs; then
+            echo "Do not use @sentry/nextjs in web Sentry code." >&2
+            exit 1
+          fi
+          if rg --files-with-matches 'process\\.env\\.NEXT_' src/lib/obs; then
+            echo "Do not use process.env.NEXT_* in web Sentry code." >&2
+            exit 1
+          fi
+
   lint:
     needs: setup
     runs-on: ubuntu-latest
@@ -73,7 +89,7 @@ jobs:
       - run: pnpm test
 
   build:
-    needs: [lint, typecheck, unit]
+    needs: [lint, sentry-guard, typecheck, unit]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/src/lib/obs/sentry.web.ts
+++ b/src/lib/obs/sentry.web.ts
@@ -16,7 +16,7 @@ const resolveSampleRate = (raw: string | undefined, fallback: number): number =>
   return Math.max(0, Math.min(1, parsed));
 };
 
-const ensureSentryClient = () => {
+const ensureSentryClient = (): void => {
   const dsn = import.meta.env.VITE_SENTRY_DSN;
   if (!dsn) {
     return;
@@ -41,19 +41,11 @@ const ensureSentryClient = () => {
       return event ? (redact(event) as typeof event) : event;
     },
     beforeBreadcrumb(breadcrumb) {
-      if (!breadcrumb) {
-        return breadcrumb;
-      }
-
-      const sanitizedData = breadcrumb.data ? (redact(breadcrumb.data) as Breadcrumb['data']) : breadcrumb.data;
-      return {
-        ...breadcrumb,
-        data: sanitizedData,
-      };
+      return breadcrumb ? (redact(breadcrumb) as Breadcrumb) : breadcrumb;
     },
   });
 };
 
 ensureSentryClient();
 
-export { Sentry };
+export { Sentry, ensureSentryClient };

--- a/tests/sentry.redaction.test.ts
+++ b/tests/sentry.redaction.test.ts
@@ -1,0 +1,133 @@
+import type { Mock } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const currentClientRef: { value: unknown } = { value: null };
+
+vi.mock('@sentry/react', () => {
+  const init = vi.fn((options: unknown) => {
+    currentClientRef.value = { options };
+  });
+
+  const getCurrentHub = vi.fn(() => ({
+    getClient: vi.fn(() => currentClientRef.value),
+  }));
+
+  return {
+    init,
+    getCurrentHub,
+  };
+});
+
+const loadSentryModule = async () => import('@/lib/obs/sentry.web');
+
+const stubBaseEnv = () => {
+  vi.stubEnv('VITE_SENTRY_DSN', 'https://example.ingest.sentry.io/123');
+  vi.stubEnv('VITE_SENTRY_ENVIRONMENT', 'test');
+  vi.stubEnv('VITE_SENTRY_RELEASE', 'release@1.0.0');
+  vi.stubEnv('VITE_SENTRY_TRACES_SAMPLE_RATE', '0.5');
+  vi.stubEnv('VITE_SENTRY_REPLAYS_SESSION_SAMPLE_RATE', '0.1');
+  vi.stubEnv('VITE_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE', '0.2');
+};
+
+describe('ensureSentryClient', () => {
+  beforeEach(() => {
+    currentClientRef.value = null;
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('redacts sensitive data via beforeSend and beforeBreadcrumb', async () => {
+    stubBaseEnv();
+    const { Sentry } = await loadSentryModule();
+
+    const initMock = Sentry.init as Mock;
+    expect(initMock).toHaveBeenCalled();
+
+    const initOptions = initMock.mock.calls.at(-1)?.[0] as {
+      beforeSend: (event: unknown) => unknown;
+      beforeBreadcrumb: (breadcrumb: unknown) => unknown;
+    };
+
+    expect(initOptions).toBeDefined();
+
+    const redactedEvent = initOptions.beforeSend({
+      message: 'User bearer Bearer super-secret-token',
+      request: {
+        headers: {
+          authorization: 'Bearer super-secret-token',
+          'x-forwarded-for': '192.168.0.1',
+        },
+        data: {
+          token: 'abcdef',
+          nested: {
+            password: 'secret-password',
+            safe: 'value',
+          },
+        },
+      },
+    });
+
+    expect(redactedEvent).toMatchInlineSnapshot(`
+      {
+        "message": "User bearer Bearer [REDACTED]",
+        "request": {
+          "data": {
+            "nested": {
+              "password": "[REDACTED]",
+              "safe": "value",
+            },
+            "token": "[REDACTED]",
+          },
+          "headers": {
+            "authorization": "[REDACTED]",
+            "x-forwarded-for": "192.168.0.1",
+          },
+        },
+      }
+    `);
+
+    const redactedBreadcrumb = initOptions.beforeBreadcrumb({
+      category: 'ui.click',
+      message: 'Clicked with Bearer top-secret',
+      data: {
+        authorization: 'Bearer top-secret',
+        nested: {
+          email: 'user@example.com',
+          other: 'value',
+        },
+      },
+    });
+
+    expect(redactedBreadcrumb).toMatchInlineSnapshot(`
+      {
+        "category": "ui.click",
+        "data": {
+          "authorization": "[REDACTED]",
+          "nested": {
+            "email": "[REDACTED]",
+            "other": "value",
+          },
+        },
+        "message": "Clicked with Bearer [REDACTED]",
+      }
+    `);
+  });
+
+  it('is idempotent', async () => {
+    stubBaseEnv();
+    const { ensureSentryClient, Sentry } = await loadSentryModule();
+
+    const initMock = Sentry.init as Mock;
+    initMock.mockClear();
+
+    ensureSentryClient();
+    ensureSentryClient();
+
+    expect(initMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the Vite Sentry client initialises only once and redacts events and breadcrumbs
- add a dedicated test covering client idempotency and snapshotting redaction behaviour
- enforce in CI that the web Sentry code avoids the Next.js SDK and NEXT_* env variables

## Testing
- npm run test -- tests/sentry.redaction.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d2bd55f228832da6229d04aa5d7e05