### PR TITLE
chore: refresh robots and sitemap

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,14 +1,5 @@
-User-agent: Googlebot
-Allow: /
-
-User-agent: Bingbot
-Allow: /
-
-User-agent: Twitterbot
-Allow: /
-
-User-agent: facebookexternalhit
-Allow: /
-
 User-agent: *
 Allow: /
+
+Sitemap: https://emotionscare.com/sitemap.xml
+

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,283 +1,74 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" 
-        xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"
-        xmlns:xhtml="http://www.w3.org/1999/xhtml" 
-        xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" 
-        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" 
-        xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-
-  <!-- Page d'accueil -->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://emotionscare.com/</loc>
-    <lastmod>2025-01-09T13:13:00+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
-    <xhtml:link rel="alternate" hreflang="fr" href="https://emotionscare.com/" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://emotionscare.com/en/" />
-    <mobile:mobile/>
-    <image:image>
-      <image:loc>https://emotionscare.com/images/hero-banner.jpg</image:loc>
-      <image:title>EmotionsCare - Plateforme de Bien-être Émotionnel</image:title>
-      <image:caption>Votre plateforme de bien-être émotionnel en entreprise</image:caption>
-    </image:image>
   </url>
-
-  <!-- Page B2C -->
-  <url>
-    <loc>https://emotionscare.com/b2c</loc>
-    <lastmod>2025-01-09T13:13:00+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-    <xhtml:link rel="alternate" hreflang="fr" href="https://emotionscare.com/b2c" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://emotionscare.com/en/b2c" />
-    <mobile:mobile/>
-    <image:image>
-      <image:loc>https://emotionscare.com/images/b2c-features.jpg</image:loc>
-      <image:title>Fonctionnalités B2C EmotionsCare</image:title>
-      <image:caption>Découvrez nos fonctionnalités pour particuliers</image:caption>
-    </image:image>
-  </url>
-
-  <!-- Page Entreprise -->
-  <url>
-    <loc>https://emotionscare.com/entreprise</loc>
-    <lastmod>2025-01-09T13:13:00+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-    <xhtml:link rel="alternate" hreflang="fr" href="https://emotionscare.com/entreprise" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://emotionscare.com/en/enterprise" />
-    <mobile:mobile/>
-    <image:image>
-      <image:loc>https://emotionscare.com/images/enterprise-dashboard.jpg</image:loc>
-      <image:title>Solutions Entreprise EmotionsCare</image:title>
-      <image:caption>Solutions de bien-être pour vos équipes</image:caption>
-    </image:image>
-  </url>
-
-  <!-- Page de connexion -->
-  <url>
-    <loc>https://emotionscare.com/login</loc>
-    <lastmod>2025-01-09T13:13:00+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-    <mobile:mobile/>
-  </url>
-
-  <!-- Page d'inscription -->
-  <url>
-    <loc>https://emotionscare.com/signup</loc>
-    <lastmod>2025-01-09T13:13:00+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-    <mobile:mobile/>
-  </url>
-
-  <!-- Page d'aide -->
-  <url>
-    <loc>https://emotionscare.com/help</loc>
-    <lastmod>2025-01-09T13:13:00+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-    <xhtml:link rel="alternate" hreflang="fr" href="https://emotionscare.com/help" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://emotionscare.com/en/help" />
-    <mobile:mobile/>
-  </url>
-
-  <!-- Documentation API -->
-  <url>
-    <loc>https://emotionscare.com/api</loc>
-    <lastmod>2025-01-09T13:13:00+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
-    <mobile:mobile/>
-  </url>
-
-  <!-- Page de tarification -->
-  <url>
-    <loc>https://emotionscare.com/pricing</loc>
-    <lastmod>2025-01-09T13:13:00+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-    <xhtml:link rel="alternate" hreflang="fr" href="https://emotionscare.com/pricing" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://emotionscare.com/en/pricing" />
-    <mobile:mobile/>
-  </url>
-
-  <!-- Pages légales -->
-  <url>
-    <loc>https://emotionscare.com/legal/terms</loc>
-    <lastmod>2025-01-09T13:13:00+00:00</lastmod>
-    <changefreq>quarterly</changefreq>
-    <priority>0.3</priority>
-    <mobile:mobile/>
-  </url>
-
-  <url>
-    <loc>https://emotionscare.com/legal/privacy</loc>
-    <lastmod>2025-01-09T13:13:00+00:00</lastmod>
-    <changefreq>quarterly</changefreq>
-    <priority>0.3</priority>
-    <mobile:mobile/>
-  </url>
-
-  <!-- Fonctionnalités principales (pages publiques d'information) -->
-  <url>
-    <loc>https://emotionscare.com/features/emotion-scanner</loc>
-    <lastmod>2025-01-09T13:13:00+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-    <mobile:mobile/>
-    <image:image>
-      <image:loc>https://emotionscare.com/images/emotion-scanner.jpg</image:loc>
-      <image:title>Scanner d'Émotions EmotionsCare</image:title>
-      <image:caption>Analysez vos émotions en temps réel</image:caption>
-    </image:image>
-  </url>
-
-  <url>
-    <loc>https://emotionscare.com/features/ai-coach</loc>
-    <lastmod>2025-01-09T13:13:00+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-    <mobile:mobile/>
-    <image:image>
-      <image:loc>https://emotionscare.com/images/ai-coach.jpg</image:loc>
-      <image:title>Coach IA EmotionsCare</image:title>
-      <image:caption>Votre accompagnateur personnel intelligent</image:caption>
-    </image:image>
-  </url>
-
-  <url>
-    <loc>https://emotionscare.com/features/vr-meditation</loc>
-    <lastmod>2025-01-09T13:13:00+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-    <mobile:mobile/>
-    <image:image>
-      <image:loc>https://emotionscare.com/images/vr-meditation.jpg</image:loc>
-      <image:title>Méditation VR EmotionsCare</image:title>
-      <image:caption>Méditation immersive en réalité virtuelle</image:caption>
-    </image:image>
-  </url>
-
-  <url>
-    <loc>https://emotionscare.com/features/music-therapy</loc>
-    <lastmod>2025-01-09T13:13:00+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-    <mobile:mobile/>
-    <image:image>
-      <image:loc>https://emotionscare.com/images/music-therapy.jpg</image:loc>
-      <image:title>Musicothérapie EmotionsCare</image:title>
-      <image:caption>Thérapie par la musique personnalisée</image:caption>
-    </image:image>
-  </url>
-
-  <!-- Blog/Articles (exemples) -->
-  <url>
-    <loc>https://emotionscare.com/blog/gestion-stress-entreprise</loc>
-    <lastmod>2025-01-08T10:00:00+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-    <mobile:mobile/>
-    <news:news>
-      <news:publication>
-        <news:name>EmotionsCare Blog</news:name>
-        <news:language>fr</news:language>
-      </news:publication>
-      <news:publication_date>2025-01-08T10:00:00+00:00</news:publication_date>
-      <news:title>Guide complet de la gestion du stress en entreprise</news:title>
-    </news:news>
-  </url>
-
-  <url>
-    <loc>https://emotionscare.com/blog/intelligence-artificielle-bien-etre</loc>
-    <lastmod>2025-01-07T14:30:00+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-    <mobile:mobile/>
-    <news:news>
-      <news:publication>
-        <news:name>EmotionsCare Blog</news:name>
-        <news:language>fr</news:language>
-      </news:publication>
-      <news:publication_date>2025-01-07T14:30:00+00:00</news:publication_date>
-      <news:title>L'IA au service du bien-être : révolution ou évolution ?</news:title>
-    </news:news>
-  </url>
-
-  <!-- Ressources -->
-  <url>
-    <loc>https://emotionscare.com/resources/guides</loc>
-    <lastmod>2025-01-09T13:13:00+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
-    <mobile:mobile/>
-  </url>
-
-  <url>
-    <loc>https://emotionscare.com/resources/webinars</loc>
-    <lastmod>2025-01-09T13:13:00+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
-    <mobile:mobile/>
-  </url>
-
-  <url>
-    <loc>https://emotionscare.com/resources/case-studies</loc>
-    <lastmod>2025-01-09T13:13:00+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
-    <mobile:mobile/>
-  </url>
-
-  <!-- À propos -->
   <url>
     <loc>https://emotionscare.com/about</loc>
-    <lastmod>2025-01-09T13:13:00+00:00</lastmod>
-    <changefreq>quarterly</changefreq>
-    <priority>0.4</priority>
-    <mobile:mobile/>
-  </url>
-
-  <url>
-    <loc>https://emotionscare.com/about/team</loc>
-    <lastmod>2025-01-09T13:13:00+00:00</lastmod>
-    <changefreq>quarterly</changefreq>
-    <priority>0.3</priority>
-    <mobile:mobile/>
-  </url>
-
-  <url>
-    <loc>https://emotionscare.com/about/careers</loc>
-    <lastmod>2025-01-09T13:13:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.4</priority>
-    <mobile:mobile/>
+    <priority>0.7</priority>
   </url>
-
-  <!-- Contact -->
   <url>
     <loc>https://emotionscare.com/contact</loc>
-    <lastmod>2025-01-09T13:13:00+00:00</lastmod>
-    <changefreq>quarterly</changefreq>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://emotionscare.com/help</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://emotionscare.com/demo</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://emotionscare.com/onboarding</loc>
+    <changefreq>monthly</changefreq>
     <priority>0.5</priority>
-    <mobile:mobile/>
   </url>
-
-  <!-- Sitemaps additionnels -->
   <url>
-    <loc>https://emotionscare.com/sitemap-blog.xml</loc>
-    <lastmod>2025-01-09T13:13:00+00:00</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.2</priority>
+    <loc>https://emotionscare.com/b2c</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
-
   <url>
-    <loc>https://emotionscare.com/sitemap-products.xml</loc>
-    <lastmod>2025-01-09T13:13:00+00:00</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.2</priority>
+    <loc>https://emotionscare.com/entreprise</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
-
+  <url>
+    <loc>https://emotionscare.com/choose-mode</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://emotionscare.com/login</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://emotionscare.com/signup</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://emotionscare.com/privacy</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.4</priority>
+  </url>
+  <url>
+    <loc>https://emotionscare.com/legal/terms</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.4</priority>
+  </url>
+  <url>
+    <loc>https://emotionscare.com/legal/privacy</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.4</priority>
+  </url>
 </urlset>
+


### PR DESCRIPTION
## Summary
- point robots.txt to the sitemap and keep a single, permissive crawl policy
- replace sitemap.xml with a concise list of public marketing routes

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d2cc19c338832db7cc962ecd84c9f0