### PR TITLE
Handle scheduling failures correctly

### DIFF
--- a/src/features/social-cocon/api.ts
+++ b/src/features/social-cocon/api.ts
@@ -424,10 +424,15 @@ export const scheduleBreak = async (
 
     return mapBreakRecord(data);
   } catch (error) {
-    Sentry.captureException(error, {
+    const normalizedError =
+      error instanceof Error ? error : new Error('schedule_failed');
+
+    Sentry.captureException(normalizedError, {
       tags: { feature: 'social-cocon', action: 'schedule-break' },
+      extra: { basePlan },
     });
-    return basePlan;
+
+    throw normalizedError;
   }
 };
 

--- a/src/features/social-cocon/hooks/useSocialBreakPlanner.ts
+++ b/src/features/social-cocon/hooks/useSocialBreakPlanner.ts
@@ -70,6 +70,15 @@ export const useSocialBreakPlanner = (
   const scheduleMutation = useMutation({
     mutationFn: scheduleBreakRequest,
     onSuccess: (plan) => {
+      if (!plan) {
+        toast({
+          title: 'Planification impossible',
+          description: 'Le créneau n’a pas pu être enregistré.',
+          variant: 'destructive',
+        });
+        return;
+      }
+
       setBreaks((prev) => sortByDate([plan, ...prev.filter((existing) => existing.id !== plan.id)]));
       toast({
         title: 'Pause planifiée',


### PR DESCRIPTION
## Summary
- throw when scheduling a social break fails instead of returning an optimistic plan
- ensure the social break planner hook skips optimistic updates and shows an error toast when scheduling fails

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dff5846b9c832d9fbd33b1a5400eba