### PR TITLE
feat: scaffold assessments storage and workflows

### DIFF
--- a/packages/contracts/assess.ts
+++ b/packages/contracts/assess.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+export const Instrument = z.enum([
+  "WHO5","STAI6","PANAS10","PSS10","UCLA3","MSPSS","AAQ2","POMS_SF","SSQ",
+  "ISI","GAS","GRITS","BRS","WEMWBS","SWEMWBS","UWES9","CBI","CVSQ","SAM","SUDS"
+]);
+
+export const Context = z.enum(["pre","post","weekly","monthly","adhoc"]);
+
+export const StartInput = z.object({
+  instrument: Instrument,
+  lang: z.string().default("fr"),
+  context: Context.optional()
+});
+
+export const StartOutput = z.object({
+  session_id: z.string().uuid(),
+  items: z.array(z.object({
+    id: z.string(),
+    prompt: z.string(),
+    choices: z.array(z.union([z.string(), z.number()])).optional()
+  })),
+  expiry_ts: z.number()
+});
+
+export const SubmitInput = z.object({
+  session_id: z.string().uuid(),
+  answers: z.array(z.object({ id: z.string(), value: z.number() })),
+  meta: z.object({
+    duration_ms: z.number().int().nonnegative().optional(),
+    device_flags: z.record(z.string(), z.any()).optional()
+  }).optional()
+});
+
+export const SubmitOutput = z.object({
+  receipt_id: z.string().uuid(),
+  orchestration: z.object({
+    hints: z.array(z.string())
+  })
+});
+
+export const AggregateInput = z.object({
+  org_id: z.string().uuid(),
+  period: z.object({ from: z.string(), to: z.string() }),
+  instruments: z.array(Instrument).optional(),
+  team_id: z.string().uuid().optional(),
+  min_n: z.number().int().min(5).default(5)
+});
+
+export const AggregateOutput = z.object({
+  ok: z.literal(true),
+  n: z.number().int(),
+  text_summary: z.array(z.string())
+});

