### PR TITLE
feat(obs): configure sentry tags and redact web events

### DIFF
--- a/src/lib/obs/__tests__/sentry.web.spec.ts
+++ b/src/lib/obs/__tests__/sentry.web.spec.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const initMock = vi.fn();
+const setTagMock = vi.fn();
+const configureScopeMock = vi.fn((callback: (scope: { setTag: typeof setTagMock }) => void) => {
+  callback({ setTag: setTagMock });
+});
+const getClientMock = vi.fn();
+
+vi.mock('@sentry/react', () => ({
+  init: initMock,
+  configureScope: configureScopeMock,
+  getCurrentHub: vi.fn(() => ({
+    getClient: getClientMock,
+  })),
+}));
+
+describe('sentry.web', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.stubEnv('VITE_SENTRY_DSN', 'https://example.com/1');
+    vi.stubEnv('VITE_SENTRY_ENVIRONMENT', 'staging');
+    vi.stubEnv('VITE_SENTRY_RELEASE', '1.0.0');
+    getClientMock.mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('initializes Sentry with release and environment tags', async () => {
+    await import('../sentry.web');
+
+    expect(initMock).toHaveBeenCalledTimes(1);
+    expect(initMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        environment: 'staging',
+        release: '1.0.0',
+      }),
+    );
+    expect(setTagMock).toHaveBeenCalledWith('release', '1.0.0');
+    expect(setTagMock).toHaveBeenCalledWith('environment', 'staging');
+  });
+
+  it('redacts sensitive information before sending events and breadcrumbs', async () => {
+    await import('../sentry.web');
+
+    const options = initMock.mock.calls[0][0] as {
+      beforeSend?: (event: Record<string, unknown>) => Record<string, unknown>;
+      beforeBreadcrumb?: (breadcrumb: Record<string, unknown>) => Record<string, unknown>;
+    };
+
+    const event = {
+      user: { email: 'user@example.com' },
+      request: { headers: { authorization: 'Bearer secret-token' } },
+      tags: { custom: 'value' },
+    };
+    const sanitizedEvent = options.beforeSend?.(event) as typeof event;
+
+    expect(sanitizedEvent.user?.email).toBe('[REDACTED]');
+    expect(sanitizedEvent.request?.headers?.authorization).toBe('[REDACTED]');
+    expect(sanitizedEvent.tags).toEqual(
+      expect.objectContaining({
+        custom: 'value',
+        release: '1.0.0',
+        environment: 'staging',
+      }),
+    );
+
+    const breadcrumb = { message: 'Bearer abc.def-ghi' };
+    const sanitizedBreadcrumb = options.beforeBreadcrumb?.(breadcrumb) as typeof breadcrumb;
+
+    expect(sanitizedBreadcrumb.message).toBe('Bearer [REDACTED]');
+  });
+});

--- a/src/lib/obs/sentry.web.ts
+++ b/src/lib/obs/sentry.web.ts
@@ -26,24 +26,51 @@ const ensureSentryClient = (): void => {
     return;
   }
 
+  const environment = import.meta.env.VITE_SENTRY_ENVIRONMENT;
+  const release = import.meta.env.VITE_SENTRY_RELEASE;
   const tracesSampleRate = resolveSampleRate(import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE, 0.2);
   const replaysSampleRate = resolveSampleRate(import.meta.env.VITE_SENTRY_REPLAYS_SESSION_SAMPLE_RATE, 0);
   const replaysOnErrorSampleRate = resolveSampleRate(import.meta.env.VITE_SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE, 0);
 
   Sentry.init({
     dsn,
-    environment: import.meta.env.VITE_SENTRY_ENVIRONMENT,
-    release: import.meta.env.VITE_SENTRY_RELEASE,
+    environment,
+    release,
     tracesSampleRate,
     replaysSessionSampleRate: replaysSampleRate,
     replaysOnErrorSampleRate,
     beforeSend(event) {
-      return event ? (redact(event) as typeof event) : event;
+      if (!event) {
+        return event;
+      }
+
+      const sanitizedEvent = redact(event);
+
+      if (release || environment) {
+        sanitizedEvent.tags = {
+          ...(sanitizedEvent.tags ?? {}),
+          ...(release ? { release } : {}),
+          ...(environment ? { environment } : {}),
+        };
+      }
+
+      return sanitizedEvent as typeof event;
     },
     beforeBreadcrumb(breadcrumb) {
       return breadcrumb ? (redact(breadcrumb) as Breadcrumb) : breadcrumb;
     },
   });
+
+  if (release || environment) {
+    Sentry.configureScope((scope) => {
+      if (release) {
+        scope.setTag('release', release);
+      }
+      if (environment) {
+        scope.setTag('environment', environment);
+      }
+    });
+  }
 };
 
 ensureSentryClient();


### PR DESCRIPTION
## Summary
- configure the Sentry web client to forward release and environment metadata as tags
- ensure captured events add the tags after redaction while keeping breadcrumb scrubbing intact
- add targeted tests covering the configuration and redaction behaviour

## Testing
- npm run test -- src/lib/obs/__tests__/sentry.web.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d2cc8bba14832da444c5a5dcea7437