### PR TITLE
Fix tsconfig include paths

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,18 +21,18 @@
     }
   },
   "include": [
-    "src",
-    "types",
-    "tests",
-    "test",
-    "services",
-    "scripts",
-    "supabase",
-    "ci",
-    "tools",
-    "vitest.config.ts",
-    "vitest.*.config.ts",
-    "playwright.config.ts"
+    "./src",
+    "./types",
+    "./tests",
+    "./test",
+    "./services",
+    "./scripts",
+    "./supabase",
+    "./ci",
+    "./tools",
+    "./vitest.config.ts",
+    "./vitest.*.config.ts",
+    "./playwright.config.ts"
   ],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- prefix the tsconfig include globs with relative paths to resolve TS5090 errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d794fc3b80832da77df2a3657a569b