--- a/supabase/functions/assess/aggregate/index.ts
+++ b/supabase/functions/assess/aggregate/index.ts
@@ -1,0 +1,257 @@
+import { serve } from '../../_shared/serve.ts';
+import { z } from '../../_shared/zod.ts';
+import { authenticateRequest, logUnauthorizedAccess } from '../../_shared/auth-middleware.ts';
+import { appendCorsHeaders, preflightResponse, rejectCors, resolveCors } from '../../_shared/cors.ts';
+import { applySecurityHeaders, json } from '../../_shared/http.ts';
+import { traced } from '../../_shared/otel.ts';
+import { recordEdgeLatencyMetric } from '../../_shared/metrics.ts';
+import { createClient } from '../../_shared/supabase.ts';
+import { hash } from '../../_shared/hash_user.ts';
+import { captureSentryException } from '../../_shared/sentry.ts';
+
+const instrumentValues = [
+  'WHO5','STAI6','PANAS10','PSS10','UCLA3','MSPSS','AAQ2','POMS_SF','SSQ',
+  'ISI','GAS','GRITS','BRS','WEMWBS','SWEMWBS','UWES9','CBI','CVSQ','SAM','SUDS',
+] as const;
+
+const aggregateSchema = z.object({
+  org_id: z.string().uuid(),
+  period: z.object({ from: z.string(), to: z.string() }),
+  instruments: z.array(z.enum(instrumentValues)).optional(),
+  team_id: z.string().uuid().optional(),
+  min_n: z.number().int().min(5).default(5),
+});
+
+type AggregatePayload = z.infer<typeof aggregateSchema>;
+type InstrumentCode = (typeof instrumentValues)[number];
+
+type AggRow = {
+  instrument: InstrumentCode;
+  bucket_week: string;
+  n: number;
+  payloads: unknown;
+  org_id: string | null;
+  team_id: string | null;
+};
+
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL') ?? '';
+const SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+
+const ORG_ALLOWED_ROLES = ['b2b_admin', 'b2b_hr', 'b2b_manager', 'admin'] as const;
+
+function parseDate(value: string): Date | null {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date;
+}
+
+function summariseInstrument(instrument: AggRow['instrument'], payloads: unknown[]): string {
+  switch (instrument) {
+    case 'WHO5':
+      return 'Les ressentis globaux restent cohérents et appellent à maintenir le cocon.';
+    case 'STAI6':
+      return 'Les signaux de tension sont suivis avec douceur et sans chiffres.';
+    case 'PANAS10':
+      return 'Les émotions rapportées se balancent entre énergie et calme, avec une attention verbale.';
+    case 'PSS10':
+      return 'La charge perçue reste verbalisée sans métriques, avec un accompagnement apaisé.';
+    case 'MSPSS':
+      return 'Le soutien ressenti continue d’être discuté en mots, jamais en pourcentages.';
+    case 'SSQ':
+      return 'Le suivi VR privilégie la sécurité : ajustements textuels et fallback 2D si nécessaire.';
+    case 'SUDS':
+      return 'Les montées et redescendes de ressenti sont guidées par des invites verbales.';
+    default:
+      return "Les tendances collectives sont décrites en langage naturel, sans aucune donnée individuelle.";
+  }
+}
+
+serve(async (req) => {
+  const startedAt = Date.now();
+  const cors = resolveCors(req);
+  let hashedUserId: string | null = null;
+  let hashedOrgId: string | null = null;
+
+  const finalize = async (
+    response: Response,
+    metadata: { outcome?: 'success' | 'error' | 'denied'; stage?: string | null; error?: string | null } = {},
+  ) => {
+    await recordEdgeLatencyMetric({
+      route: 'assess/aggregate',
+      durationMs: Date.now() - startedAt,
+      status: response.status,
+      hashedUserId,
+      hashedOrgId,
+      outcome: metadata.outcome,
+      stage: metadata.stage ?? null,
+      error: metadata.error ?? null,
+    });
+    return response;
+  };
+
+  if (req.method === 'OPTIONS') {
+    return finalize(applySecurityHeaders(preflightResponse(cors), { cacheControl: 'no-store' }));
+  }
+
+  if (!cors.allowed) {
+    return finalize(applySecurityHeaders(rejectCors(cors), { cacheControl: 'no-store' }), {
+      outcome: 'denied',
+      error: 'origin_not_allowed',
+      stage: 'cors',
+    });
+  }
+
+  if (req.method !== 'POST') {
+    const response = appendCorsHeaders(json(405, { error: 'method_not_allowed' }), cors);
+    return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+      outcome: 'denied',
+      error: 'method_not_allowed',
+      stage: 'method',
+    });
+  }
+
+  if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
+    const response = appendCorsHeaders(json(500, { error: 'SERVER_ERROR' }), cors);
+    return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+      outcome: 'error',
+      error: 'configuration_missing',
+      stage: 'config',
+    });
+  }
+
+  try {
+    const auth = await authenticateRequest(req);
+    if (auth.status !== 200 || !auth.user) {
+      if (auth.status === 401 || auth.status === 403) {
+        await logUnauthorizedAccess(req, auth.error ?? 'unauthorized');
+      }
+      const response = appendCorsHeaders(json(auth.status, { error: 'FORBIDDEN' }), cors);
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'denied',
+        error: 'auth_failed',
+        stage: 'auth',
+      });
+    }
+
+    hashedUserId = hash(auth.user.id);
+
+    const role = (auth.user.user_metadata?.role as string | undefined) ?? 'b2c';
+    if (!ORG_ALLOWED_ROLES.includes(role as (typeof ORG_ALLOWED_ROLES)[number])) {
+      const response = appendCorsHeaders(json(403, { error: 'FORBIDDEN' }), cors);
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'denied',
+        error: 'forbidden',
+        stage: 'role',
+      });
+    }
+
+    const body = await req.json().catch(() => null);
+    if (!body) {
+      const response = appendCorsHeaders(json(422, { error: 'INVALID_PAYLOAD' }), cors);
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'denied',
+        error: 'invalid_payload',
+        stage: 'payload',
+      });
+    }
+
+    const parsed = aggregateSchema.safeParse(body);
+    if (!parsed.success) {
+      const response = appendCorsHeaders(json(422, { error: 'INVALID_PAYLOAD' }), cors);
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'denied',
+        error: 'validation_failed',
+        stage: 'payload',
+      });
+    }
+
+    const payload = parsed.data;
+    const fromDate = parseDate(payload.period.from);
+    const toDate = parseDate(payload.period.to);
+
+    if (!fromDate || !toDate || fromDate > toDate) {
+      const response = appendCorsHeaders(json(422, { error: 'INVALID_PAYLOAD' }), cors);
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'denied',
+        error: 'invalid_period',
+        stage: 'payload',
+      });
+    }
+
+    hashedOrgId = hash(payload.org_id);
+
+    const client = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+
+    const query = client
+      .from('assess_agg_source')
+      .select('instrument,bucket_week,n,payloads,org_id,team_id')
+      .eq('org_id', payload.org_id)
+      .gte('bucket_week', fromDate.toISOString())
+      .lte('bucket_week', toDate.toISOString());
+
+    if (payload.team_id) {
+      query.eq('team_id', payload.team_id);
+    }
+
+    if (payload.instruments && payload.instruments.length > 0) {
+      query.in('instrument', payload.instruments);
+    }
+
+    const { data, error } = await traced(
+      'supabase.assess_agg_source',
+      () => query,
+      { attributes: { route: 'assess/aggregate', org_id: payload.org_id } },
+    );
+
+    if (error) {
+      console.error('[assess/aggregate] fetch failed', error);
+      const response = appendCorsHeaders(json(500, { error: 'SERVER_ERROR' }), cors);
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'error',
+        error: 'fetch_failed',
+        stage: 'storage',
+      });
+    }
+
+    const rows = (data ?? []) as AggRow[];
+
+    const totalN = rows.reduce((acc, row) => acc + (row.n ?? 0), 0);
+    if (totalN < payload.min_n) {
+      const response = appendCorsHeaders(json(400, { error: { code: 'MIN_N' } }), cors);
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'denied',
+        error: 'min_n',
+        stage: 'threshold',
+      });
+    }
+
+    const textSummary = Array.from(
+      new Set(
+        rows.map((row) => {
+          const payloads = Array.isArray(row.payloads) ? row.payloads : [];
+          return summariseInstrument(row.instrument, payloads);
+        }),
+      ),
+    );
+
+    const response = appendCorsHeaders(
+      json(200, { ok: true, n: totalN, text_summary: textSummary }),
+      cors,
+    );
+
+    return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+      outcome: 'success',
+    });
+  } catch (error) {
+    console.error('[assess/aggregate] unexpected failure', error);
+    captureSentryException(error);
+    const response = appendCorsHeaders(json(500, { error: 'SERVER_ERROR' }), cors);
+    return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+      outcome: 'error',
+      error: 'unexpected',
+      stage: 'exception',
+    });
+  }
+});

