### PR TITLE
Fix TypeScript path aliases to use explicit relative prefixes

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,9 +15,9 @@
     "types": ["vite/client", "node"],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
-      "@types/*": ["types/*"],
-      "cross-fetch": ["tests/polyfills/cross-fetch.ts"]
+      "@/*": ["./src/*"],
+      "@types/*": ["./types/*"],
+      "cross-fetch": ["./tests/polyfills/cross-fetch.ts"]
     }
   },
   "include": [


### PR DESCRIPTION
## Summary
- update the tsconfig path aliases to include explicit `./` prefixes required by TypeScript 5.x

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7a15745a8832d88cd7546d6e60713