### PR TITLE
Fix TypeScript JSX configuration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "jsx": "react-jsx",
     "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary
- enable the React JSX transform in the root TypeScript configuration so TSX files compile without TS6142 errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7a3e16818832d9b39ecd57a8dff93