--- a/supabase/functions/assess/start/index.ts
+++ b/supabase/functions/assess/start/index.ts
@@ -1,0 +1,267 @@
+import { serve } from '../../_shared/serve.ts';
+import { z } from '../../_shared/zod.ts';
+import { authenticateRequest, logUnauthorizedAccess } from '../../_shared/auth-middleware.ts';
+import { appendCorsHeaders, preflightResponse, rejectCors, resolveCors } from '../../_shared/cors.ts';
+import { applySecurityHeaders, json } from '../../_shared/http.ts';
+import { addSentryBreadcrumb, captureSentryException } from '../../_shared/sentry.ts';
+import { traced } from '../../_shared/otel.ts';
+import { recordEdgeLatencyMetric } from '../../_shared/metrics.ts';
+import { createClient } from '../../_shared/supabase.ts';
+import { hash } from '../../_shared/hash_user.ts';
+
+const SESSION_TTL_MS = 15 * 60 * 1000;
+
+const startSchema = z.object({
+  instrument: z.enum([
+    'WHO5','STAI6','PANAS10','PSS10','UCLA3','MSPSS','AAQ2','POMS_SF','SSQ',
+    'ISI','GAS','GRITS','BRS','WEMWBS','SWEMWBS','UWES9','CBI','CVSQ','SAM','SUDS'
+  ]),
+  lang: z.string().min(2).max(5).default('fr'),
+  context: z.enum(['pre','post','weekly','monthly','adhoc']).optional()
+});
+
+type StartPayload = z.infer<typeof startSchema>;
+
+type CatalogRow = {
+  item_id: string;
+  prompt: string;
+  choices: unknown | null;
+};
+
+type SessionEntry = {
+  user_id: string;
+  instrument: StartPayload['instrument'];
+  lang: string;
+  context: StartPayload['context'] | null;
+  item_ids: string[];
+  created_at: number;
+  expires_at: number;
+};
+
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL') ?? '';
+const SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+
+function featureKey(instrument: StartPayload['instrument']): string {
+  return `FF_ASSESS_${instrument}`;
+}
+
+async function fetchCatalog(
+  client: ReturnType<typeof createClient>,
+  instrument: StartPayload['instrument'],
+  lang: string,
+): Promise<CatalogRow[]> {
+  const { data, error } = await traced(
+    'supabase.catalog',
+    () =>
+      client
+        .from('assess_items_catalog')
+        .select('item_id,prompt,choices')
+        .eq('instrument', instrument)
+        .eq('version', 'v1')
+        .eq('lang', lang)
+        .order('item_id', { ascending: true }),
+    {
+      attributes: { route: 'assess/start', instrument, lang },
+    },
+  );
+
+  if (error) {
+    throw new Error(`catalog_fetch_failed:${error.message}`);
+  }
+  return data ?? [];
+}
+
+async function ensureFeatureFlag(
+  client: ReturnType<typeof createClient>,
+  instrument: StartPayload['instrument'],
+): Promise<boolean> {
+  const key = featureKey(instrument);
+  const { data, error } = await traced(
+    'supabase.feature',
+    () =>
+      client
+        .from('assess_features')
+        .select('enabled')
+        .eq('key', key)
+        .maybeSingle(),
+    { attributes: { route: 'assess/start', feature: key } },
+  );
+
+  if (error) {
+    console.error('[assess/start] feature flag lookup failed', { message: error.message });
+    return true;
+  }
+
+  if (!data) {
+    return true;
+  }
+
+  return Boolean(data.enabled);
+}
+
+async function storeSession(sessionId: string, entry: SessionEntry) {
+  const kv = await Deno.openKv();
+  await kv.set(['assess', 'session', sessionId], entry, { expireIn: SESSION_TTL_MS });
+}
+
+serve(async (req) => {
+  const startedAt = Date.now();
+  const cors = resolveCors(req);
+  let hashedUserId: string | null = null;
+
+  const finalize = async (
+    response: Response,
+    metadata: { outcome?: 'success' | 'error' | 'denied'; stage?: string | null; error?: string | null } = {},
+  ) => {
+    await recordEdgeLatencyMetric({
+      route: 'assess/start',
+      durationMs: Date.now() - startedAt,
+      status: response.status,
+      hashedUserId,
+      outcome: metadata.outcome,
+      stage: metadata.stage ?? null,
+      error: metadata.error ?? null,
+    });
+    return response;
+  };
+
+  if (req.method === 'OPTIONS') {
+    return finalize(applySecurityHeaders(preflightResponse(cors), { cacheControl: 'no-store' }));
+  }
+
+  if (!cors.allowed) {
+    return finalize(applySecurityHeaders(rejectCors(cors), { cacheControl: 'no-store' }), {
+      outcome: 'denied',
+      error: 'origin_not_allowed',
+      stage: 'cors',
+    });
+  }
+
+  if (req.method !== 'POST') {
+    const response = appendCorsHeaders(json(405, { error: 'method_not_allowed' }), cors);
+    return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+      outcome: 'denied',
+      error: 'method_not_allowed',
+      stage: 'method',
+    });
+  }
+
+  if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
+    console.error('[assess/start] missing Supabase configuration');
+    const response = appendCorsHeaders(json(500, { error: 'SERVER_ERROR' }), cors);
+    return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+      outcome: 'error',
+      error: 'configuration_missing',
+      stage: 'config',
+    });
+  }
+
+  try {
+    const auth = await authenticateRequest(req);
+    if (auth.status !== 200 || !auth.user) {
+      if (auth.status === 401 || auth.status === 403) {
+        await logUnauthorizedAccess(req, auth.error ?? 'unauthorized');
+      }
+      const response = appendCorsHeaders(json(auth.status, { error: 'FORBIDDEN' }), cors);
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'denied',
+        error: 'auth_failed',
+        stage: 'auth',
+      });
+    }
+
+    hashedUserId = hash(auth.user.id);
+
+    const body = await req.json().catch(() => null);
+    if (!body) {
+      const response = appendCorsHeaders(json(422, { error: 'INVALID_PAYLOAD' }), cors);
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'denied',
+        error: 'invalid_payload',
+        stage: 'payload',
+      });
+    }
+
+    const parsed = startSchema.safeParse(body);
+    if (!parsed.success) {
+      const response = appendCorsHeaders(json(422, { error: 'INVALID_PAYLOAD' }), cors);
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'denied',
+        error: 'validation_failed',
+        stage: 'payload',
+      });
+    }
+
+    const payload = parsed.data;
+    const client = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+
+    const enabled = await ensureFeatureFlag(client, payload.instrument);
+    if (!enabled) {
+      addSentryBreadcrumb({
+        category: 'assess.start',
+        message: 'feature_flag_off',
+        data: { instrument: payload.instrument },
+      });
+      const response = appendCorsHeaders(json(404, { error: 'FEATURE_OFF' }), cors);
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'denied',
+        error: 'feature_off',
+        stage: 'feature',
+      });
+    }
+
+    let catalog = await fetchCatalog(client, payload.instrument, payload.lang);
+    if (catalog.length === 0 && payload.lang !== 'en') {
+      catalog = await fetchCatalog(client, payload.instrument, 'en');
+    }
+
+    if (catalog.length === 0) {
+      const response = appendCorsHeaders(json(404, { error: 'catalog_missing' }), cors);
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'error',
+        error: 'catalog_missing',
+        stage: 'catalog',
+      });
+    }
+
+    const sessionId = crypto.randomUUID();
+    const createdAt = Date.now();
+    const expiresAt = createdAt + SESSION_TTL_MS;
+
+    await storeSession(sessionId, {
+      user_id: auth.user.id,
+      instrument: payload.instrument,
+      lang: payload.lang,
+      context: payload.context ?? null,
+      item_ids: catalog.map((row) => row.item_id),
+      created_at: createdAt,
+      expires_at: expiresAt,
+    });
+
+    const responsePayload = {
+      session_id: sessionId,
+      items: catalog.map((row) => ({
+        id: row.item_id,
+        prompt: row.prompt,
+        choices: Array.isArray(row.choices)
+          ? (row.choices as (string | number)[])
+          : undefined,
+      })),
+      expiry_ts: expiresAt,
+    };
+
+    const response = appendCorsHeaders(json(200, responsePayload), cors);
+    return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+      outcome: 'success',
+    });
+  } catch (error) {
+    console.error('[assess/start] unexpected failure', error);
+    captureSentryException(error);
+    const response = appendCorsHeaders(json(500, { error: 'SERVER_ERROR' }), cors);
+    return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+      outcome: 'error',
+      error: 'unexpected',
+      stage: 'exception',
+    });
+  }
+});

--- a/supabase/functions/assess/submit/index.ts
+++ b/supabase/functions/assess/submit/index.ts
@@ -165,7 +165,7 @@ function computePANAS10(values: number[]) {
 }
 
 function computePSS10(values: number[]) {
-  const inverted = new Set([1, 2, 3, 6, 9]);
+  const inverted = new Set([0, 1, 2, 5, 8]);
   const corrected = values.map((value, index) => (inverted.has(index) ? 4 - value : value));
   const sum = corrected.reduce((acc, value) => acc + value, 0);
   return { score_scaled: scale(sum, 0, 40) };

--- a/supabase/functions/assess/submit/index.ts
+++ b/supabase/functions/assess/submit/index.ts
@@ -1,0 +1,493 @@
+import { serve } from '../../_shared/serve.ts';
+import { z } from '../../_shared/zod.ts';
+import { authenticateRequest, logUnauthorizedAccess } from '../../_shared/auth-middleware.ts';
+import { appendCorsHeaders, preflightResponse, rejectCors, resolveCors } from '../../_shared/cors.ts';
+import { applySecurityHeaders, json } from '../../_shared/http.ts';
+import { traced } from '../../_shared/otel.ts';
+import { recordEdgeLatencyMetric } from '../../_shared/metrics.ts';
+import { createClient } from '../../_shared/supabase.ts';
+import { hash } from '../../_shared/hash_user.ts';
+import { captureSentryException } from '../../_shared/sentry.ts';
+
+const submitSchema = z.object({
+  session_id: z.string().uuid(),
+  answers: z.array(z.object({ id: z.string(), value: z.number() })).min(1),
+  meta: z
+    .object({
+      duration_ms: z.number().int().nonnegative().optional(),
+      device_flags: z.record(z.string(), z.any()).optional(),
+    })
+    .optional(),
+});
+
+type SessionEntry = {
+  user_id: string;
+  instrument:
+    | 'WHO5'
+    | 'STAI6'
+    | 'PANAS10'
+    | 'PSS10'
+    | 'UCLA3'
+    | 'MSPSS'
+    | 'AAQ2'
+    | 'POMS_SF'
+    | 'SSQ'
+    | 'ISI'
+    | 'GAS'
+    | 'GRITS'
+    | 'BRS'
+    | 'WEMWBS'
+    | 'SWEMWBS'
+    | 'UWES9'
+    | 'CBI'
+    | 'CVSQ'
+    | 'SAM'
+    | 'SUDS';
+  lang: string;
+  context: 'pre' | 'post' | 'weekly' | 'monthly' | 'adhoc' | null;
+  item_ids: string[];
+  created_at: number;
+  expires_at: number;
+};
+
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL') ?? '';
+const SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+
+async function getSession(sessionId: string): Promise<SessionEntry | null> {
+  const kv = await Deno.openKv();
+  const value = await kv.get<SessionEntry>(['assess', 'session', sessionId]);
+  if (!value.value) {
+    return null;
+  }
+  return value.value;
+}
+
+async function destroySession(sessionId: string) {
+  const kv = await Deno.openKv();
+  await kv.delete(['assess', 'session', sessionId]);
+}
+
+async function enforceInstrumentRateLimit(
+  client: ReturnType<typeof createClient>,
+  userId: string,
+  instrument: SessionEntry['instrument'],
+): Promise<void> {
+  const { data: freq } = await traced(
+    'supabase.frequency',
+    () =>
+      client
+        .from('assess_frequency')
+        .select('min_interval_secs,max_per_day')
+        .eq('instrument', instrument)
+        .maybeSingle(),
+    { attributes: { route: 'assess/submit', instrument } },
+  );
+
+  if (!freq) {
+    return;
+  }
+
+  const { data: rl } = await traced(
+    'supabase.rate_limiter',
+    () =>
+      client
+        .from('assess_rate_limiter')
+        .select('last_ts,count_today')
+        .eq('user_id', userId)
+        .eq('instrument', instrument)
+        .maybeSingle(),
+    { attributes: { route: 'assess/submit', instrument } },
+  );
+
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const todayKey = nowIso.slice(0, 10);
+
+  if (rl) {
+    const last = new Date(rl.last_ts);
+    const diffSeconds = (now.getTime() - last.getTime()) / 1000;
+    if (diffSeconds < freq.min_interval_secs) {
+      const retry = Math.max(0, freq.min_interval_secs - diffSeconds) * 1000;
+      throw { code: 'RATE_LIMIT', retry_after_ms: Math.ceil(retry) } as const;
+    }
+
+    const lastDayKey = rl.last_ts.slice(0, 10);
+    const nextCount = lastDayKey === todayKey ? rl.count_today + 1 : 1;
+
+    if (nextCount > freq.max_per_day) {
+      throw { code: 'RATE_LIMIT', retry_after_ms: 24 * 60 * 60 * 1000 } as const;
+    }
+
+    await client
+      .from('assess_rate_limiter')
+      .update({ last_ts: nowIso, count_today: nextCount })
+      .eq('user_id', userId)
+      .eq('instrument', instrument);
+  } else {
+    await client.from('assess_rate_limiter').insert({
+      user_id: userId,
+      instrument,
+      last_ts: nowIso,
+      count_today: 1,
+    });
+  }
+}
+
+function clampScore(value: number): number {
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function scale(value: number, min: number, max: number): number {
+  if (max === min) return 0;
+  const normalized = ((value - min) / (max - min)) * 100;
+  return clampScore(normalized);
+}
+
+function computeWHO5(values: number[]) {
+  const sum = values.reduce((acc, value) => acc + value, 0);
+  return { score_scaled: clampScore(sum * 4) };
+}
+
+function computeSTAI6(values: number[]) {
+  const inverted = new Set([1, 3, 5]);
+  const corrected = values.map((value, index) => (inverted.has(index) ? 5 - value : value));
+  const sum = corrected.reduce((acc, value) => acc + value, 0);
+  return { score_scaled: scale(sum, 6, 24) };
+}
+
+function computePANAS10(values: number[]) {
+  const positive = values.slice(0, 5).reduce((acc, value) => acc + value, 0);
+  const negative = values.slice(5, 10).reduce((acc, value) => acc + value, 0);
+  return {
+    pa_scaled: scale(positive, 5, 25),
+    na_scaled: scale(negative, 5, 25),
+  };
+}
+
+function computePSS10(values: number[]) {
+  const inverted = new Set([1, 2, 3, 6, 9]);
+  const corrected = values.map((value, index) => (inverted.has(index) ? 4 - value : value));
+  const sum = corrected.reduce((acc, value) => acc + value, 0);
+  return { score_scaled: scale(sum, 0, 40) };
+}
+
+function computeMSPSS(values: number[]) {
+  const family = values.slice(0, 4).reduce((acc, value) => acc + value, 0);
+  const friends = values.slice(4, 8).reduce((acc, value) => acc + value, 0);
+  const significant = values.slice(8, 12).reduce((acc, value) => acc + value, 0);
+  const clamp = (value: number) => clampScore((value / 28) * 100);
+  return {
+    family: clamp(family),
+    friends: clamp(friends),
+    significant: clamp(significant),
+    global: clampScore(((family + friends + significant) / 84) * 100),
+  };
+}
+
+function computeSSQ(values: number[]) {
+  const nausea = values.slice(0, 4).reduce((acc, value) => acc + value, 0);
+  const oculomotor = values.slice(4, 8).reduce((acc, value) => acc + value, 0);
+  const disorientation = values.slice(8, 12).reduce((acc, value) => acc + value, 0);
+  const total = nausea + oculomotor + disorientation;
+  return {
+    nausea: clampScore((nausea / 32) * 100),
+    oculomotor: clampScore((oculomotor / 32) * 100),
+    disorientation: clampScore((disorientation / 32) * 100),
+    global: clampScore((total / 96) * 100),
+  };
+}
+
+function computeSUDS(values: number[]) {
+  const level = values[0] ?? 0;
+  return { level: clampScore(level) };
+}
+
+function computeSAM(values: number[]) {
+  const [valence = 0, arousal = 0] = values;
+  return {
+    valence: clampScore((valence / 9) * 100),
+    arousal: clampScore((arousal / 9) * 100),
+  };
+}
+
+function computeGeneric(values: number[]) {
+  if (values.length === 0) {
+    return { note: 'empty' };
+  }
+  const average = values.reduce((acc, value) => acc + value, 0) / values.length;
+  return { summary_scaled: clampScore((average / 5) * 100) };
+}
+
+function computeScore(instrument: SessionEntry['instrument'], values: number[]) {
+  switch (instrument) {
+    case 'WHO5':
+      return computeWHO5(values);
+    case 'STAI6':
+      return computeSTAI6(values);
+    case 'PANAS10':
+      return computePANAS10(values);
+    case 'PSS10':
+      return computePSS10(values);
+    case 'MSPSS':
+      return computeMSPSS(values);
+    case 'SSQ':
+      return computeSSQ(values);
+    case 'SUDS':
+      return computeSUDS(values);
+    case 'SAM':
+      return computeSAM(values);
+    default:
+      return computeGeneric(values);
+  }
+}
+
+type ScoreResult = ReturnType<typeof computeScore>;
+
+function deriveHints(instrument: SessionEntry['instrument'], score: ScoreResult): string[] {
+  switch (instrument) {
+    case 'WHO5':
+      if (typeof (score as { score_scaled?: number }).score_scaled === 'number' &&
+        (score as { score_scaled?: number }).score_scaled < 40) {
+        return ['nudges_cocon', 'cta_respire_1m', 'prioriser_journal_2lignes'];
+      }
+      return ['ambiance_douce'];
+    case 'STAI6': {
+      const value = (score as { score_scaled?: number }).score_scaled ?? 0;
+      return value <= 30 ? ['silence_ancrage'] : ['carte_54321'];
+    }
+    case 'SUDS': {
+      const value = (score as { level?: number }).level ?? 0;
+      return value >= 70 ? ['encore_60s'] : ['sortie_douce'];
+    }
+    case 'SSQ': {
+      const global = (score as { global?: number }).global ?? 0;
+      if (global >= 20) {
+        return ['fallback_vr_2d', 'effets_reduits'];
+      }
+      return ['continuite_vr'];
+    }
+    case 'PANAS10': {
+      const na = (score as { na_scaled?: number }).na_scaled ?? 0;
+      return na > 60 ? ['petite_pause_apaisante'] : ['vibration_positive'];
+    }
+    default:
+      return ['presence_gentille'];
+  }
+}
+
+serve(async (req) => {
+  const startedAt = Date.now();
+  const cors = resolveCors(req);
+  let hashedUserId: string | null = null;
+
+  const finalize = async (
+    response: Response,
+    metadata: { outcome?: 'success' | 'error' | 'denied'; stage?: string | null; error?: string | null } = {},
+  ) => {
+    await recordEdgeLatencyMetric({
+      route: 'assess/submit',
+      durationMs: Date.now() - startedAt,
+      status: response.status,
+      hashedUserId,
+      outcome: metadata.outcome,
+      stage: metadata.stage ?? null,
+      error: metadata.error ?? null,
+    });
+    return response;
+  };
+
+  if (req.method === 'OPTIONS') {
+    return finalize(applySecurityHeaders(preflightResponse(cors), { cacheControl: 'no-store' }));
+  }
+
+  if (!cors.allowed) {
+    return finalize(applySecurityHeaders(rejectCors(cors), { cacheControl: 'no-store' }), {
+      outcome: 'denied',
+      error: 'origin_not_allowed',
+      stage: 'cors',
+    });
+  }
+
+  if (req.method !== 'POST') {
+    const response = appendCorsHeaders(json(405, { error: 'method_not_allowed' }), cors);
+    return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+      outcome: 'denied',
+      error: 'method_not_allowed',
+      stage: 'method',
+    });
+  }
+
+  if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
+    const response = appendCorsHeaders(json(500, { error: 'SERVER_ERROR' }), cors);
+    return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+      outcome: 'error',
+      error: 'configuration_missing',
+      stage: 'config',
+    });
+  }
+
+  try {
+    const auth = await authenticateRequest(req);
+    if (auth.status !== 200 || !auth.user) {
+      if (auth.status === 401 || auth.status === 403) {
+        await logUnauthorizedAccess(req, auth.error ?? 'unauthorized');
+      }
+      const response = appendCorsHeaders(json(auth.status, { error: 'FORBIDDEN' }), cors);
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'denied',
+        error: 'auth_failed',
+        stage: 'auth',
+      });
+    }
+
+    hashedUserId = hash(auth.user.id);
+
+    const body = await req.json().catch(() => null);
+    if (!body) {
+      const response = appendCorsHeaders(json(422, { error: 'INVALID_PAYLOAD' }), cors);
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'denied',
+        error: 'invalid_payload',
+        stage: 'payload',
+      });
+    }
+
+    const parsed = submitSchema.safeParse(body);
+    if (!parsed.success) {
+      const response = appendCorsHeaders(json(422, { error: 'INVALID_PAYLOAD' }), cors);
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'denied',
+        error: 'validation_failed',
+        stage: 'payload',
+      });
+    }
+
+    const payload = parsed.data;
+
+    const session = await getSession(payload.session_id);
+    if (!session) {
+      const response = appendCorsHeaders(json(410, { error: 'INVALID_SESSION' }), cors);
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'denied',
+        error: 'invalid_session',
+        stage: 'session',
+      });
+    }
+
+    if (session.user_id !== auth.user.id) {
+      const response = appendCorsHeaders(json(403, { error: 'FORBIDDEN' }), cors);
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'denied',
+        error: 'session_mismatch',
+        stage: 'session',
+      });
+    }
+
+    if (Date.now() > session.expires_at) {
+      await destroySession(payload.session_id);
+      const response = appendCorsHeaders(json(410, { error: 'SESSION_EXPIRED' }), cors);
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'denied',
+        error: 'session_expired',
+        stage: 'session',
+      });
+    }
+
+    const sessionItemSet = new Set(session.item_ids);
+    const numericValues: number[] = [];
+    for (const answer of payload.answers) {
+      if (!sessionItemSet.has(answer.id)) {
+        const response = appendCorsHeaders(json(422, { error: 'INVALID_PAYLOAD' }), cors);
+        return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+          outcome: 'denied',
+          error: 'invalid_item',
+          stage: 'payload',
+        });
+      }
+      numericValues.push(answer.value);
+    }
+
+    const client = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+
+    try {
+      await enforceInstrumentRateLimit(client, auth.user.id, session.instrument);
+    } catch (error) {
+      if (typeof error === 'object' && error && 'code' in error) {
+        const retryAfterMs = (error as { retry_after_ms?: number }).retry_after_ms ?? 0;
+        const response = appendCorsHeaders(
+          json(429, { error: { code: 'RATE_LIMIT', retry_after_ms: retryAfterMs } }),
+          cors,
+        );
+        return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+          outcome: 'denied',
+          error: 'rate_limit',
+          stage: 'rate_limit',
+        });
+      }
+      throw error;
+    }
+
+    const score = computeScore(session.instrument, numericValues);
+
+    const insertPayload = {
+      user_id: auth.user.id,
+      instrument: session.instrument,
+      context: session.context ?? 'adhoc',
+      lang: session.lang,
+      score_json_min: score,
+      meta: {
+        ...payload.meta,
+        answered_count: numericValues.length,
+        session_created_at: new Date(session.created_at).toISOString(),
+      },
+    };
+
+    const { data, error } = await traced(
+      'supabase.assessment_insert',
+      () =>
+        client
+          .from('assessments')
+          .insert(insertPayload)
+          .select('id,score_json_min')
+          .single(),
+      { attributes: { route: 'assess/submit', instrument: session.instrument } },
+    );
+
+    if (error || !data) {
+      console.error('[assess/submit] failed to persist assessment', error);
+      const response = appendCorsHeaders(json(500, { error: 'SERVER_ERROR' }), cors);
+      return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+        outcome: 'error',
+        error: 'persistence_failed',
+        stage: 'storage',
+      });
+    }
+
+    const hints = deriveHints(session.instrument, score);
+
+    await destroySession(payload.session_id);
+
+    const response = appendCorsHeaders(
+      json(200, {
+        receipt_id: data.id,
+        orchestration: {
+          hints,
+        },
+      }),
+      cors,
+    );
+
+    return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+      outcome: 'success',
+    });
+  } catch (error) {
+    console.error('[assess/submit] unexpected failure', error);
+    captureSentryException(error);
+    const response = appendCorsHeaders(json(500, { error: 'SERVER_ERROR' }), cors);
+    return finalize(applySecurityHeaders(response, { cacheControl: 'no-store' }), {
+      outcome: 'error',
+      error: 'unexpected',
+      stage: 'exception',
+    });
+  }
+});

--- a/supabase/functions/assess/submit/index.ts
+++ b/supabase/functions/assess/submit/index.ts
@@ -149,7 +149,7 @@ function computeWHO5(values: number[]) {
 }
 
 function computeSTAI6(values: number[]) {
-  const inverted = new Set([1, 3, 5]);
+  const inverted = new Set([0, 2, 4]);
   const corrected = values.map((value, index) => (inverted.has(index) ? 5 - value : value));
   const sum = corrected.reduce((acc, value) => acc + value, 0);
   return { score_scaled: scale(sum, 6, 24) };

--- a/supabase/migrations/20250929_assessments.sql
+++ b/supabase/migrations/20250929_assessments.sql
@@ -88,6 +88,7 @@ create table if not exists public.org_members (
   org_id uuid not null,
   team_id uuid,
   role text default 'member',
+  -- The default UUID '00000000-0000-0000-0000-000000000000' is used to represent a "no team" value for team_id in the primary key.
   constraint org_members_pk primary key (user_id, org_id, coalesce(team_id,'00000000-0000-0000-0000-000000000000'))
 );
 

--- a/supabase/migrations/20250929_assessments.sql
+++ b/supabase/migrations/20250929_assessments.sql
@@ -1,0 +1,199 @@
+-- 1) ENUMS
+create type assess_instrument as enum (
+  'WHO5','STAI6','PANAS10','PSS10','UCLA3','MSPSS','AAQ2','POMS_SF','SSQ',
+  'ISI','GAS','GRITS','BRS','WEMWBS','SWEMWBS','UWES9','CBI','CVSQ','SAM','SUDS'
+);
+
+create type assess_context as enum ('pre','post','weekly','monthly','adhoc');
+
+-- 2) CORE TABLES
+create table if not exists public.assessments (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  org_id uuid,       -- null en B2C ; rempli si user est rattaché à une org (B2B)
+  team_id uuid,      -- optionnel : sous-groupe B2B
+  instrument assess_instrument not null,
+  context assess_context not null,
+  ts timestamptz not null default now(),
+  lang text not null default 'fr',
+  -- Résumé strict (aucun item brut, aucune PII)
+  score_json_min jsonb not null, -- ex: {"score_scaled":73} ou {"pa_scaled":44,"na_scaled":17}
+  -- Métadonnées non-PII
+  meta jsonb,
+  -- Soft-delete
+  deleted_at timestamptz
+);
+
+comment on column assessments.score_json_min is 'Résumé strict: pas de réponses item-level; pas de PII.';
+
+create index on public.assessments (user_id, instrument, ts desc);
+create index on public.assessments (org_id, team_id, instrument, ts desc) where org_id is not null and deleted_at is null;
+
+-- 3) ITEM-LEVEL (temp buffer + purge auto par trigger)
+create table if not exists public.assessment_items (
+  assessment_id uuid not null references public.assessments(id) on delete cascade,
+  item_id text not null,
+  value numeric not null,
+  constraint assessment_items_pk primary key(assessment_id, item_id)
+);
+
+-- 4) LOCALES & ITEMS (versionnées)
+create table if not exists public.assess_items_catalog (
+  instrument assess_instrument not null,
+  version text not null default 'v1',
+  item_id text not null,
+  lang text not null,
+  prompt text not null,
+  choices jsonb, -- optionnel (Likert)
+  constraint assess_items_catalog_pk primary key (instrument,version,item_id,lang)
+);
+
+-- 5) FEATURE FLAGS & FREQUENCE
+create table if not exists public.assess_features (
+  key text primary key,              -- ex: 'FF_ASSESS_WHO5'
+  enabled boolean not null default true,
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.assess_frequency (
+  instrument assess_instrument primary key,
+  min_interval_secs int not null,   -- capping global minimal entre deux prises
+  max_per_day int not null default 10
+);
+
+-- Valeurs de référence (ajuste si besoin)
+insert into public.assess_frequency (instrument, min_interval_secs, max_per_day) values
+  ('STAI6', 3600, 8) on conflict do nothing,
+  ('SUDS',   120, 30) on conflict do nothing,
+  ('WHO5',  518400, 2) on conflict do nothing,        -- 6 jours
+  ('PSS10', 2419200, 1) on conflict do nothing,       -- 28 jours
+  ('MSPSS', 2419200, 1) on conflict do nothing,
+  ('UCLA3', 1209600, 2) on conflict do nothing,       -- 14 jours
+  ('SSQ',     0, 99) on conflict do nothing;          -- post-VR systématique
+
+-- 6) RATE LIMITER PER USER/INSTRUMENT
+create table if not exists public.assess_rate_limiter (
+  user_id uuid not null,
+  instrument assess_instrument not null,
+  last_ts timestamptz not null default now(),
+  count_today int not null default 0,
+  constraint assess_rate_limiter_pk primary key (user_id, instrument)
+);
+
+create index on public.assess_rate_limiter (user_id, instrument);
+
+-- 7) ORG/TEAM MEMBERSHIP (B2B)
+create table if not exists public.org_members (
+  user_id uuid not null,
+  org_id uuid not null,
+  team_id uuid,
+  role text default 'member',
+  constraint org_members_pk primary key (user_id, org_id, coalesce(team_id,'00000000-0000-0000-0000-000000000000'))
+);
+
+create index on public.org_members (org_id, team_id);
+create index on public.org_members (user_id);
+
+-- 8) RLS
+alter table public.assessments enable row level security;
+alter table public.assessment_items enable row level security;
+alter table public.assess_rate_limiter enable row level security;
+alter table public.org_members enable row level security;
+alter table public.assess_features enable row level security;
+alter table public.assess_frequency enable row level security;
+alter table public.assess_items_catalog enable row level security;
+
+-- Policies
+-- Users: CRUD seulement sur leurs propres enregistrements (hors B2B aggregate)
+create policy sel_own_assess on public.assessments
+  for select using (auth.uid() = user_id and deleted_at is null);
+
+create policy ins_own_assess on public.assessments
+  for insert with check (auth.uid() = user_id);
+
+create policy upd_softdel_own_assess on public.assessments
+  for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+create policy del_own_assess_items on public.assessment_items
+  for all using (exists (select 1 from public.assessments a where a.id = assessment_id and a.user_id = auth.uid()));
+
+-- Catalog & configs : lecture publique (read-only), écriture restreinte (service role)
+create policy read_catalog on public.assess_items_catalog for select using (true);
+revoke all on public.assess_items_catalog from public;
+grant select on public.assess_items_catalog to anon, authenticated;
+
+create policy read_features on public.assess_features for select using (true);
+revoke all on public.assess_features from public;
+grant select on public.assess_features to anon, authenticated;
+
+create policy read_frequency on public.assess_frequency for select using (true);
+revoke all on public.assess_frequency from public;
+grant select on public.assess_frequency to anon, authenticated;
+
+-- rate limiter : lecture/écriture propre
+create policy rl_sel on public.assess_rate_limiter for select using (auth.uid() = user_id);
+create policy rl_upsert on public.assess_rate_limiter for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+-- org_members : lecture propre + par service role
+create policy om_sel_self on public.org_members for select using (auth.uid() = user_id);
+
+-- 9) VIEW / MATERIALIZED VIEW B2B (AGRÉGÉ TEXTE)
+-- Vue source (strictement non matérialisée pour logique custom)
+create or replace view public.assess_agg_source as
+select
+  org_id, team_id, instrument,
+  date_trunc('week', ts) as bucket_week,
+  count(*) as n,
+  jsonb_agg(score_json_min) as payloads
+from public.assessments
+where org_id is not null and deleted_at is null
+group by org_id, team_id, instrument, date_trunc('week', ts);
+
+-- Matérialisée + garde min_n >= 5 côté requête d’agrégation (Edge)
+-- (facultatif de matérialiser selon la volumétrie)
+
+-- 10) TRIGGERS
+-- a) Auto-injection org_id/team_id à l’insert depuis org_members (si existe)
+create or replace function public.fn_assess_fill_org_team()
+returns trigger language plpgsql as $$
+begin
+  if new.org_id is null then
+    select m.org_id, m.team_id
+    into new.org_id, new.team_id
+    from public.org_members m
+    where m.user_id = new.user_id
+    limit 1;
+  end if;
+  return new;
+end $$;
+
+create trigger trg_assess_fill_org_team
+before insert on public.assessments
+for each row execute function public.fn_assess_fill_org_team();
+
+-- b) Purge item-level après insertion (minimisation : on peut conserver X minutes max)
+create or replace function public.fn_purge_items_after_insert()
+returns trigger language plpgsql as $$
+begin
+  -- Ici on ne purge pas immédiatement pour permettre recalcul si besoin,
+  -- mais on peut programmer une purge différée (ex: job cron).
+  return null;
+end $$;
+
+-- c) Soft delete cascade items
+create or replace function public.fn_softdelete_items()
+returns trigger language plpgsql as $$
+begin
+  if new.deleted_at is not null then
+    delete from public.assessment_items where assessment_id = new.id;
+  end if;
+  return new;
+end $$;
+
+create trigger trg_softdelete_items
+after update of deleted_at on public.assessments
+for each row execute function public.fn_softdelete_items();
+
+-- d) Rate limiter (mise à jour au submit via Edge plutôt que trigger SQL pour logique horaire)
+
+Rollback minimal (au besoin) : supprimer les tables dans l’ordre inverse + types ENUM.


### PR DESCRIPTION
## Summary
- add Supabase migration defining assessment storage, RLS policies, and supporting tables
- introduce shared Zod contracts for assessment API payloads
- implement assess/start, assess/submit, and assess/aggregate edge functions with capping and text-only outputs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da9a661014832daee63a463bfdfdda